### PR TITLE
fix(appointments): #RDV-50 add missing icon for appointments

### DIFF
--- a/packages/bootstrap/src/abstracts/_icons.scss
+++ b/packages/bootstrap/src/abstracts/_icons.scss
@@ -534,6 +534,6 @@ $icons-connectors: (
   ),
   'appointments': (
     'neo': $green,
-    'one': $green,
+    'one': $one-green,
   ),
 ) !default;

--- a/packages/bootstrap/src/abstracts/_icons.scss
+++ b/packages/bootstrap/src/abstracts/_icons.scss
@@ -532,4 +532,8 @@ $icons-connectors: (
     'neo': $nabook-color,
     'one': $nabook-color,
   ),
+  'appointments': (
+    'neo': $green,
+    'one': $green,
+  ),
 ) !default;


### PR DESCRIPTION
# Description

This pull request adds a new icon color configuration for "appointments" in the `$icons-connectors` map within the `_icons.scss` file.

* [`packages/bootstrap/src/abstracts/_icons.scss`](diffhunk://#diff-51787a72acbfefbbeec434f9c627be056ad12816f2f1c9763d8be81a7847b16fR535-R538): Added a new entry for `'appointments'` with the color `$green` for both `'neo'` and `'one'` themes in the `$icons-connectors` map.

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [x] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
