### PR TITLE
fix: #WB2-2243, fix page navigation Attachment update

### DIFF
--- a/packages/react/src/modules/editor/components/Renderer/AttachmentRenderer.tsx
+++ b/packages/react/src/modules/editor/components/Renderer/AttachmentRenderer.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Editor, NodeViewWrapper } from '@tiptap/react';
 import { useTranslation } from 'react-i18next';
@@ -20,15 +20,19 @@ interface AttachmentAttrsProps {
 }
 
 const AttachmentRenderer = (props: AttachmentProps) => {
-  const { t } = useTranslation();
-
   const { node, editor } = props;
-
-  const { editable } = useEditorContext();
-
   const [attachmentArrayAttrs, setAttachmentArrayAttrs] = useState<
     AttachmentAttrsProps[]
   >(node.attrs.links);
+  const { t } = useTranslation();
+  const { editable } = useEditorContext();
+
+  // Fix #WB2-2243: update attachmentArrayAttrs state when props changes
+  useEffect(() => {
+    if (attachmentArrayAttrs !== node.attrs.links) {
+      setAttachmentArrayAttrs(node.attrs.links);
+    }
+  }, [node.attrs.links, attachmentArrayAttrs]);
 
   const handleDelete = (index: any, documentId: any) => {
     editor.commands.unsetAttachment(documentId);
@@ -38,7 +42,7 @@ const AttachmentRenderer = (props: AttachmentProps) => {
   };
 
   return (
-    attachmentArrayAttrs.length !== 0 && (
+    attachmentArrayAttrs?.length !== 0 && (
       <NodeViewWrapper>
         <div
           style={{


### PR DESCRIPTION
# Description

Fix page navigation Attachment update.

Attachment link state was not updated when prop changed in AttachmentRenderer so the attachment was not updated in the page.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
