### PR TITLE
fix(react):#COCO-4152 use appname as module value for store event

### DIFF
--- a/packages/client/src/ts/data/Service.ts
+++ b/packages/client/src/ts/data/Service.ts
@@ -82,7 +82,7 @@ export class DataService implements IDataService {
   ) {
     const eventData = this.addUserInfos({
       'event-type': 'VIDEO_SAVE',
-      'module': 'video',
+      'module': this.app || 'video',
       video_id,
       browser,
       'duration': Math.round(duration),
@@ -90,7 +90,6 @@ export class DataService implements IDataService {
       'source': isCaptation ? 'CAPTURED' : 'UPLOADED',
       url,
     });
-    if (this.app) eventData['override-module'] = this.app;
     if (deviceType) eventData['device_type'] = deviceType;
 
     this.trackWebEvent(eventData);


### PR DESCRIPTION
# Description

use appname as module value for store event
Ticket : https://edifice-community.atlassian.net/browse/COCO-4152

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
