### PR TITLE
fix(react):#WB-4005 fix modal padding

### DIFF
--- a/packages/bootstrap/src/abstracts/_variables.scss
+++ b/packages/bootstrap/src/abstracts/_variables.scss
@@ -251,7 +251,7 @@ $modal-header-border-width: 0 !default;
 $modal-inner-padding: 1.5rem !default;
 $modal-content-border-width: 0 !default;
 $modal-inner-padding: $spacer-0 !default;
-$modal-content-padding: $spacer-32 !default;
+$modal-content-padding: $spacer-24 !default;
 $modal-header-padding: $spacer-0 !default;
 $modal-footer-padding: $spacer-0 !default;
 $modal-dialog-margin: $spacer-32 !default;

--- a/packages/bootstrap/src/components/_modal.scss
+++ b/packages/bootstrap/src/components/_modal.scss
@@ -125,21 +125,17 @@
   &.modal-lg {
     padding-inline: $spacer-16;
 
-    .modal-dialog {
-      max-width: 100%;
-    }
-
     @include bootstrap.media-breakpoint-up(md) {
       padding-inline: $spacer-32;
     }
 
-    & > .modal-content {
-      @include bootstrap.media-breakpoint-up(xs) {
-        padding: $spacer-24;
-      }
+    .modal-dialog {
+      max-width: 100%;
+    }
 
+    .modal-content {
       @include bootstrap.media-breakpoint-up(md) {
-        padding: var(--#{$prefix}modal-content-padding);
+        padding: $spacer-32;
       }
     }
   }


### PR DESCRIPTION
# Description

modal padding to 24px up to md, then 32px 
Ticket : https://edifice-community.atlassian.net/jira/software/c/projects/WB/boards/234?assignee=712020%3Aa351bfd8-8169-43e4-821c-48991f7e3d43&selectedIssue=WB-4005

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
