### PR TITLE
fix(conversation-history): #WB-3438 conversation history have multiple block children

### DIFF
--- a/packages/extensions/src/conversation-history/conversation-history.ts
+++ b/packages/extensions/src/conversation-history/conversation-history.ts
@@ -34,12 +34,15 @@ import { Plugin } from 'prosemirror-state';
 export const ConversationHistory = Node.create({
   name: 'converstationHistory',
   group: 'block',
-  content: 'block',
+  content: 'block+',
 
   parseHTML() {
     return [
       {
         tag: 'div.conversation-history',
+      },
+      {
+        tag: 'p.conversation-history',
       },
     ];
   },

--- a/packages/react/src/modules/editor/components/Renderer/ConversationHistoryRenderer.tsx
+++ b/packages/react/src/modules/editor/components/Renderer/ConversationHistoryRenderer.tsx
@@ -17,8 +17,7 @@ const ConversationHistoryRenderer = () => {
   // const appCode = getIconCode(appPrefix);
   const [open, toggleOpen] = useToggle(false);
 
-  const classes = clsx('conversation-history ps-16', { show: open });
-
+  const classes = clsx('conversation-history ps-16 pt-4', { show: open });
   return (
     <NodeViewWrapper as="div" contentEditable={false}>
       <Button


### PR DESCRIPTION
# Description

The conversation history container can have multiple blocks as children.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks
- [x] Tiptap extensions

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
