### PR TITLE
fix(react): #COCO-4307 spacing on button icon

### DIFF
--- a/packages/react/src/components/Button/Button.tsx
+++ b/packages/react/src/components/Button/Button.tsx
@@ -91,7 +91,7 @@ const Button = forwardRef(
         [`btn-filled btn-${color}`]: variant === 'filled',
         [`btn-${variant}-${color}`]:
           variant === 'outline' || variant === 'ghost',
-        'btn-icon btn-sm': !children,
+        'btn-icon': !children,
         'btn-loading': isLoading,
         'btn-lg': size === 'lg',
         'btn-sm': size === 'sm',

--- a/packages/react/src/components/Button/IconButton.tsx
+++ b/packages/react/src/components/Button/IconButton.tsx
@@ -22,8 +22,9 @@ const IconButton = forwardRef(
     const buttonProps = {
       ...restProps,
       ...{
-        className: clsx('btn-icon btn-sm', className),
+        className: clsx('btn-icon', className),
       },
+      size: restProps.size || 'sm',
     };
 
     return <Button ref={ref} {...buttonProps} leftIcon={icon} />;

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -265,6 +265,7 @@ export const Toolbar = forwardRef(
                     key={item.name ?? index}
                     color={item.props.color || 'tertiary'}
                     variant="ghost"
+                    size={item.props.size || hideLabel ? 'sm' : 'md'}
                     tabIndex={index === firstFocusableItemIndex ? 0 : -1}
                     onKeyDown={handleKeyDown}
                   />


### PR DESCRIPTION
# Description

[COCO-4307](https://edifice-community.atlassian.net/browse/COCO-4307) Error with IconButton padding we are setting the size via `className` instead of using the `size` props

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


[COCO-4307]: https://edifice-community.atlassian.net/browse/COCO-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ