### PR TITLE
feat(ConfirmModal):WB-4004 hide toolbar labels on mobile

### DIFF
--- a/packages/react/src/components/List/List.tsx
+++ b/packages/react/src/components/List/List.tsx
@@ -1,8 +1,7 @@
-import { useMediaQuery } from '@uidotdev/usehooks';
 import clsx from 'clsx';
 import { Fragment, ReactNode, useEffect } from 'react';
 import { Checkbox, Toolbar, ToolbarItem } from '..';
-import { useCheckable } from '../..';
+import { useBreakpoint, useCheckable } from '../..';
 
 export type ListProps<T> = {
   /**
@@ -29,6 +28,12 @@ export type ListProps<T> = {
    * Custom class name
    */
   className?: string;
+  /**
+   * Toolbar options
+   */
+  toolbarOptions?: {
+    shouldHideLabelsOnMobile?: boolean;
+  };
 };
 
 export const List = <T extends { _id: string }>({
@@ -38,6 +43,7 @@ export const List = <T extends { _id: string }>({
   renderNode,
   onSelectedItems,
   className,
+  toolbarOptions,
 }: ListProps<T>) => {
   const {
     selectedItems,
@@ -47,7 +53,7 @@ export const List = <T extends { _id: string }>({
     handleOnSelectItem,
   } = useCheckable<T>(data);
 
-  const isDesktopDevice = useMediaQuery('only screen and (min-width: 1024px)');
+  const { lg } = useBreakpoint();
 
   useEffect(() => {
     if (selectedItems) onSelectedItems?.(selectedItems);
@@ -75,11 +81,14 @@ export const List = <T extends { _id: string }>({
               {items && (
                 <Toolbar
                   items={items}
+                  shouldHideLabelsOnMobile={
+                    toolbarOptions?.shouldHideLabelsOnMobile
+                  }
                   isBlock
                   align="left"
                   variant="no-shadow"
                   className={clsx('gap-4 py-4', {
-                    'px-0 ms-auto': !isDesktopDevice,
+                    'px-0 ms-auto': !lg,
                   })}
                 />
               )}

--- a/packages/react/src/components/Toolbar/Toolbar.stories.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.stories.tsx
@@ -308,6 +308,50 @@ export const WithDropdownAction: Story = {
   },
 };
 
+export const HideLabelOnMobile: Story = {
+  render: (args) => <Toolbar {...args} />,
+  decorators: [
+    (Story) => (
+      <div className="m-24 w-100" style={{ height: '300px' }}>
+        {Story()}
+      </div>
+    ),
+  ],
+  args: {
+    shouldHideLabelsOnMobile: true,
+    items: [
+      {
+        type: 'button',
+        name: 'Label',
+        props: {
+          disabled: false,
+          leftIcon: <IconRecord />,
+          children: 'Record',
+          onClick: () => console.log('on click'),
+        },
+      },
+      {
+        type: 'button',
+        name: 'Label',
+        props: {
+          disabled: false,
+          leftIcon: <IconSave />,
+          children: 'Save',
+          onClick: () => console.log('on click'),
+        },
+      },
+    ],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'For items of type `button`, you can hide labels of the toolbar item when the screen is smaller than 1024px with the property `shouldHideLabelsOnMobile`.',
+      },
+    },
+  },
+};
+
 export const WithoutShadow: Story = {
   render: (args) => <Toolbar {...args} variant="no-shadow" />,
   parameters: {

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -261,7 +261,7 @@ export const Toolbar = forwardRef(
                   <Button
                     {...item.props}
                     children={hideLabel ? undefined : item.props.children}
-                    aria-label={hideLabel ? item.name : undefined}
+                    aria-label={item.name}
                     key={item.name ?? index}
                     color={item.props.color ? item.props.color : 'tertiary'}
                     variant="ghost"

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -10,6 +10,7 @@ import {
 
 import clsx from 'clsx';
 
+import { useBreakpoint } from '../../hooks';
 import { mergeRefs } from '../../utilities';
 import { Button, ButtonProps, IconButton, IconButtonProps } from '../Button';
 import { Dropdown, DropdownProps } from '../Dropdown';
@@ -105,6 +106,10 @@ export interface ToolbarProps extends React.ComponentPropsWithRef<'div'> {
    * Accept optional children
    */
   children?: ReactNode;
+  /**
+   * Hide labels on mobile
+   */
+  shouldHideLabelsOnMobile?: boolean;
 }
 
 export const Toolbar = forwardRef(
@@ -116,6 +121,7 @@ export const Toolbar = forwardRef(
       isBlock = false,
       ariaControls,
       className,
+      shouldHideLabelsOnMobile = false,
     }: ToolbarProps,
     ref: Ref<ToolbarRef>,
   ) => {
@@ -130,6 +136,7 @@ export const Toolbar = forwardRef(
       useState<HTMLElement>();
 
     const divToolbarRef = useRef<HTMLDivElement>();
+    const { lg } = useBreakpoint();
 
     const classes = clsx('toolbar z-1000 bg-white', className, {
       'default': variant === 'default',
@@ -236,6 +243,7 @@ export const Toolbar = forwardRef(
       >
         {items.map((item, index) => {
           if (item.visibility === 'hide') return null;
+          const hideLabel = shouldHideLabelsOnMobile && !lg;
 
           switch (item.type) {
             case 'divider':
@@ -247,11 +255,13 @@ export const Toolbar = forwardRef(
               return (
                 <Tooltip
                   key={item.name ?? index}
-                  message={renderTooltipMessage(item)}
+                  message={hideLabel ? renderTooltipMessage(item) : undefined}
                   placement={renderTooltipPosition(item)}
                 >
                   <Button
                     {...item.props}
+                    children={hideLabel ? undefined : item.props.children}
+                    aria-label={hideLabel ? item.name : undefined}
                     key={item.name ?? index}
                     color={item.props.color ? item.props.color : 'tertiary'}
                     variant="ghost"

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -260,10 +260,10 @@ export const Toolbar = forwardRef(
                 >
                   <Button
                     {...item.props}
-                    children={hideLabel ? undefined : item.props.children}
+                    children={!hideLabel && item.props.children}
                     aria-label={item.name}
                     key={item.name ?? index}
-                    color={item.props.color ? item.props.color : 'tertiary'}
+                    color={item.props.color || 'tertiary'}
                     variant="ghost"
                     tabIndex={index === firstFocusableItemIndex ? 0 : -1}
                     onKeyDown={handleKeyDown}


### PR DESCRIPTION
# Description

Toolbar : masquer texte des boutons en responsive ([Ticket](https://edifice-community.atlassian.net/browse/WB-4004))

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
