### PR TITLE
Feat/wb2 2041

### DIFF
--- a/packages/react/ui/src/components/Tree/components/SortableTree.tsx
+++ b/packages/react/ui/src/components/Tree/components/SortableTree.tsx
@@ -86,26 +86,27 @@ const SortableTree = ({
             strategy={verticalListSortingStrategy}
           >
             {Array.isArray(items) &&
-              newNodes.map((node) => (
+              newNodes.map((node) =>
                 node.parentExpanded ? (
-                <TreeNode
-                  node={node}
-                  key={node.id}
-                  showIcon={showIcon}
-                  expandedNodes={expandedNodes}
-                  selectedNodeId={selectedNodeId}
-                  renderNode={renderNode}
-                  disabled={isDisabled(node.id)}
-                  onTreeItemClick={handleItemClick}
-                  onToggleNode={handleFoldUnfold}
-                  depth={
-                    node.id === activeId && projected ? projected.depth : 0
-                  }
-                  isChild={node.isChild}
-                 indentationWidth={indentationWidth}
-                  projected={projected}
-                />): null
-              ))}
+                  <TreeNode
+                    node={node}
+                    key={node.id}
+                    showIcon={showIcon}
+                    expandedNodes={expandedNodes}
+                    selectedNodeId={selectedNodeId}
+                    renderNode={renderNode}
+                    disabled={isDisabled(node.id)}
+                    onTreeItemClick={handleItemClick}
+                    onToggleNode={handleFoldUnfold}
+                    depth={
+                      node.id === activeId && projected ? projected.depth : 0
+                    }
+                    isChild={node.isChild}
+                    indentationWidth={indentationWidth}
+                    projected={projected}
+                  />
+                ) : null,
+              )}
           </SortableContext>
           {createPortal(
             <DragOverlay

--- a/packages/react/ui/src/components/Tree/hooks/useTree.ts
+++ b/packages/react/ui/src/components/Tree/hooks/useTree.ts
@@ -242,10 +242,6 @@ export const useTree = ({
     handleCollapseNode(nodeId);
   };
 
-  const collapseAllNodes = () => {
-    setExpandedNodes(new Set());
-  };
-
   return {
     selectedNodeId,
     expandedNodes,
@@ -253,6 +249,6 @@ export const useTree = ({
     draggedNodeId,
     handleItemClick,
     handleFoldUnfold,
-    collapseAllNodes,
+    handleCollapseNode,
   };
 };

--- a/packages/react/ui/src/components/Tree/hooks/useTreeSortable.ts
+++ b/packages/react/ui/src/components/Tree/hooks/useTreeSortable.ts
@@ -32,11 +32,11 @@ import {
 export const useTreeSortable = ({
   nodes,
   onSortable,
-  collapseAllNodes,
+  handleCollapseNode,
 }: {
   nodes: TreeItem[];
   onSortable: (updateArray: UpdateTreeData[]) => void;
-  collapseAllNodes: () => void;
+  handleCollapseNode: (nodeId: string) => void;
 }) => {
   const [items, setItems] = useState<TreeItem[]>(() => nodes);
   const [activeId, setActiveId] = useState<string | null>(null);
@@ -86,7 +86,7 @@ export const useTreeSortable = ({
     const { activeNode } = getActiveAndOverNodes(flattenedTree, active.id);
 
     if (!activeNode.parentId) {
-      collapseAllNodes();
+      handleCollapseNode(activeNode.id);
     }
 
     setActiveId(active.id as unknown as string);

--- a/packages/react/ui/src/components/Tree/types/index.ts
+++ b/packages/react/ui/src/components/Tree/types/index.ts
@@ -177,8 +177,8 @@ export interface FlattenedItem extends TreeItem {
 }
 
 export interface FlattendedNodes extends TreeItem {
-  expandNode: boolean,
-  parentExpanded: boolean,
+  expandNode: boolean;
+  parentExpanded: boolean;
 }
 
 export interface TreeViewHandlers {

--- a/packages/react/ui/src/components/Tree/types/index.ts
+++ b/packages/react/ui/src/components/Tree/types/index.ts
@@ -176,6 +176,11 @@ export interface FlattenedItem extends TreeItem {
   depth: number;
 }
 
+export interface FlattendedNodes extends TreeItem {
+  expandNode: boolean,
+  parentExpanded: boolean,
+}
+
 export interface TreeViewHandlers {
   unselect: () => void;
   select: (nodeId: string) => void;

--- a/packages/react/ui/src/components/Tree/utilities/tree-sortable.ts
+++ b/packages/react/ui/src/components/Tree/utilities/tree-sortable.ts
@@ -97,10 +97,18 @@ export function flattenTree(
   }, [] as FlattenedItem[]);
 }
 
-export function flattenNodes(nodes: TreeItem[], expandedNodes: Set<string>): FlattendedNodes[] {
-  const flatten = (nodes: TreeItem[], isChild = false, parentExpanded = true): FlattendedNodes[] => {
+export function flattenNodes(
+  nodes: TreeItem[],
+  expandedNodes: Set<string>,
+): FlattendedNodes[] {
+  const flatten = (
+    nodes: TreeItem[],
+    isChild = false,
+    parentExpanded = true,
+  ): FlattendedNodes[] => {
     return nodes.reduce<FlattendedNodes[]>((acc, node) => {
-      const isExpanded = expandedNodes.has(node.id) && node.children && node.children.length > 0;
+      const isExpanded =
+        expandedNodes.has(node.id) && node.children && node.children.length > 0;
       acc.push({
         id: node.id,
         name: node.name,

--- a/packages/react/ui/src/components/Tree/utilities/tree-sortable.ts
+++ b/packages/react/ui/src/components/Tree/utilities/tree-sortable.ts
@@ -1,6 +1,6 @@
 import { Active, Over, UniqueIdentifier } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
-import { FlattenedItem, Projected, TreeItem } from "../types";
+import { FlattendedNodes, FlattenedItem, Projected, TreeItem } from "../types";
 
 export function getDragDepth(offset: number, indentationWidth: number) {
   return Math.round(offset / indentationWidth);
@@ -95,6 +95,27 @@ export function flattenTree(
 
     return acc;
   }, [] as FlattenedItem[]);
+}
+
+export function flattenNodes(nodes: TreeItem[], expandedNodes: Set<string>): FlattendedNodes[] {
+  const flatten = (nodes: TreeItem[], isChild = false, parentExpanded = true): FlattendedNodes[] => {
+    return nodes.reduce<FlattendedNodes[]>((acc, node) => {
+      const isExpanded = expandedNodes.has(node.id) && node.children && node.children.length > 0;
+      acc.push({
+        id: node.id,
+        name: node.name,
+        isChild,
+        haveChilds: !!node.children?.length,
+        expandNode: isExpanded ?? false,
+        parentExpanded,
+      });
+      if (node.children && isExpanded) {
+        acc = acc.concat(flatten(node.children, true, isExpanded));
+      }
+      return acc;
+    }, []);
+  };
+  return flatten(nodes);
 }
 
 export function updateParentIds(


### PR DESCRIPTION
# Description

On avait un problème sur le déplacement des nodes dans le treeview via la library draggable de dndkit car elle n'arrive pas a gérer les `<li><ul>`. J'ai modifié la structure du code afin de n'avoir que des `<li>` afin que la library comprenne bien et s'adapte a son contexte. 

Ticket : https://edifice-community.atlassian.net/browse/WB2-2041

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
