### PR TITLE
fix: #wb2-2138, transform pad url in iframe

### DIFF
--- a/packages/extensions/src/iframe/iframe.ts
+++ b/packages/extensions/src/iframe/iframe.ts
@@ -1,4 +1,5 @@
 import { Node } from '@tiptap/core';
+import { iframeTransformer } from './transformers';
 
 export interface IframeOptions {
   allowFullscreen: boolean;
@@ -90,6 +91,8 @@ export const Iframe = Node.create<IframeOptions>({
   },
 
   renderHTML({ HTMLAttributes }) {
+    // Call the onRenderHTML method from the iframeTransformer before rendering the iframe
+    iframeTransformer.onRenderHTML({ HTMLAttributes });
     return ['div', this.options.HTMLAttributes, ['iframe', HTMLAttributes]];
   },
 

--- a/packages/extensions/src/iframe/transformers/index.ts
+++ b/packages/extensions/src/iframe/transformers/index.ts
@@ -1,0 +1,17 @@
+import { IframeTransformer } from './interface';
+import { PadIframeTransformer } from './pad-transformer';
+/**
+ * Default iframe transformer
+ * This transformer is used to call all the transformers
+ */
+class DefaultIframeTransformer implements IframeTransformer {
+  #transformers = [new PadIframeTransformer()];
+  onRenderHTML({ HTMLAttributes }) {
+    for (const transformer of this.#transformers) {
+      transformer.onRenderHTML({ HTMLAttributes });
+    }
+  }
+}
+
+export const iframeTransformer: IframeTransformer =
+  new DefaultIframeTransformer();

--- a/packages/extensions/src/iframe/transformers/interface.ts
+++ b/packages/extensions/src/iframe/transformers/interface.ts
@@ -1,0 +1,7 @@
+/**
+ * Interface for the iframe transformer.
+ * Iframe transformers are used to transform the iframe attributes before rendering it.
+ */
+export interface IframeTransformer {
+  onRenderHTML({ HTMLAttributes }): void;
+}

--- a/packages/extensions/src/iframe/transformers/pad-transformer.ts
+++ b/packages/extensions/src/iframe/transformers/pad-transformer.ts
@@ -1,0 +1,39 @@
+import { IframeTransformer } from './interface';
+
+/**
+ * This transformer is used to transform the pad URL to the embed URL inside the iframe
+ * The embed URL is used to create a session for the pad before redirecting to the pad url
+ */
+export class PadIframeTransformer implements IframeTransformer {
+  // Define the pad path
+  #padPath: '/pad/';
+  // Define the embed path
+  #embedPath = '/collaborativeeditor/embed/';
+  onRenderHTML({ HTMLAttributes }) {
+    try {
+      // Get host URL from the current window
+      const currentUrl = window.location.href.split('?')[0];
+      const baseUrl = new URL(currentUrl).origin;
+      // Get Iframe src URL
+      const srcUrl = new URL(HTMLAttributes.src);
+      const pathMatch = srcUrl.pathname.match(
+        new RegExp(`^${this.#padPath}(.+)$`),
+      );
+      // Check if the src URL is from the same origin and matches the pad path
+      if (srcUrl.origin === baseUrl && pathMatch) {
+        // Extract pad ID from the URL
+        const padId = pathMatch[1];
+        // Create a new URL with the embed path
+        const newUrl = new URL(`${baseUrl}${this.#embedPath}${padId}`);
+        // Copy search params from the src URL to the new URL
+        srcUrl.searchParams.forEach((value, key) => {
+          newUrl.searchParams.set(key, value);
+        });
+        // Set the new URL
+        HTMLAttributes.src = newUrl.toString();
+      }
+    } catch (e) {
+      console.error('Error transforming pad URL:', e);
+    }
+  }
+}


### PR DESCRIPTION
# Description

Ce fix permet de transformer les URL de pad dans l extension iframe. Ainsi lorsqu'une URL de pad est détecté on redirige l'appel vers une URL embed de l'ent. Cette URL embed va crée une session etherpad puis va rediriger vers le pad.
On évite ainsi les soucis "d'accès non autorisé" au pad.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [X] Extensions
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
