### PR TITLE
fix: #WB2-2156, fix Attachment links parsing

### DIFF
--- a/packages/tiptap/extensions/extension-attachment/src/Attachment.ts
+++ b/packages/tiptap/extensions/extension-attachment/src/Attachment.ts
@@ -62,12 +62,18 @@ export const Attachment = Node.create<AttachmentOptions>({
 
           for (let i = 0; i < links.length; i++) {
             const link = links[i];
+
+            const dataDocumentId = link.getAttribute("data-document-id");
             const href = link.getAttribute("href");
+
+            if (!dataDocumentId && !href) {
+              continue;
+            }
+
             const name = link.textContent;
             const regexResult = href.match(/([^/]+$)/);
             const documentId =
-              link.getAttribute("data-document-id") ||
-              (regexResult && regexResult[0]);
+              dataDocumentId || (regexResult && regexResult[0]);
             const dataContentType = link.getAttribute("data-content-type");
 
             parsedLinks.push({

--- a/packages/tiptap/extensions/extension-attachment/src/Attachment.ts
+++ b/packages/tiptap/extensions/extension-attachment/src/Attachment.ts
@@ -14,7 +14,11 @@ declare module "@tiptap/core" {
 
 export const Attachment = Node.create<AttachmentOptions>({
   name: "attachments",
-  content: "",
+
+  // FIX #WB2-2156: links parsing
+  content: "block+",
+  priority: 10001,
+
   marks: "",
   group: "block",
   selectable: true,


### PR DESCRIPTION
# Description

Hotfix for links parsing for tiptap Attachment extension.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
