### PR TITLE
fix: WB-3800 add reactQuery for API call

### DIFF
--- a/packages/react/src/components/SearchBar/SearchBar.tsx
+++ b/packages/react/src/components/SearchBar/SearchBar.tsx
@@ -7,7 +7,6 @@ import { IconSearch } from '../../modules/icons/components';
 import { Size } from '../../types';
 import { SearchButton } from '../Button';
 import FormControl from '../Form/FormControl';
-import { InputProps } from '../Input';
 
 export interface BaseProps
   extends Omit<React.ComponentPropsWithoutRef<'input'>, 'size'> {

--- a/packages/react/src/hooks/useConversation/useConversation.ts
+++ b/packages/react/src/hooks/useConversation/useConversation.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { odeServices } from '@edifice.io/client';
 
 import { useHasWorkflow } from '../useHasWorkflow';
+import { useQuery } from '@tanstack/react-query';
 
 const useConversation = () => {
   const zimbraWorkflow = useHasWorkflow(
@@ -15,28 +16,23 @@ const useConversation = () => {
   /**
    * Count conversation app
    */
-  const [messages, setMessages] = useState<number>(0);
   const [msgLink, setMsgLink] = useState<string>('');
   /**
    * Get message count for zimbra or chat app
    */
   const queryParams = { unread: true, _: new Date().getTime() };
 
-  const refreshMails = async () => {
-    const url = zimbraWorkflow
-      ? '/zimbra/count/INBOX'
-      : '/conversation/count/INBOX';
-
-    try {
-      const { count } = await odeServices.http().get(url, { queryParams });
-
-      setMessages(count ?? 0);
-    } catch (error) {
-      console.error(error);
-      setMessages(0);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  };
+  const { data: messages } = useQuery({
+    queryKey: ['conversation-navbar-count'],
+    queryFn: async () =>
+      await odeServices
+        .http()
+        .get(
+          zimbraWorkflow ? '/zimbra/count/INBOX' : '/conversation/count/INBOX',
+          { queryParams },
+        ),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
 
   const goToMessagerie = async () => {
     const defaultLink = '/zimbra/zimbra';
@@ -57,20 +53,18 @@ const useConversation = () => {
       console.error(error);
       setMsgLink(window.location.origin + defaultLink);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   };
-
-  useEffect(() => {
-    refreshMails();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   useEffect(() => {
     goToMessagerie();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return { messages, msgLink, zimbraWorkflow } as const;
+  return {
+    messages: messages ? messages.count : 0,
+    msgLink,
+    zimbraWorkflow,
+  } as const;
 };
 
 export default useConversation;


### PR DESCRIPTION
# Description

Permettre de mettre à jour le badge indiquant le nombre de messages non lu au niveau de la navbar 

Utiliser reactQuery pour faire l’appel à l’API. Cela permettra à l’application de pouvoir invalider la requête afin de mettre à jour la donnée.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
