### PR TITLE
fix(react):#COCO-4320 fix empty userid in avatar url causing redirect…

### DIFF
--- a/packages/react/src/hooks/useDirectory/useDirectory.ts
+++ b/packages/react/src/hooks/useDirectory/useDirectory.ts
@@ -1,8 +1,11 @@
 import { ID, odeServices } from '@edifice.io/client';
 
 const useDirectory = () => {
-  function getAvatarURL(userId: ID, type: 'user' | 'group'): string {
-    if (userId === '') return '';
+  function getAvatarURL(
+    userId: ID,
+    type: 'user' | 'group',
+  ): string | undefined {
+    if (userId === '') return undefined;
     return odeServices.directory().getAvatarUrl(userId, type);
   }
 

--- a/packages/react/src/hooks/useDirectory/useDirectory.ts
+++ b/packages/react/src/hooks/useDirectory/useDirectory.ts
@@ -2,6 +2,7 @@ import { ID, odeServices } from '@edifice.io/client';
 
 const useDirectory = () => {
   function getAvatarURL(userId: ID, type: 'user' | 'group'): string {
+    if (userId === '') return '';
     return odeServices.directory().getAvatarUrl(userId, type);
   }
 


### PR DESCRIPTION


# Description
Sur la messagerie on constate une boucle de redirection causé par l'URL malformée : `https://oneconnect.edifice.io/userbook/avatar/?thumbnail=100x100` 

modification de la recuperation de l'url d'un avatar en retourner une chaine vide  `""` plutôt qu'une url inexistante causant une redirection. Cet url vide est ensuite remplacé par par le placeholder du composant `<Avatar>`
https://edifice-community.atlassian.net/browse/COCO-4320

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
