### PR TITLE
fix: #WB2-2156, allow inline attachment

### DIFF
--- a/packages/tiptap/extensions/extension-attachment/src/AttachmentTransformer.ts
+++ b/packages/tiptap/extensions/extension-attachment/src/AttachmentTransformer.ts
@@ -1,0 +1,114 @@
+import { Node } from "@tiptap/core";
+
+export interface AttachmentOptions {
+  HTMLAttributes: Record<string, string>;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    attachment: {
+      setAttachment: (attachment) => ReturnType;
+    };
+  }
+}
+
+export const AttachmentTransformer = Node.create<AttachmentOptions>({
+  name: "attachments",
+  content: "",
+  marks: "",
+  group: "inline",
+  inline: true,
+  selectable: true,
+  atom: true,
+  draggable: true,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {
+        class: "attachments",
+      },
+    };
+  },
+
+  parseHTML() {
+    return [{ tag: "div[class=attachments]" }];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    const links = HTMLAttributes.links;
+
+    const renderedLinks = links.map((el) => {
+      return [
+        "a",
+        {
+          name: el.name,
+          href: el.href,
+          documentId: el.documentId,
+          dataContentType: el.dataContentType,
+        },
+        el.name,
+      ];
+    });
+
+    return ["div", this.options.HTMLAttributes, ...renderedLinks];
+  },
+
+  addAttributes() {
+    return {
+      links: {
+        default: [],
+        parseHTML: (element) => {
+          const links = element.getElementsByTagName("a");
+          const parsedLinks = [];
+
+          for (let i = 0; i < links.length; i++) {
+            const link = links[i];
+            const href = link.getAttribute("href");
+            const name = link.textContent;
+            const regexResult = href.match(/([^/]+$)/);
+            const documentId =
+              link.getAttribute("data-document-id") ||
+              (regexResult && regexResult[0]);
+            const dataContentType = link.getAttribute("data-content-type");
+
+            parsedLinks.push({
+              href,
+              name,
+              documentId,
+              dataContentType,
+            });
+          }
+
+          return parsedLinks;
+        },
+        renderHTML: (attributes) => {
+          return {
+            links: attributes.links.map((link) => ({
+              href: link.href,
+              name: link.name,
+              documentId: link.documentId,
+              dataContentType: link.dataContentType,
+            })),
+          };
+        },
+      },
+    };
+  },
+
+  addCommands() {
+    return {
+      setAttachment:
+        (
+          attrs = {
+            dataContentType: "",
+            name: "",
+            documentId: "",
+            href: "",
+          },
+        ) =>
+        ({ chain }) => {
+          return chain().insertContent({ type: this.name, attrs }).run();
+        },
+    };
+  },
+});

--- a/packages/tiptap/extensions/extension-attachment/src/index.ts
+++ b/packages/tiptap/extensions/extension-attachment/src/index.ts
@@ -1,5 +1,4 @@
 import { Attachment } from "./Attachment";
-
+export { AttachmentTransformer } from "./AttachmentTransformer";
 export * from "./Attachment";
-
 export default Attachment;


### PR DESCRIPTION
# Description

Cette PR ajoute une extension attachment en mode inline pour le back tiptap-transformer

## Which Package changed?

Please check the name of the package you changed

- [X] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
