### PR TITLE
fix: #WB-2857, linker searchbar forces filtering resources

### DIFF
--- a/packages/react/src/components/Tabs/TabsPanel.tsx
+++ b/packages/react/src/components/Tabs/TabsPanel.tsx
@@ -18,9 +18,9 @@ const TabsPanel = ({ children, currentItem }: TabsPanelProps) => {
   const { activeTab } = useTabsContext();
 
   return (
-    <div className="tab-content d-flex flex-fill">
+    <div className="tab-content d-flex flex-fill w-100">
       <div
-        className={`tab-pane flex-fill fade ${
+        className={`tab-pane flex-fill w-100 fade ${
           activeTab === currentItem?.id ? "show active" : ""
         }`}
         id={`tabpanel-${currentItem?.id}`}

--- a/packages/react/src/multimedia/Linker/InternalLinker.stories.tsx
+++ b/packages/react/src/multimedia/Linker/InternalLinker.stories.tsx
@@ -48,7 +48,7 @@ export const Base: Story = {
               {
                 application: "timelinegenerator",
                 modifiedAt: "2023-10-23T01:00:00.000Z",
-                name: "Another fake timelinegenerator",
+                name: "Another fake timelinegenerator with a very long name that should now overflow aloooooot, don't you think ?",
                 modifierId: "sarge",
                 modifierName: "Batou",
                 thumbnail: "",

--- a/packages/react/src/multimedia/Linker/InternalLinker.tsx
+++ b/packages/react/src/multimedia/Linker/InternalLinker.tsx
@@ -81,7 +81,15 @@ const InternalLinker = ({
                 filters: {},
                 pagination: { startIdx: 0, pageSize: 300 }, // ignored at the moment
               })
-            ).sort((a, b) => (a.modifiedAt < b.modifiedAt ? 1 : -1));
+            )
+              .filter((resource) => {
+                if (!search || search.length === 0) return true;
+                let found = resource.name?.includes(search) ?? false;
+                found ||= resource.creatorName?.includes(search) ?? false;
+                found ||= resource.description?.includes(search) ?? false;
+                return found;
+              })
+              .sort((a, b) => (a.modifiedAt < b.modifiedAt ? 1 : -1));
 
             setResources(resources);
             return; // end here

--- a/packages/react/src/multimedia/LinkerCard/LinkerCard.tsx
+++ b/packages/react/src/multimedia/LinkerCard/LinkerCard.tsx
@@ -61,7 +61,7 @@ const LinkerCard = ({
           )}
         </div>
 
-        <div className="w-100">
+        <div className="w-75">
           <Card.Text>{doc.name}</Card.Text>
           <Card.Text className="text-black-50">{doc?.creatorName}</Card.Text>
         </div>


### PR DESCRIPTION
# Description

[Ticket WB-2857](https://edifice-community.atlassian.net/browse/WB-2857)

* Added CSS classes to limit width of TabsPanel, so that `text-truncate` can effectively truncate text content in panel...
* Use `array.filter` to limit the displayed resources in Linker tab.
This is required because the historical behaviours' `loadResources` function may not filter by text, in some app. Explorer API would have treated this issue better...

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [X] Multimedia
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [X] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
