### PR TITLE
feat: #WB-3735 add isCheckable props in List component

### DIFF
--- a/packages/react/src/components/List/List.mdx
+++ b/packages/react/src/components/List/List.mdx
@@ -55,12 +55,37 @@ const items: ToolbarItem[] = [
 
 ## renderNode with checkboxes
 
+By passing `isCheckable`, you make the list checkable. A checkbox will appear to the left of the Toolbar and will give you access to two new props in the `renderNode` prop: `checkbox` and `checked`.
+
+- `checkbox` is the Checkbox component that you can use to render anywhere in your JSX within the `renderNode` prop.
+- `checked` is the state of the currently selected checkbox, allowing you to style your code accordingly.
+
+<Canvas of={listStories.ListWithCheckboxes} />
+
+```jsx
+renderNode={(node, checkbox, checked) => (
+  <div
+    className={clsx("grid gap-24 px-12 py-8 mb-2", {
+      "bg-secondary-200 rounded": checked,
+    })}
+    style={{ "--edifice-columns": 8 } as React.CSSProperties}
+  >
+    <div className="d-flex align-items-center gap-8 g-col-3">
+      {checkbox}
+      <p className="text-truncate text-truncate-2">{node.title}</p>
+    </div>
+  </div>
+)}
+```
+
+## renderNode with checkboxes and toolbar
+
 By passing `items` to the List component, you provide actions to your component and make the list checkable. A checkbox will appear to the left of the Toolbar and will give you access to two new props in the `renderNode` prop: `checkbox` and `checked`.
 
 - `checkbox` is the Checkbox component that you can use to render anywhere in your JSX within the `renderNode` prop.
 - `checked` is the state of the currently selected checkbox, allowing you to style your code accordingly.
 
-<Canvas of={listStories.ListWithCheckboxes} sourceState="none" />
+<Canvas of={listStories.ListWithCheckboxesAndToolbar} sourceState="none" />
 
 ```jsx
 renderNode={(node, checkbox, checked) => (

--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof List> = {
     docs: {
       description: {
         component:
-          'The `List` component provides a flexible way to display collections of items with optional toolbar actions. It supports various item types and interactive elements like icons and tooltips. Features include:\n\n- Customizable list items with icons and text\n- Optional toolbar with action buttons\n- Tooltip support for actions\n- Flexible styling options\n- Support for selection and interaction states',
+          'The `List` component provides a flexible way to display collections of items with optional toolbar actions. It supports various item types and interactive elements like icons and tooltips. Features include:\n\n- Customizable list items with icons and text\n- Optional toolbar with action buttons\n- Optional checkbox for all data\n- Tooltip support for actions\n- Flexible styling options\n- Support for selection and interaction states',
       },
     },
   },
@@ -141,6 +141,32 @@ export const ListWithToolbar: Story = {
 };
 
 export const ListWithCheckboxes: Story = {
+  render: (args) => {
+    return (
+      <>
+        <List
+          isCheckable={true}
+          data={data}
+          renderNode={(node, checkbox, checked) => (
+            <div
+              className={clsx('grid gap-24 px-12 py-8 mb-2', {
+                'bg-secondary-200 rounded': checked,
+              })}
+              style={{ '--edifice-columns': 8 } as React.CSSProperties}
+            >
+              <div className="d-flex align-items-center gap-8 g-col-3">
+                {checkbox}
+                <p className="text-truncate text-truncate-2">{node.title}</p>
+              </div>
+            </div>
+          )}
+        />
+      </>
+    );
+  },
+};
+
+export const ListWithCheckboxesAndToolbar: Story = {
   render: (args) => {
     return (
       <>

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -29,7 +29,7 @@ export type ListProps<T> = {
 
 export const List = <T extends { _id: string }>({
   items,
-  isCheckable,
+  isCheckable = false,
   data,
   renderNode,
   onSelectedItems,

--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -10,6 +10,10 @@ export type ListProps<T> = {
    */
   items?: ToolbarItem[];
   /**
+   * Checkable list
+   */
+  isCheckable?: boolean;
+  /**
    * Generic data
    */
   data: T[] | undefined;
@@ -25,6 +29,7 @@ export type ListProps<T> = {
 
 export const List = <T extends { _id: string }>({
   items,
+  isCheckable,
   data,
   renderNode,
   onSelectedItems,
@@ -45,11 +50,12 @@ export const List = <T extends { _id: string }>({
 
   return (
     <>
-      {items && (
+      {(items || isCheckable) && (
         <>
           <div
             className={clsx('d-flex align-items-center gap-8', {
               'px-12': items,
+              'px-12 py-12': !items?.length,
             })}
           >
             <>
@@ -61,15 +67,17 @@ export const List = <T extends { _id: string }>({
                 />
                 <span>({selectedItems.length})</span>
               </div>
-              <Toolbar
-                items={items}
-                isBlock
-                align="left"
-                variant="no-shadow"
-                className={clsx('gap-4 py-4', {
-                  'px-0 ms-auto': !isDesktopDevice,
-                })}
-              />
+              {items && (
+                <Toolbar
+                  items={items}
+                  isBlock
+                  align="left"
+                  variant="no-shadow"
+                  className={clsx('gap-4 py-4', {
+                    'px-0 ms-auto': !isDesktopDevice,
+                  })}
+                />
+              )}
             </>
           </div>
           <div className="border-top"></div>


### PR DESCRIPTION
# Description

Add isCheckable option on List component to be able to have the global check without toolbar.

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
