### PR TITLE
fix(react,bootstrap):COCO-4207 editor-re-add-media-after-deletion

### DIFF
--- a/packages/bootstrap/src/components/_dropzone.scss
+++ b/packages/bootstrap/src/components/_dropzone.scss
@@ -34,7 +34,6 @@
       background: $white;
       position: sticky;
       top: 0;
-      z-index: 100;
       width: 100%;
       border-bottom: solid 1px $gray-400;
 

--- a/packages/react/src/hooks/useDropzone/useDropzone.ts
+++ b/packages/react/src/hooks/useDropzone/useDropzone.ts
@@ -20,7 +20,6 @@ const useDropzone = (props?: {
     setFiles((prevFiles) =>
       prevFiles.filter((prevFile) => prevFile.name !== file.name),
     );
-    if (inputRef.current) inputRef.current.value = '';
   };
 
   const replaceFileAt = (index: number, file: File) => {

--- a/packages/react/src/hooks/useDropzone/useDropzone.ts
+++ b/packages/react/src/hooks/useDropzone/useDropzone.ts
@@ -20,6 +20,7 @@ const useDropzone = (props?: {
     setFiles((prevFiles) =>
       prevFiles.filter((prevFile) => prevFile.name !== file.name),
     );
+    if (inputRef.current) inputRef.current.value = '';
   };
 
   const replaceFileAt = (index: number, file: File) => {

--- a/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
@@ -31,6 +31,12 @@ const useUploadFiles = ({
     uploadAlternateFile,
   } = useUpload(visibility, application);
 
+  const resetInputValue = useCallback(() => {
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+  }, [inputRef]);
+
   const tryUploading = useCallback(
     (files: Array<File | null>) => {
       files.forEach(async (file, index) => {
@@ -54,9 +60,7 @@ const useUploadFiles = ({
             resource,
           ]);
         } else {
-          if (inputRef.current) {
-            inputRef.current.value = '';
-          }
+          resetInputValue();
         }
       });
     },
@@ -130,9 +134,7 @@ const useUploadFiles = ({
     }
     // Remove the file from `files`
     deleteFile(file);
-    if (inputRef.current) {
-      inputRef.current.value = '';
-    }
+    resetInputValue();
   }
 
   async function updateImage({

--- a/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
@@ -21,7 +21,7 @@ const useUploadFiles = ({
     WorkspaceElement | undefined
   >(undefined);
 
-  const { files, deleteFile, replaceFileAt } = useDropzoneContext();
+  const { files, deleteFile, replaceFileAt, inputRef } = useDropzoneContext();
   const { remove, createOrUpdate } = useWorkspaceFile();
   const {
     getUploadStatus,
@@ -126,6 +126,9 @@ const useUploadFiles = ({
     }
     // Remove the file from `files`
     deleteFile(file);
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
   }
 
   async function updateImage({

--- a/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
@@ -44,10 +44,10 @@ const useUploadFiles = ({
           } catch (err) {
             console.error(err);
           }
-        }
-        if (!resource) {
+        } else {
           resource = await uploadFile(file);
         }
+
         if (resource) {
           setUploadedFiles((prevFiles: WorkspaceElement[]) => [
             ...prevFiles,

--- a/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
@@ -41,16 +41,19 @@ const useUploadFiles = ({
     (files: Array<File | null>) => {
       files.forEach(async (file, index) => {
         if (file == null) return;
-        let resource;
+        let resource, replacement;
+
         if (file.type.startsWith('image')) {
           try {
-            const replacement = await ImageResizer.resizeImageFile(file);
+            replacement = await ImageResizer.resizeImageFile(file);
             resource = await uploadAlternateFile(file, replacement);
             replaceFileAt(index, replacement);
           } catch (err) {
             console.error(err);
           }
-        } else {
+        }
+
+        if (!resource && !replacement) {
           resource = await uploadFile(file);
         }
 

--- a/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
+++ b/packages/react/src/hooks/useUploadFiles/useUploadFiles.ts
@@ -53,6 +53,10 @@ const useUploadFiles = ({
             ...prevFiles,
             resource,
           ]);
+        } else {
+          if (inputRef.current) {
+            inputRef.current.value = '';
+          }
         }
       });
     },


### PR DESCRIPTION
# Description

Lors de l'ajout PJ dans l'editeur,
https://edifice-community.atlassian.net/browse/COCO-4207
-  supprimer le fichier et le remettre ne fonctionnait pas 
Lorsqu'il n'y a pas d'espace disponible
- deux toast d'erreurs sont affiché au lieu d'un seul (car la requete est retenté avec l'image d'origine => ne plus avoir ce callback)
- upload la même image si il y a eu une erreur 


## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
