### PR TITLE
fix: #WB2-1294, fix group icon in share modal

### DIFF
--- a/packages/react/ui/src/common/ShareModal/ShareBookmarkLine.tsx
+++ b/packages/react/ui/src/common/ShareModal/ShareBookmarkLine.tsx
@@ -32,30 +32,32 @@ export const ShareBookmarkLine = ({
   const { t } = useTranslation();
 
   return shareRights?.rights.map((shareRight: ShareRight) => {
+    const avatarMapping = {
+      user: (
+        <Avatar
+          alt={t("explorer.modal.share.avatar.shared.alt")}
+          size="xs"
+          src={shareRight.avatarUrl}
+          variant="circle"
+        />
+      ),
+      group: (
+        <div className="avatar-xs bg-primary-200 justify-content-center d-flex rounded-circle">
+          <Users width={16} />
+        </div>
+      ),
+      sharebookmark: <Bookmark />,
+    };
+
+    const selectedAvatar = avatarMapping[shareRight.type] || null;
+
     return (
       showShareRightLine(shareRight, showBookmark) && (
         <tr
           key={shareRight.id}
           className={shareRight.isBookmarkMember ? "bg-light" : ""}
         >
-          <td>
-            {{
-              user: (
-                <Avatar
-                  alt={t("explorer.modal.share.avatar.shared.alt")}
-                  size="xs"
-                  src={shareRight.avatarUrl}
-                  variant="circle"
-                />
-              ),
-              group: (
-                <div className="avatar-xs bg-secondary-200 justify-content-center d-flex rounded-circle">
-                  <Users width={16} />
-                </div>
-              ),
-              sharebookmark: <Bookmark />,
-            }[shareRight.type] || null}
-          </td>
+          <td>{selectedAvatar}</td>
           <td>
             <div className="d-flex">
               {shareRight.type === "sharebookmark" && (

--- a/packages/react/ui/src/common/ShareModal/ShareBookmarkLine.tsx
+++ b/packages/react/ui/src/common/ShareModal/ShareBookmarkLine.tsx
@@ -51,6 +51,9 @@ export const ShareBookmarkLine = ({
 
     const selectedAvatar = avatarMapping[shareRight.type] || null;
 
+    const isTypeBookmark = shareRight.type === "sharebookmark";
+    const isTypeUser = shareRight.type === "user";
+
     return (
       showShareRightLine(shareRight, showBookmark) && (
         <tr
@@ -60,7 +63,7 @@ export const ShareBookmarkLine = ({
           <td>{selectedAvatar}</td>
           <td>
             <div className="d-flex">
-              {shareRight.type === "sharebookmark" && (
+              {isTypeBookmark && (
                 <Button
                   color="tertiary"
                   rightIcon={
@@ -81,9 +84,8 @@ export const ShareBookmarkLine = ({
                   {shareRight.displayName}
                 </Button>
               )}
-              {shareRight.type !== "sharebookmark" && shareRight.displayName}
-              {shareRight.type === "user" &&
-                ` (${t(shareRight.profile || "")})`}
+              {!isTypeBookmark && shareRight.displayName}
+              {isTypeUser && ` (${t(shareRight.profile || "")})`}
             </div>
           </td>
           {shareRightActions.map((shareRightAction) => (

--- a/packages/react/ui/src/common/ShareModal/ShareBookmarkLine.tsx
+++ b/packages/react/ui/src/common/ShareModal/ShareBookmarkLine.tsx
@@ -1,4 +1,4 @@
-import { Bookmark, Close, RafterDown } from "@edifice-ui/icons";
+import { Bookmark, Close, RafterDown, Users } from "@edifice-ui/icons";
 import {
   ShareRight,
   ShareRightAction,
@@ -30,6 +30,7 @@ export const ShareBookmarkLine = ({
   onDeleteRow: (shareRight: ShareRight) => void;
 }) => {
   const { t } = useTranslation();
+
   return shareRights?.rights.map((shareRight: ShareRight) => {
     return (
       showShareRightLine(shareRight, showBookmark) && (
@@ -38,16 +39,22 @@ export const ShareBookmarkLine = ({
           className={shareRight.isBookmarkMember ? "bg-light" : ""}
         >
           <td>
-            {shareRight.type !== "sharebookmark" && (
-              <Avatar
-                alt={t("explorer.modal.share.avatar.shared.alt")}
-                size="xs"
-                src={shareRight.avatarUrl}
-                variant="circle"
-              />
-            )}
-
-            {shareRight.type === "sharebookmark" && <Bookmark />}
+            {{
+              user: (
+                <Avatar
+                  alt={t("explorer.modal.share.avatar.shared.alt")}
+                  size="xs"
+                  src={shareRight.avatarUrl}
+                  variant="circle"
+                />
+              ),
+              group: (
+                <div className="avatar-xs bg-secondary-200 justify-content-center d-flex rounded-circle">
+                  <Users width={16} />
+                </div>
+              ),
+              sharebookmark: <Bookmark />,
+            }[shareRight.type] || null}
           </td>
           <td>
             <div className="d-flex">


### PR DESCRIPTION
# Description

Ajout d'une nouvelle icône groupe dans la modal de partage : 
https://www.figma.com/design/A8noABDGvUFP8F3dGqG735/Library_Web?node-id=757-10225&t=vhu1aALrCQ2GowMJ-1

Ticket : https://edifice-community.atlassian.net/browse/WB2-1294

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
