### PR TITLE
feat(WorkspaceFolders):WB-3971 show folder without contrib right to browse into it

### DIFF
--- a/packages/client/src/ts/workspace/interface.ts
+++ b/packages/client/src/ts/workspace/interface.ts
@@ -13,7 +13,7 @@ export interface WorkspaceElement {
   //shared
   _shared: any[];
   inheritedShares?: any[];
-  _isShared: boolean;
+  _isShared: boolean; //Wrong property name, should be isShared ?
   //
   showComments?: boolean;
   editing?: boolean;
@@ -22,7 +22,7 @@ export interface WorkspaceElement {
   comment?: string;
   //
   ownerName?: string;
-  owner: { userId: string; displayName: string };
+  owner: { userId: string; displayName: string }; // Wrong type, should be owner:string ?
   //upload
   uploadStatus?: 'loading' | 'loaded' | 'failed' | 'abort';
   uploadXhr?: XMLHttpRequest;

--- a/packages/config/src/msw/mocks/workspace/data/sharedFolders.ts
+++ b/packages/config/src/msw/mocks/workspace/data/sharedFolders.ts
@@ -4,6 +4,7 @@ export const folderOfUser = {
   _id: 'cdfc982f-421a-462f-9045-90f292bb3f33',
   owner: userInfo.userId,
   name: 'Images',
+  isShared: true,
 };
 
 export const subFolderOfUser = {
@@ -11,6 +12,7 @@ export const subFolderOfUser = {
   owner: userInfo.userId,
   name: 'Sub Images',
   eParent: 'cdfc982f-421a-462f-9045-90f292bb3f33',
+  isShared: true,
 };
 
 export const folderOfOtherWithoutContribRights = {
@@ -18,6 +20,23 @@ export const folderOfOtherWithoutContribRights = {
   owner: '1493a7fb-fb90-4acb-a1d8-7c579eba7583',
   ownerName: 'Jeanne Martin',
   name: 'Périscolaire',
+  isShared: true,
+};
+
+export const subFolderOfOtherWithUserContribRights = {
+  _id: 'bdab9120-2142-447a-94b0-382a34fecc06',
+  name: 'ParaScolaire',
+  inheritedShares: [
+    {
+      'userId': userInfo.userId,
+      'org-entcore-workspace-controllers-WorkspaceController|updateDocument':
+        true,
+    },
+  ],
+  owner: '1493a7fb-fb90-4acb-a1d8-7c579eba7583',
+  ownerName: 'Jeanne Martin',
+  eParent: '0d9ec0ee-97b5-4d33-b636-a4ca2ad1d332',
+  isShared: true,
 };
 
 export const folderOfOtherWithUserContribRights = {
@@ -31,6 +50,7 @@ export const folderOfOtherWithUserContribRights = {
     },
   ],
   owner: '971d1c4a-b784-4d0e-84d3-77efb70c4479',
+  isShared: true,
 };
 
 export const folderOfOtherWithGroupContribRights = {
@@ -44,12 +64,14 @@ export const folderOfOtherWithGroupContribRights = {
     },
   ],
   owner: 'b92e3d37-16b0-4ed9-b4c3-992091687132',
+  isShared: true,
 };
 
 export const sharedFolders = [
   folderOfUser,
   subFolderOfUser,
   folderOfOtherWithoutContribRights,
+  subFolderOfOtherWithUserContribRights,
   folderOfOtherWithUserContribRights,
   folderOfOtherWithGroupContribRights,
 ];

--- a/packages/config/src/msw/mocks/workspace/workspace.ts
+++ b/packages/config/src/msw/mocks/workspace/workspace.ts
@@ -50,10 +50,9 @@ export const handlers = [
   }),
 
   http.post('/workspace/folder', async ({ request }) => {
-    const { name, parentFolderId } = (await request.json()) as {
-      name: string;
-      parentFolderId: string;
-    };
+    const formData = await request.formData();
+    const name = formData.get('name') as string;
+    const parentFolderId = formData.get('parentFolderId') as string;
 
     const newFolder = {
       _id: `new-folder-${Date.now()}`,

--- a/packages/react/src/hooks/useWorkspaceFolders/index.ts
+++ b/packages/react/src/hooks/useWorkspaceFolders/index.ts
@@ -1,2 +1,3 @@
 export { default as useWorkspaceFolders } from './useWorkspaceFolders';
-export * from './useWorkspaceFolders';
+export { default as useWorkspaceFoldersTree } from './useWorkspaceFoldersTree';
+export * from './useWorkspaceFoldersTree';

--- a/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.ts
+++ b/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.ts
@@ -52,8 +52,7 @@ function useWorkspaceFolders() {
       );
       const contrib =
         'org-entcore-workspace-controllers-WorkspaceController|updateDocument';
-      const hasContribRights = !!userRights?.find((right) => right[contrib]);
-      return hasContribRights;
+      return !!userRights?.find((right) => right[contrib]);
     },
     [folders, user],
   );

--- a/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.ts
+++ b/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.ts
@@ -1,24 +1,11 @@
-import { IUserInfo, odeServices, WorkspaceElement } from '@edifice.io/client';
+import { odeServices } from '@edifice.io/client';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useCallback, useMemo } from 'react';
 import { useEdificeClient } from '../../providers/EdificeClientProvider/EdificeClientProvider.hook';
 
-interface FolderTreeNode {
-  id: string;
-  name: string;
-  children?: FolderTreeNode[];
-  canCopyFileInto: boolean;
-  disabled?: boolean;
-}
-
-export const WORKSPACE_OWNER_FOLDER_ID = 'workspace-owner-folder-id';
-export const WORKSPACE_SHARED_FOLDER_ID = 'workspace-shared-folder-id';
-
 function useWorkspaceFolders() {
-  const { t } = useTranslation();
-  const { user } = useEdificeClient();
   const queryClient = useQueryClient();
+  const { user } = useEdificeClient();
 
   const { data: ownerWorkspaceData = [], isLoading: isLoadingOwner } = useQuery(
     {
@@ -47,116 +34,36 @@ function useWorkspaceFolders() {
     },
   });
 
-  const [searchQuery, setSearchQuery] = useState('');
+  const folders = useMemo(() => {
+    return [...ownerWorkspaceData, ...sharedWorkspaceData];
+  }, [ownerWorkspaceData, sharedWorkspaceData]);
 
-  const userfolders = useMemo(() => {
-    const buildWorkspaceTree = (
-      ownerTree: FolderTreeNode[],
-      sharedTree: FolderTreeNode[],
-    ) => {
-      return [
-        {
-          id: WORKSPACE_OWNER_FOLDER_ID,
-          name: t('workspace.myDocuments'),
-          children: ownerTree,
-          canCopyFileInto: true,
-        },
-        {
-          id: WORKSPACE_SHARED_FOLDER_ID,
-          name: t('workspace.sharedDocuments'),
-          children: sharedTree,
-          canCopyFileInto: false,
-          disabled: true,
-        },
-      ];
-    };
+  const canCopyFileIntoFolder = useCallback(
+    (folderId: string) => {
+      const folder = folders.find((folder) => folder._id === folderId);
+      if (!folder || !user) return false;
+      const userId = user.userId;
 
-    const ownerFolders = buildTree(ownerWorkspaceData, user);
-    const sharedFolders = buildTree(sharedWorkspaceData, user);
+      if (folder.owner === userId) return true;
 
-    return buildWorkspaceTree(
-      searchQuery ? filterTree(ownerFolders, searchQuery) : ownerFolders,
-      searchQuery ? filterTree(sharedFolders, searchQuery) : sharedFolders,
-    );
-  }, [ownerWorkspaceData, sharedWorkspaceData, searchQuery, user]);
+      const userRights = folder.inheritedShares?.filter(
+        (right) =>
+          right.userId === userId || user.groupsIds.includes(right.groupId),
+      );
+      const contrib =
+        'org-entcore-workspace-controllers-WorkspaceController|updateDocument';
+      const hasContribRights = !!userRights?.find((right) => right[contrib]);
+      return hasContribRights;
+    },
+    [folders, user],
+  );
 
   return {
-    folderTree: userfolders,
-    setSearchQuery,
-    user,
+    folders,
     createFolderMutation,
+    canCopyFileIntoFolder,
     isLoading: isLoadingOwner || isLoadingShared,
   };
 }
 
-const buildTree = (workspaceData: WorkspaceElement[], user?: IUserInfo) => {
-  const nodes = new Map();
-  const fullTree: FolderTreeNode[] = [];
-
-  // 1 - list all folders with empty children
-  workspaceData.forEach((item) => {
-    const canCopyFileInto =
-      user && canWriteOnFolder(item, user.userId, user.groupsIds);
-    nodes.set(item._id, {
-      id: item._id,
-      name: item.name,
-      children: [],
-      canCopyFileInto,
-      expandedNodes: [
-        '0576e0dd-129b-4244-b36a-49bda713d273',
-        '50c1b81b-d8b7-4474-9d69-b5e441b31a8c',
-        'a1aac5c0-6bfe-4308-8c43-812378e2d9bf',
-      ],
-    });
-  });
-
-  // 2 - assign children to their parents
-  workspaceData.forEach((item) => {
-    const nodeItem = nodes.get(item._id);
-    if (!nodeItem.canCopyFileInto) return;
-
-    if (item.eParent && nodes.has(item.eParent)) {
-      nodes.get(item.eParent)?.children.push(nodeItem);
-    } else {
-      fullTree.push(nodeItem);
-    }
-  });
-  return fullTree;
-};
-
-const filterTree = (
-  nodes: FolderTreeNode[],
-  search: string,
-): FolderTreeNode[] => {
-  return nodes
-    .map((node) => {
-      const filteredChildren = node.children
-        ? filterTree(node.children, search)
-        : [];
-      if (
-        node.name.toLowerCase().includes(search.toLowerCase()) ||
-        filteredChildren.length > 0
-      ) {
-        return { ...node, children: filteredChildren };
-      }
-      return null;
-    })
-    .filter((node) => node !== null);
-};
-
-const canWriteOnFolder = (
-  folderData: WorkspaceElement,
-  userId: string,
-  userGroupsIds: string[],
-) => {
-  if (folderData.owner === userId) return true;
-
-  const userRights = folderData.inheritedShares?.filter(
-    (right) => right.userId === userId || userGroupsIds.includes(right.groupId),
-  );
-  const contrib =
-    'org-entcore-workspace-controllers-WorkspaceController|updateDocument';
-  const hasContribRights = !!userRights?.find((right) => right[contrib]);
-  return hasContribRights;
-};
 export default useWorkspaceFolders;

--- a/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFoldersTree.ts
+++ b/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFoldersTree.ts
@@ -1,0 +1,103 @@
+import { WorkspaceElement } from '@edifice.io/client';
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useEdificeClient } from '../../providers/EdificeClientProvider/EdificeClientProvider.hook';
+
+interface FolderTreeNode {
+  id: string;
+  name: string;
+  children?: FolderTreeNode[];
+}
+
+export const WORKSPACE_USER_FOLDER_ID = 'workspace-user-folder-id';
+export const WORKSPACE_SHARED_FOLDER_ID = 'workspace-shared-folder-id';
+
+function useWorkspaceFoldersTree(folders?: WorkspaceElement[]) {
+  const { t } = useTranslation();
+  const { user } = useEdificeClient();
+
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filtredFoldersTree = useMemo(() => {
+    const userTreeLabel = t('workspace.myDocuments');
+    const sharedTreeLabel = t('workspace.sharedDocuments');
+    const foldersTree = buildTree(
+      folders || [],
+      userTreeLabel,
+      sharedTreeLabel,
+    );
+
+    return searchQuery ? filterTree(foldersTree, searchQuery) : foldersTree;
+  }, [folders, searchQuery, user]);
+
+  return {
+    foldersTree: filtredFoldersTree,
+    filterTree: setSearchQuery,
+  };
+}
+
+export default useWorkspaceFoldersTree;
+
+const buildTree = (
+  workspaceData: WorkspaceElement[],
+  userTreeLabel: string,
+  sharedTreeLabel: string,
+) => {
+  const nodes = new Map();
+  const userTree: FolderTreeNode[] = [];
+  const sharedTree: FolderTreeNode[] = [];
+
+  // 1 - list all folders with empty children
+  workspaceData.forEach((item) => {
+    nodes.set(item._id, {
+      id: item._id,
+      name: item.name,
+      children: [],
+    });
+  });
+
+  // 2 - assign children to their parents
+  workspaceData.forEach((item) => {
+    const nodeItem = nodes.get(item._id);
+
+    if (item.eParent && nodes.has(item.eParent)) {
+      nodes.get(item.eParent)?.children.push(nodeItem);
+    } else if (item.isShared || item.inheritedShares) {
+      sharedTree.push(nodeItem);
+    } else {
+      userTree.push(nodeItem);
+    }
+  });
+  return [
+    {
+      id: WORKSPACE_USER_FOLDER_ID,
+      name: userTreeLabel,
+      children: userTree,
+    },
+    {
+      id: WORKSPACE_SHARED_FOLDER_ID,
+      name: sharedTreeLabel,
+      children: sharedTree,
+    },
+  ];
+};
+
+const filterTree = (
+  nodes: FolderTreeNode[],
+  search: string,
+): FolderTreeNode[] => {
+  return nodes
+    .map((node) => {
+      const filteredChildren = node.children
+        ? filterTree(node.children, search)
+        : [];
+      if (
+        node.name.toLowerCase().includes(search.toLowerCase()) ||
+        filteredChildren.length > 0
+      ) {
+        return { ...node, children: filteredChildren };
+      }
+      return null;
+    })
+    .filter((node) => node !== null);
+};

--- a/packages/react/src/modules/multimedia/WorkspaceFolders/WorkspaceFolders.tsx
+++ b/packages/react/src/modules/multimedia/WorkspaceFolders/WorkspaceFolders.tsx
@@ -1,9 +1,9 @@
 import { ChangeEvent, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, Loading, SearchBar, Tree } from '../../../components';
-import { useWorkspaceFolders } from '../../../hooks';
+import { useWorkspaceFolders, useWorkspaceFoldersTree } from '../../../hooks';
 import {
-  WORKSPACE_OWNER_FOLDER_ID,
+  WORKSPACE_USER_FOLDER_ID,
   WORKSPACE_SHARED_FOLDER_ID,
 } from '../../../hooks/useWorkspaceFolders';
 import { IconFolderAdd } from '../../icons/components';
@@ -20,29 +20,40 @@ export default function WorkspaceFolders({
   onFolderSelected,
 }: WorkspaceFoldersProps) {
   const { t } = useTranslation();
-  const { folderTree, setSearchQuery, isLoading } = useWorkspaceFolders();
+  const { folders, isLoading, canCopyFileIntoFolder } = useWorkspaceFolders();
+  const { foldersTree, filterTree } = useWorkspaceFoldersTree(folders);
   const [shouldExpandAllNodes, setShouldExpandAllNodes] = useState(false);
   const [searchValue, setSearchValue] = useState('');
   const [selectedFolderId, setSelectedFolderId] = useState<string | undefined>(
     undefined,
   );
   const [showNewFolderForm, setShowNewFolderForm] = useState(false);
+  const [
+    canCreateFolderIntoSelectedFolder,
+    setCanCreateFolderIntoSelectedFolder,
+  ] = useState(false);
 
   const handleSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value);
   };
 
   const handleSearchSubmit = () => {
-    setSearchQuery(searchValue);
+    filterTree(searchValue);
     setShouldExpandAllNodes(searchValue !== '');
   };
 
   const handleFolderSelected = (folderId: string) => {
     const newSelectedFolderId =
-      folderId === WORKSPACE_OWNER_FOLDER_ID ? '' : folderId;
-    const canCopyFileInto = folderId != WORKSPACE_SHARED_FOLDER_ID;
-    onFolderSelected(newSelectedFolderId, canCopyFileInto);
+      folderId === WORKSPACE_USER_FOLDER_ID ? '' : folderId;
+
+    const canCopyFileInto =
+      folderId === WORKSPACE_USER_FOLDER_ID ||
+      (canCopyFileIntoFolder(folderId) &&
+        folderId !== WORKSPACE_SHARED_FOLDER_ID);
+
+    setCanCreateFolderIntoSelectedFolder(canCopyFileInto);
     setSelectedFolderId(newSelectedFolderId);
+    onFolderSelected(newSelectedFolderId, canCopyFileInto);
   };
 
   const handleNewFolderClick = () => {
@@ -65,7 +76,7 @@ export default function WorkspaceFolders({
               <Loading isLoading className="justify-content-center" />
             ) : (
               <Tree
-                nodes={folderTree}
+                nodes={foldersTree}
                 onTreeItemClick={handleFolderSelected}
                 shouldExpandAllNodes={shouldExpandAllNodes}
               />
@@ -79,15 +90,13 @@ export default function WorkspaceFolders({
                 variant="ghost"
                 leftIcon={<IconFolderAdd />}
                 onClick={handleNewFolderClick}
-                disabled={[WORKSPACE_SHARED_FOLDER_ID, undefined].includes(
-                  selectedFolderId,
-                )}
+                disabled={!canCreateFolderIntoSelectedFolder}
               >
                 {t('workspace.folder.create')}
               </Button>
             )}
 
-            {selectedFolderId != undefined && showNewFolderForm && (
+            {showNewFolderForm && selectedFolderId && (
               <NewFolderForm
                 onClose={() => setShowNewFolderForm(false)}
                 folderParentId={selectedFolderId}

--- a/packages/react/src/modules/multimedia/WorkspaceFolders/WorkspaceFolders.tsx
+++ b/packages/react/src/modules/multimedia/WorkspaceFolders/WorkspaceFolders.tsx
@@ -43,19 +43,26 @@ export default function WorkspaceFolders({
   };
 
   const handleFolderSelected = (folderId: string) => {
+    setShowNewFolderForm(false);
+
+    // the user folder Id have to be an empty string to match with the API (parentId property)
     const newSelectedFolderId =
       folderId === WORKSPACE_USER_FOLDER_ID ? '' : folderId;
+    setSelectedFolderId(newSelectedFolderId);
 
     const canCopyFileInto =
       folderId === WORKSPACE_USER_FOLDER_ID ||
       (canCopyFileIntoFolder(folderId) &&
         folderId !== WORKSPACE_SHARED_FOLDER_ID);
-
     setCanCreateFolderIntoSelectedFolder(canCopyFileInto);
-    setSelectedFolderId(newSelectedFolderId);
+
     onFolderSelected(newSelectedFolderId, canCopyFileInto);
   };
 
+  console.log(
+    'canCreateFolderIntoSelectedFolder:',
+    canCreateFolderIntoSelectedFolder,
+  );
   const handleNewFolderClick = () => {
     setShowNewFolderForm(true);
   };
@@ -96,7 +103,7 @@ export default function WorkspaceFolders({
               </Button>
             )}
 
-            {showNewFolderForm && selectedFolderId && (
+            {showNewFolderForm && selectedFolderId !== undefined && (
               <NewFolderForm
                 onClose={() => setShowNewFolderForm(false)}
                 folderParentId={selectedFolderId}


### PR DESCRIPTION
# Description

Show folder without contribution rights to browse into it and create folder into children with contribution rights

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
