### PR TITLE
fix(editor): #COCO-4232 icon not displayed for information panel

### DIFF
--- a/packages/react/src/modules/editor/components/BubbleMenuEditInformationPane/BubbleMenuEditInformationPane.tsx
+++ b/packages/react/src/modules/editor/components/BubbleMenuEditInformationPane/BubbleMenuEditInformationPane.tsx
@@ -31,7 +31,7 @@ const BubbleMenuEditInformationPane = ({
         name: 'info',
         props: {
           'size': 'lg',
-          'leftIcon': <IconInfoCircle />,
+          'icon': <IconInfoCircle />,
           'aria-label': t('tiptap.tooltip.bubblemenu.information.pane.info'),
           'className':
             selectedNode?.attrs?.type === 'info' ? 'is-selected' : '',
@@ -52,7 +52,7 @@ const BubbleMenuEditInformationPane = ({
         name: 'success',
         props: {
           'size': 'lg',
-          'leftIcon': <IconSuccessOutline />,
+          'icon': <IconSuccessOutline />,
           'aria-label': t('tiptap.tooltip.bubblemenu.information.pane.success'),
           'className':
             selectedNode?.attrs?.type === 'success' ? 'is-selected' : '',
@@ -73,7 +73,7 @@ const BubbleMenuEditInformationPane = ({
         name: 'warning',
         props: {
           'size': 'lg',
-          'leftIcon': <IconAlertTriangle />,
+          'icon': <IconAlertTriangle />,
           'aria-label': t('tiptap.tooltip.bubblemenu.information.pane.warning'),
           'className':
             selectedNode?.attrs?.type === 'warning' ? 'is-selected' : '',
@@ -94,7 +94,7 @@ const BubbleMenuEditInformationPane = ({
         name: 'question',
         props: {
           'size': 'lg',
-          'leftIcon': <IconQuestion />,
+          'icon': <IconQuestion />,
           'aria-label': t(
             'tiptap.tooltip.bubblemenu.information.pane.question',
           ),


### PR DESCRIPTION
# Description

[Fix COCO-4232](https://edifice-community.atlassian.net/browse/COCO-4232), issue with the icon inside the bubble menu was not displayed.

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks
- [x] Editor

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
