### PR TITLE
feat: #WB2-1868, pass full node to Tree renderNode function

### DIFF
--- a/packages/react/ui/src/components/Tree/SortableTree.tsx
+++ b/packages/react/ui/src/components/Tree/SortableTree.tsx
@@ -254,12 +254,10 @@ const TreeNode = forwardRef(
               onKeyDown={handleItemKeyDown}
             >
               {renderNode && !isChildren ? (
-                renderNode({
-                  nodeId: node.id,
-                  nodeName: node.name,
-                  hasChildren:
-                    Array.isArray(node.children) && !!node.children.length,
-                })
+                renderNode(
+                  node,
+                  Array.isArray(node.children) && !!node.children.length,
+                )
               ) : (
                 <div className="text-truncate">{node.name}</div>
               )}

--- a/packages/react/ui/src/components/Tree/SortableTree.tsx
+++ b/packages/react/ui/src/components/Tree/SortableTree.tsx
@@ -131,7 +131,7 @@ const TreeNode = forwardRef(
       disabled,
       indentationWidth,
       depth,
-      isChildren,
+      isChild,
       projected,
       renderNode,
       onTreeItemClick,
@@ -198,7 +198,7 @@ const TreeNode = forwardRef(
     const spaceGestion = () =>
       !isDragging
         ? null
-        : isChildren
+        : isChild
           ? depth === 1
             ? `${indentationWidth * depth}px`
             : "0px"
@@ -253,11 +253,13 @@ const TreeNode = forwardRef(
               onClick={() => onTreeItemClick(node.id)}
               onKeyDown={handleItemKeyDown}
             >
-              {renderNode && !isChildren ? (
-                renderNode(
+              {renderNode ? (
+                renderNode({
                   node,
-                  Array.isArray(node.children) && !!node.children.length,
-                )
+                  hasChildren:
+                    Array.isArray(node.children) && !!node.children.length,
+                  isChild,
+                })
               ) : (
                 <div className="text-truncate">{node.name}</div>
               )}
@@ -283,7 +285,7 @@ const TreeNode = forwardRef(
                       ? projected.depth
                       : 0
                   }
-                  isChildren={true}
+                  isChild={true}
                   projected={projected}
                 />
               ))}

--- a/packages/react/ui/src/components/Tree/Tree.tsx
+++ b/packages/react/ui/src/components/Tree/Tree.tsx
@@ -167,7 +167,7 @@ export const TreeNode = forwardRef(
               onClick={() => onTreeItemClick(node.id)}
               onKeyDown={handleItemKeyDown}
             >
-              {renderNode && !isChild ? (
+              {renderNode ? (
                 renderNode({
                   node,
                   hasChildren:

--- a/packages/react/ui/src/components/Tree/Tree.tsx
+++ b/packages/react/ui/src/components/Tree/Tree.tsx
@@ -75,7 +75,7 @@ export const TreeNode = forwardRef(
       showIcon = false,
       expandedNodes,
       focused,
-      isChildren,
+      isChild,
       renderNode,
       onTreeItemClick,
       onToggleNode,
@@ -167,11 +167,13 @@ export const TreeNode = forwardRef(
               onClick={() => onTreeItemClick(node.id)}
               onKeyDown={handleItemKeyDown}
             >
-              {renderNode && !isChildren ? (
-                renderNode(
+              {renderNode && !isChild ? (
+                renderNode({
                   node,
-                  Array.isArray(node.children) && !!node.children.length,
-                )
+                  hasChildren:
+                    Array.isArray(node.children) && !!node.children.length,
+                  isChild,
+                })
               ) : (
                 <div className="text-truncate">{node.name}</div>
               )}
@@ -192,7 +194,7 @@ export const TreeNode = forwardRef(
                   onTreeItemClick={onTreeItemClick}
                   onToggleNode={onToggleNode}
                   renderNode={renderNode}
-                  isChildren={true}
+                  isChild={true}
                 />
               ))}
             </ul>

--- a/packages/react/ui/src/components/Tree/Tree.tsx
+++ b/packages/react/ui/src/components/Tree/Tree.tsx
@@ -168,12 +168,10 @@ export const TreeNode = forwardRef(
               onKeyDown={handleItemKeyDown}
             >
               {renderNode && !isChildren ? (
-                renderNode({
-                  nodeId: node.id,
-                  nodeName: node.name,
-                  hasChildren:
-                    Array.isArray(node.children) && !!node.children.length,
-                })
+                renderNode(
+                  node,
+                  Array.isArray(node.children) && !!node.children.length,
+                )
               ) : (
                 <div className="text-truncate">{node.name}</div>
               )}

--- a/packages/react/ui/src/components/Tree/stories/SortableTree.stories.tsx
+++ b/packages/react/ui/src/components/Tree/stories/SortableTree.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react";
 import SortableTree from "../SortableTree";
 import { SortableTreeProps } from "../types";
+import { Hide } from "@edifice-ui/icons";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<typeof SortableTree> = {
@@ -39,7 +40,11 @@ const meta: Meta<typeof SortableTree> = {
       },
     ],
     selectedNodeId: "1",
-    renderNode: (node) => <div>{node.nodeName}</div>,
+    renderNode: (node) => (
+      <div className="d-flex align-items-center">
+        {node.name} <Hide width="20" height="20" className="mx-8" />
+      </div>
+    ),
     onSortable: (nodes) => console.log(nodes),
     onTreeItemClick: (nodeId) => console.log(nodeId),
   },

--- a/packages/react/ui/src/components/Tree/stories/SortableTree.stories.tsx
+++ b/packages/react/ui/src/components/Tree/stories/SortableTree.stories.tsx
@@ -40,10 +40,8 @@ const meta: Meta<typeof SortableTree> = {
       },
     ],
     selectedNodeId: "1",
-    renderNode: (node) => (
-      <div className="d-flex align-items-center">
-        {node.name} <Hide width="20" height="20" className="mx-8" />
-      </div>
+    renderNode: (payload) => (
+      <div className="d-flex align-items-center">{payload?.node?.name}</div>
     ),
     onSortable: (nodes) => console.log(nodes),
     onTreeItemClick: (nodeId) => console.log(nodeId),

--- a/packages/react/ui/src/components/Tree/types.ts
+++ b/packages/react/ui/src/components/Tree/types.ts
@@ -7,6 +7,7 @@ export type TreeItem = {
   position?: number;
   section?: boolean;
   children?: TreeItem[];
+  isVisible?: boolean;
 };
 
 export type Projected = {
@@ -80,11 +81,7 @@ export interface SharedTreeProps {
   /**
    * Customize the JSX we render inside a node
    */
-  renderNode?: (payload: {
-    nodeId: string;
-    nodeName: string;
-    hasChildren: boolean;
-  }) => React.ReactNode;
+  renderNode?: (node: TreeItem, hasChildren: boolean) => React.ReactNode;
   /**
    * Show Section Icon
    */

--- a/packages/react/ui/src/components/Tree/types.ts
+++ b/packages/react/ui/src/components/Tree/types.ts
@@ -7,7 +7,7 @@ export type TreeItem = {
   position?: number;
   section?: boolean;
   children?: TreeItem[];
-  isVisible?: boolean;
+  [index: string]: any;
 };
 
 export type Projected = {
@@ -81,7 +81,11 @@ export interface SharedTreeProps {
   /**
    * Customize the JSX we render inside a node
    */
-  renderNode?: (node: TreeItem, hasChildren: boolean) => React.ReactNode;
+  renderNode?: (payload: {
+    node: TreeItem;
+    hasChildren?: boolean;
+    isChild?: boolean;
+  }) => React.ReactNode;
   /**
    * Show Section Icon
    */
@@ -126,7 +130,7 @@ export interface TreeNodeProps
   /**
    * Node is a child
    */
-  isChildren?: boolean;
+  isChild?: boolean;
   /**
    * Function to fold / unfold node
    */
@@ -153,13 +157,13 @@ export interface SortableTreeNodeProps extends TreeNodeProps {
    */
   indentationWidth: number;
   /**
-   * Node identifier as parent or child
+   * Depth.
    */
   depth: number;
   /**
    * Node identifier as parent or child
    */
-  isChildren?: boolean;
+  isChild?: boolean;
   /**
    *  Projected node before dragging it
    */


### PR DESCRIPTION
# Description

We provide full node information to the renderNode function in Tree and SortableTree components.

We also provide the information of if the node is a child, useful for some cases (for example for displaying the "+" button only for parent node)

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
