### PR TITLE
fix(conversation): #COCO-4210 fix Tooltip z-index

### DIFF
--- a/packages/react/src/components/Tooltip/Tooltip.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.tsx
@@ -71,7 +71,7 @@ const Tooltip = ({
   return (
     <>
       <div
-        className="d-inline-block position-relative z-2"
+        className="d-inline-block position-relative"
         ref={setReferenceElement}
         onMouseEnter={() => {
           setVisible(true);
@@ -85,7 +85,7 @@ const Tooltip = ({
       </div>
       {visible && message && (
         <div
-          className={clsx('tooltip d-block show mb-12', `bs-tooltip-auto`)}
+          className={clsx('tooltip d-block show mb-12 z-2', `bs-tooltip-auto`)}
           ref={setPopperElement}
           style={styles.popper}
           {...attributes.popper}


### PR DESCRIPTION
# Description

applique le z-index du toomtip sur le tooltip et non sur la cible

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
