### PR TITLE
fix(client): #WB2-2660, pick neo theme for public theme

### DIFF
--- a/packages/client/src/ts/configure/Service.ts
+++ b/packages/client/src/ts/configure/Service.ts
@@ -140,8 +140,10 @@ export class ConfService {
 
     // Fix #WB2-2660:
     // If public access => get the default skin
-    // Else get the skin from the user preference
-    const skinName = publicTheme ? 'default' : theme?.skinName;
+    // Else get the skin from the user preference (if the user preference is not set => get the first skin)
+    const skinName = publicTheme
+      ? 'default'
+      : theme?.skinName || themeOverride.skins[0];
 
     const themeUrl =
       theme?.skin || `/assets/themes/${themeOverride.child}/skins/${skinName}/`;

--- a/packages/client/src/ts/configure/Service.ts
+++ b/packages/client/src/ts/configure/Service.ts
@@ -143,27 +143,28 @@ export class ConfService {
     // Else get the skin from the user preference (if the user preference is not set => get the first skin)
     const skinName = publicTheme
       ? 'default'
-      : theme?.skinName || themeOverride.skins[0];
+      : theme?.skinName || themeOverride?.skins[0];
 
     const themeUrl =
-      theme?.skin || `/assets/themes/${themeOverride.child}/skins/${skinName}/`;
-    const skins = themeOverride.skins;
-    const bootstrapVersion = themeOverride.bootstrapVersion
+      theme?.skin ||
+      `/assets/themes/${themeOverride?.child}/skins/${skinName}/`;
+    const skins = themeOverride?.skins;
+    const bootstrapVersion = themeOverride?.bootstrapVersion
       .split('-')
       .slice(-1)[0];
-    const is1d = themeOverride.parent === 'panda';
+    const is1d = themeOverride?.parent === 'panda';
 
     return {
       basePath: `${this.cdnDomain}${themeUrl}../../`,
       bootstrapVersion,
       is1d,
       logoutCallback: theme?.logoutCallback || '/',
-      skin: themeOverride.child,
+      skin: themeOverride?.child,
       skinName,
       skins,
-      themeName: themeOverride.child,
+      themeName: themeOverride?.child,
       themeUrl,
-      npmTheme: themeOverride.npmTheme ?? undefined,
+      npmTheme: themeOverride?.npmTheme ?? undefined,
     };
   }
 

--- a/packages/client/src/ts/configure/Service.ts
+++ b/packages/client/src/ts/configure/Service.ts
@@ -125,19 +125,26 @@ export class ConfService {
       queryParams: { _: version },
     }); */
 
-    const value = await this.http.get<IOdeTheme>('/theme');
-
-    const theme = !publicTheme ? value : null;
+    const theme = await this.http.get<IOdeTheme>('/theme');
 
     const themeOverride = conf?.overriding.find(
-      (item: { child: any }) =>
-        // Public access => simply use the 1st override
-        theme === null || item.child === theme.themeName,
+      (item: { child: string; parent: string; bootstrapVersion: string }) =>
+        // Fix #WB2-2660:
+        // If Public access => get the neo theme
+        // Else get the theme from the user preference
+        publicTheme
+          ? item.parent === 'theme-open-ent' &&
+            item.bootstrapVersion === 'ode-bootstrap-neo'
+          : item.child === theme.themeName,
     );
 
-    const skinName = theme?.skinName || themeOverride.skins[0];
+    // Fix #WB2-2660:
+    // If public access => get the default skin
+    // Else get the skin from the user preference
+    const skinName = publicTheme ? 'default' : theme.skinName;
+
     const themeUrl =
-      theme?.skin || `/assets/themes/${themeOverride.child}/skins/${skinName}/`;
+      theme.skin || `/assets/themes/${themeOverride.child}/skins/${skinName}/`;
     const skins = themeOverride.skins;
     const bootstrapVersion = themeOverride.bootstrapVersion
       .split('-')
@@ -148,7 +155,7 @@ export class ConfService {
       basePath: `${this.cdnDomain}${themeUrl}../../`,
       bootstrapVersion,
       is1d,
-      logoutCallback: theme?.logoutCallback || '/',
+      logoutCallback: theme.logoutCallback || '/',
       skin: themeOverride.child,
       skinName,
       skins,

--- a/packages/client/src/ts/configure/Service.ts
+++ b/packages/client/src/ts/configure/Service.ts
@@ -127,7 +127,7 @@ export class ConfService {
 
     const theme = await this.http.get<IOdeTheme>('/theme');
 
-    const themeOverride = conf?.overriding.find(
+    const themeOverride = conf?.overriding?.find(
       (item: { child: string; parent: string; bootstrapVersion: string }) =>
         // Fix #WB2-2660:
         // If Public access => get the neo theme
@@ -135,16 +135,16 @@ export class ConfService {
         publicTheme
           ? item.parent === 'theme-open-ent' &&
             item.bootstrapVersion === 'ode-bootstrap-neo'
-          : item.child === theme.themeName,
+          : item.child === theme?.themeName,
     );
 
     // Fix #WB2-2660:
     // If public access => get the default skin
     // Else get the skin from the user preference
-    const skinName = publicTheme ? 'default' : theme.skinName;
+    const skinName = publicTheme ? 'default' : theme?.skinName;
 
     const themeUrl =
-      theme.skin || `/assets/themes/${themeOverride.child}/skins/${skinName}/`;
+      theme?.skin || `/assets/themes/${themeOverride.child}/skins/${skinName}/`;
     const skins = themeOverride.skins;
     const bootstrapVersion = themeOverride.bootstrapVersion
       .split('-')
@@ -155,7 +155,7 @@ export class ConfService {
       basePath: `${this.cdnDomain}${themeUrl}../../`,
       bootstrapVersion,
       is1d,
-      logoutCallback: theme.logoutCallback || '/',
+      logoutCallback: theme?.logoutCallback || '/',
       skin: themeOverride.child,
       skinName,
       skins,


### PR DESCRIPTION
# Description

For Public pages like for example Public Blogs, the user is not authenticated so we can't know the user theme preference. Before this fix, we picked the first theme element in the `overriding` array of the `theme-conf.js` file located in the assets of the platform's springboard. Besides we used the first skin of the `skins` array.

For the Saas platform, the first element in the overriding array is the `ONE` theme and the first skin is `Circus` but for Public Blogs we would like to show the `NEO` theme with the `default` skin. So I updated the getTheme function in the client configure Service to retrieve the NEO theme if the access is Public.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
