### PR TITLE
feat(react):#WB-3944 add formatTimeAgo to useDate hook

### DIFF
--- a/packages/react/src/hooks/useDate/useDate.ts
+++ b/packages/react/src/hooks/useDate/useDate.ts
@@ -61,13 +61,12 @@ export default function useDate() {
     [currentLanguage],
   );
 
-  /** Compute a user-friendly elapsed duration, between now and a date. */
-  const fromNow = useCallback(
-    (date: CoreDate | NumberDate): string => {
+  const toComputedDate = useCallback(
+    (date: CoreDate | NumberDate): Dayjs => {
       let computedDate: Dayjs = dayjs();
       try {
         if ('undefined' === typeof date) {
-          return '';
+          return dayjs();
         } else if ('string' === typeof date) {
           computedDate = parseDate(date);
         } else if ('number' === typeof date) {
@@ -79,57 +78,46 @@ export default function useDate() {
         } else if ('string' === typeof date.$date) {
           computedDate = parseDate(date.$date);
         }
-
-        return computedDate.isValid() ? computedDate.fromNow() : '';
+        return computedDate;
       } catch (error) {
         console.error(error);
-        return '';
       }
+      return computedDate;
+    },
+    [currentLanguage, parseDate],
+  );
+
+  /** Compute a user-friendly elapsed duration, between now and a date. */
+  const fromNow = useCallback(
+    (date: CoreDate | NumberDate): string => {
+      let computedDate = toComputedDate(date);
+      return computedDate.isValid() ? computedDate.fromNow() : '';
     },
     [currentLanguage, parseDate],
   );
 
   const formatDate = useCallback(
     (date: CoreDate, format = 'short'): string => {
-      let computedDate: Dayjs = dayjs();
+      let computedDate = toComputedDate(date);
 
-      try {
-        if ('undefined' === typeof date) {
-          return '';
-        } else if ('string' === typeof date) {
-          computedDate = parseDate(date);
-        } else if ('number' === typeof date) {
-          computedDate = dayjs(date).locale(currentLanguage as string);
-        } else if ('number' === typeof date.$date) {
-          computedDate = dayjs(new Date(date.$date)).locale(
-            currentLanguage as string,
-          );
-        } else if ('string' === typeof date.$date) {
-          computedDate = parseDate(date.$date);
-        }
-
-        let dayjsFormat = '';
-        switch (format) {
-          case 'short':
-            dayjsFormat = 'L';
-            break;
-          case 'long':
-            dayjsFormat = 'LL';
-            break;
-          case 'abbr':
-            dayjsFormat = 'll';
-            break;
-          default:
-            dayjsFormat = format;
-        }
-
-        return computedDate.isValid()
-          ? computedDate.locale(currentLanguage as string).format(dayjsFormat)
-          : '';
-      } catch (error) {
-        console.error(error);
-        return '';
+      let dayjsFormat = '';
+      switch (format) {
+        case 'short':
+          dayjsFormat = 'L';
+          break;
+        case 'long':
+          dayjsFormat = 'LL';
+          break;
+        case 'abbr':
+          dayjsFormat = 'll';
+          break;
+        default:
+          dayjsFormat = format;
       }
+
+      return computedDate.isValid()
+        ? computedDate.locale(currentLanguage as string).format(dayjsFormat)
+        : '';
     },
     [currentLanguage, parseDate],
   );

--- a/packages/react/src/hooks/useDate/useDate.ts
+++ b/packages/react/src/hooks/useDate/useDate.ts
@@ -90,7 +90,7 @@ export default function useDate() {
   /** Compute a user-friendly elapsed duration, between now and a date. */
   const fromNow = useCallback(
     (date: CoreDate | NumberDate): string => {
-      let computedDate = toComputedDate(date);
+      const computedDate = toComputedDate(date);
       return computedDate.isValid() ? computedDate.fromNow() : '';
     },
     [currentLanguage, parseDate],
@@ -98,7 +98,7 @@ export default function useDate() {
 
   const formatDate = useCallback(
     (date: CoreDate, format = 'short'): string => {
-      let computedDate = toComputedDate(date);
+      const computedDate = toComputedDate(date);
 
       let dayjsFormat = '';
       switch (format) {

--- a/packages/react/src/hooks/useDate/useDate.ts
+++ b/packages/react/src/hooks/useDate/useDate.ts
@@ -122,7 +122,7 @@ export default function useDate() {
       }
 
       // format D MMM YYYY
-      return computedDate.format(t('date.formatpreviousYear'));
+      return computedDate.format(t('date.format.previousYear'));
     },
     [currentLanguage, parseDate],
   );

--- a/packages/react/src/hooks/useDate/useDate.ts
+++ b/packages/react/src/hooks/useDate/useDate.ts
@@ -62,11 +62,11 @@ export default function useDate() {
   );
 
   const toComputedDate = useCallback(
-    (date: CoreDate | NumberDate): Dayjs => {
+    (date: CoreDate | NumberDate): Dayjs | undefined => {
       let computedDate: Dayjs = dayjs();
       try {
         if ('undefined' === typeof date) {
-          return dayjs();
+          return undefined;
         } else if ('string' === typeof date) {
           computedDate = parseDate(date);
         } else if ('number' === typeof date) {
@@ -91,7 +91,7 @@ export default function useDate() {
   const fromNow = useCallback(
     (date: CoreDate | NumberDate): string => {
       const computedDate = toComputedDate(date);
-      return computedDate.isValid() ? computedDate.fromNow() : '';
+      return computedDate?.isValid() ? computedDate.fromNow() : '';
     },
     [currentLanguage, parseDate],
   );
@@ -115,7 +115,7 @@ export default function useDate() {
           dayjsFormat = format;
       }
 
-      return computedDate.isValid()
+      return computedDate?.isValid()
         ? computedDate.locale(currentLanguage as string).format(dayjsFormat)
         : '';
     },

--- a/packages/react/src/hooks/useDate/useDate.ts
+++ b/packages/react/src/hooks/useDate/useDate.ts
@@ -15,6 +15,7 @@ import 'dayjs/locale/fr.js';
 import 'dayjs/locale/it.js';
 import 'dayjs/locale/pt.js';
 import { useEdificeClient } from '../../providers/EdificeClientProvider/EdificeClientProvider.hook';
+import { useTranslation } from 'react-i18next';
 
 dayjs.extend(relativeTime);
 dayjs.extend(customParseFormat);
@@ -36,6 +37,7 @@ export type CoreDate = IsoDate | MongoDate | NumberDate;
 export default function useDate() {
   // Current language
   const { currentLanguage } = useEdificeClient();
+  const { t } = useTranslation();
 
   /* Utility function */
   const parseDate = useCallback(
@@ -99,23 +101,28 @@ export default function useDate() {
         if (now.diff(computedDate, 'hours') <= 3) {
           return computedDate.fromNow();
         } else {
-          return computedDate.format('HH:mm');
+          // format HH:mm
+          return computedDate.format(t('date.format.currentDay'));
         }
       }
 
       if (computedDate.isSame(now.subtract(1, 'day'), 'date')) {
-        return 'Yesterday';
+        // format "Yesterday"
+        return t('date.format.yesterday');
       }
 
       if (now.diff(computedDate, 'days') <= 7) {
-        return computedDate.format('dddd');
+        // format dddd
+        return computedDate.format(t('date.format.currentWeek'));
       }
 
       if (computedDate.isSame(now, 'year')) {
-        return computedDate.format('D MMM');
+        // format D MMM
+        return computedDate.format(t('date.format.currentYear'));
       }
 
-      return computedDate.format('D MMM YYYY');
+      // format D MMM YYYY
+      return computedDate.format(t('date.formatpreviousYear'));
     },
     [currentLanguage, parseDate],
   );

--- a/packages/react/src/hooks/useDate/useDate.ts
+++ b/packages/react/src/hooks/useDate/useDate.ts
@@ -87,6 +87,39 @@ export default function useDate() {
     [currentLanguage, parseDate],
   );
 
+  const formatTimeAgo = useCallback(
+    (date: CoreDate | NumberDate): string => {
+      const computedDate = toComputedDate(date);
+
+      if (!computedDate?.isValid()) return '';
+
+      const now = dayjs();
+
+      if (computedDate.isSame(now, 'date')) {
+        if (now.diff(computedDate, 'hours') <= 3) {
+          return computedDate.fromNow();
+        } else {
+          return computedDate.format('HH:mm');
+        }
+      }
+
+      if (computedDate.isSame(now.subtract(1, 'day'), 'date')) {
+        return 'Yesterday';
+      }
+
+      if (now.diff(computedDate, 'days') <= 7) {
+        return computedDate.format('dddd');
+      }
+
+      if (computedDate.isSame(now, 'year')) {
+        return computedDate.format('D MMM');
+      }
+
+      return computedDate.format('D MMM YYYY');
+    },
+    [currentLanguage, parseDate],
+  );
+
   /** Compute a user-friendly elapsed duration, between now and a date. */
   const fromNow = useCallback(
     (date: CoreDate | NumberDate): string => {
@@ -125,5 +158,6 @@ export default function useDate() {
   return {
     fromNow,
     formatDate,
+    formatTimeAgo,
   };
 }


### PR DESCRIPTION
# Description

J'ai mis à jour le hook useDate du FF en ajoutant la fonction formatTimeAgo qui devra être utilisé sur plusieurs app selon les [specs](https://edifice-community.atlassian.net/wiki/spaces/ODE/pages/2954428501/MB+docs+-+Format+des+dates+et+temps) ([Ticket Enabling](https://edifice-community.atlassian.net/browse/ENABLING-266))

Liée à la PR de conversation : https://github.com/edificeio/entcore/pull/705

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
