### PR TITLE
fix(multimedia): COCO-4479, allow user to select a camera after giving his consent to use them

### DIFF
--- a/packages/react/src/modules/multimedia/VideoRecorder/VideoRecorder.tsx
+++ b/packages/react/src/modules/multimedia/VideoRecorder/VideoRecorder.tsx
@@ -57,7 +57,7 @@ const VideoRecorder = forwardRef(
     }: VideoRecorderProps,
     ref,
   ) => {
-    const { inputDevices, setPreferedDevice, resetStream, stream } =
+    const { inputDevices, setPreferedDevice, restartStream, stream } =
       useCameras();
 
     const [maxDuration, setMaxDuration] = useState<number>(180000);
@@ -96,8 +96,12 @@ const VideoRecorder = forwardRef(
      * Get max duration from Conf.
      */
     async function initMaxDuration() {
-      const videoConfResponse = await odeServices.video().getVideoConf();
-      setMaxDuration((videoConfResponse.maxDuration ?? 3) * 60 * 1000);
+      try {
+        const videoConfResponse = await odeServices.video().getVideoConf();
+        setMaxDuration(videoConfResponse.maxDuration * 60 * 1000);
+      } catch {
+        setMaxDuration(3 * 60 * 1000);
+      }
     }
 
     useEffect(() => {
@@ -229,7 +233,7 @@ const VideoRecorder = forwardRef(
       setRecordedTime(0);
       setRecordedChunks([]);
       setRecordedVideo(undefined);
-      resetStream();
+      restartStream();
 
       if (onRecordUpdated) {
         onRecordUpdated();
@@ -275,7 +279,7 @@ const VideoRecorder = forwardRef(
           (inputDevice) => inputDevice.label === option,
         );
         // Stop any recording.
-        if (/*isStreaming && */ recorderRef.current?.state === 'recording') {
+        if (recorderRef.current?.state === 'recording') {
           recorderRef.current.requestData();
           recorderRef.current.stop();
         }

--- a/packages/react/src/modules/multimedia/VideoRecorder/VideoRecorder.tsx
+++ b/packages/react/src/modules/multimedia/VideoRecorder/VideoRecorder.tsx
@@ -57,13 +57,8 @@ const VideoRecorder = forwardRef(
     }: VideoRecorderProps,
     ref,
   ) => {
-    const {
-      inputDevices,
-      setPreferedDevice,
-      isStreaming,
-      startStreaming,
-      stream,
-    } = useCameras();
+    const { inputDevices, setPreferedDevice, resetStream, stream } =
+      useCameras();
 
     const [maxDuration, setMaxDuration] = useState<number>(180000);
 
@@ -234,7 +229,7 @@ const VideoRecorder = forwardRef(
       setRecordedTime(0);
       setRecordedChunks([]);
       setRecordedVideo(undefined);
-      startStreaming();
+      resetStream();
 
       if (onRecordUpdated) {
         onRecordUpdated();
@@ -279,16 +274,15 @@ const VideoRecorder = forwardRef(
         const selectedDevice = inputDevices.find(
           (inputDevice) => inputDevice.label === option,
         );
-        setPreferedDevice(selectedDevice);
-
         // Stop any recording.
-        if (isStreaming && recorderRef.current?.state === 'recording') {
+        if (/*isStreaming && */ recorderRef.current?.state === 'recording') {
           recorderRef.current.requestData();
           recorderRef.current.stop();
         }
-        startStreaming();
+
+        setPreferedDevice(selectedDevice);
       },
-      [inputDevices, isStreaming, startStreaming],
+      [inputDevices, stream],
     );
 
     /**

--- a/packages/react/src/modules/multimedia/VideoRecorder/VideoRecorder.tsx
+++ b/packages/react/src/modules/multimedia/VideoRecorder/VideoRecorder.tsx
@@ -17,20 +17,11 @@ import {
   LoadingScreen,
   OptionsType,
   Select,
-  Toolbar,
-  ToolbarItem,
 } from '../../../components';
 import { useUpload } from '../../../hooks';
-import {
-  IconPause,
-  IconPlayFilled,
-  IconRecord,
-  IconRecordStop,
-  IconRecordVideo,
-  IconRefresh,
-  IconSave,
-} from '../../icons/components';
+import { IconRecord, IconRecordVideo } from '../../icons/components';
 import { useCameras } from './useCameras';
+import { VideoRecorderToolbar } from './VideoRecorderToolbar';
 
 export interface VideoRecorderProps {
   appCode: string;
@@ -298,80 +289,6 @@ const VideoRecorder = forwardRef(
       }
     }, [recordedTime, handleStop]);
 
-    const toolbarItems: ToolbarItem[] = [
-      {
-        type: 'icon',
-        name: 'record',
-        props: {
-          'icon': <IconRecord color={recording || recorded ? '' : 'red'} />,
-          'color': 'danger',
-          'disabled': recording || recorded || saving,
-          'onClick': handleRecord,
-          'aria-label': t('bbm.video.record.start'),
-        },
-        tooltip: t('bbm.video.record.start'),
-      },
-      {
-        type: 'icon',
-        name: 'stop',
-        props: {
-          'icon': <IconRecordStop />,
-          'disabled': !recording || recorded || saving,
-          'onClick': handleStop,
-          'aria-label': t('bbm.video.record.stop'),
-        },
-        tooltip: t('bbm.video.record.stop'),
-      },
-      {
-        type: 'icon',
-        name: 'play',
-        visibility: !playing ? 'show' : 'hide',
-        props: {
-          'icon': <IconPlayFilled />,
-          'disabled': !recorded || saving,
-          'onClick': handlePlayPause,
-          'aria-label': t('bbm.video.play.start'),
-        },
-        tooltip: t('bbm.video.play.start'),
-      },
-      {
-        type: 'icon',
-        name: 'pause',
-        visibility: playing ? 'show' : 'hide',
-        props: {
-          'icon': <IconPause />,
-          'disabled': !recorded || saving,
-          'onClick': handlePlayPause,
-          'aria-label': t('bbm.video.play.pause'),
-        },
-        tooltip: t('bbm.video.play.pause'),
-      },
-      { type: 'divider' },
-      {
-        type: 'icon',
-        name: 'reset',
-        props: {
-          'icon': <IconRefresh />,
-          'disabled': !recorded || saving,
-          'onClick': handleReset,
-          'aria-label': t('bbm.video.record.reset'),
-        },
-        tooltip: t('bbm.video.record.reset'),
-      },
-      {
-        type: 'icon',
-        name: 'save',
-        visibility: hideSaveAction ? 'hide' : 'show',
-        props: {
-          'icon': <IconSave />,
-          'disabled': !recorded || saving || saved,
-          'onClick': handleSave,
-          'aria-label': t('bbm.video.record.save'),
-        },
-        tooltip: t('bbm.video.record.save'),
-      },
-    ];
-
     return (
       <div className="video-recorder d-flex flex-fill flex-column align-items-center pb-8">
         <div className="video-recorder-caption d-none d-md-block">
@@ -434,9 +351,20 @@ const VideoRecorder = forwardRef(
             </div>
           )}
           {stream && (
-            <Toolbar
-              items={toolbarItems}
-              className="position-absolute bottom-0 start-50 bg-white"
+            <VideoRecorderToolbar
+              {...{
+                playing,
+                recording,
+                recorded,
+                saving,
+                saved,
+                hideSaveAction,
+                handleRecord,
+                handleStop,
+                handlePlayPause,
+                handleReset,
+                handleSave,
+              }}
             />
           )}
         </div>

--- a/packages/react/src/modules/multimedia/VideoRecorder/VideoRecorderToolbar.tsx
+++ b/packages/react/src/modules/multimedia/VideoRecorder/VideoRecorderToolbar.tsx
@@ -1,0 +1,128 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+
+import { WorkspaceElement } from '@edifice.io/client';
+import { useTranslation } from 'react-i18next';
+import { Toolbar, ToolbarItem } from '../../../components';
+import {
+  IconPause,
+  IconPlayFilled,
+  IconRecord,
+  IconRecordStop,
+  IconRefresh,
+  IconSave,
+} from '../../icons/components';
+
+export interface VideoRecorderToolbarProps {
+  playing: boolean;
+  recording: boolean;
+  recorded: boolean;
+  saving: boolean;
+  saved: boolean;
+  hideSaveAction: boolean;
+  handleRecord: () => void;
+  handleStop: () => void;
+  handlePlayPause: () => void;
+  handleReset: () => void;
+  handleSave: () => void;
+}
+
+export interface VideoRecorderRef {
+  save: () => Promise<WorkspaceElement | undefined>;
+}
+
+export const VideoRecorderToolbar = ({
+  playing,
+  recording,
+  recorded,
+  saving,
+  saved,
+  hideSaveAction,
+  handleRecord,
+  handleStop,
+  handlePlayPause,
+  handleReset,
+  handleSave,
+}: VideoRecorderToolbarProps) => {
+  const { t } = useTranslation();
+
+  const toolbarItems: ToolbarItem[] = [
+    {
+      type: 'icon',
+      name: 'record',
+      props: {
+        'icon': <IconRecord color={recording || recorded ? '' : 'red'} />,
+        'color': 'danger',
+        'disabled': recording || recorded || saving,
+        'onClick': handleRecord,
+        'aria-label': t('bbm.video.record.start'),
+      },
+      tooltip: t('bbm.video.record.start'),
+    },
+    {
+      type: 'icon',
+      name: 'stop',
+      props: {
+        'icon': <IconRecordStop />,
+        'disabled': !recording || recorded || saving,
+        'onClick': handleStop,
+        'aria-label': t('bbm.video.record.stop'),
+      },
+      tooltip: t('bbm.video.record.stop'),
+    },
+    {
+      type: 'icon',
+      name: 'play',
+      visibility: !playing ? 'show' : 'hide',
+      props: {
+        'icon': <IconPlayFilled />,
+        'disabled': !recorded || saving,
+        'onClick': handlePlayPause,
+        'aria-label': t('bbm.video.play.start'),
+      },
+      tooltip: t('bbm.video.play.start'),
+    },
+    {
+      type: 'icon',
+      name: 'pause',
+      visibility: playing ? 'show' : 'hide',
+      props: {
+        'icon': <IconPause />,
+        'disabled': !recorded || saving,
+        'onClick': handlePlayPause,
+        'aria-label': t('bbm.video.play.pause'),
+      },
+      tooltip: t('bbm.video.play.pause'),
+    },
+    { type: 'divider' },
+    {
+      type: 'icon',
+      name: 'reset',
+      props: {
+        'icon': <IconRefresh />,
+        'disabled': !recorded || saving,
+        'onClick': handleReset,
+        'aria-label': t('bbm.video.record.reset'),
+      },
+      tooltip: t('bbm.video.record.reset'),
+    },
+    {
+      type: 'icon',
+      name: 'save',
+      visibility: hideSaveAction ? 'hide' : 'show',
+      props: {
+        'icon': <IconSave />,
+        'disabled': !recorded || saving || saved,
+        'onClick': handleSave,
+        'aria-label': t('bbm.video.record.save'),
+      },
+      tooltip: t('bbm.video.record.save'),
+    },
+  ];
+
+  return (
+    <Toolbar
+      items={toolbarItems}
+      className="position-absolute bottom-0 start-50 bg-white"
+    />
+  );
+};

--- a/packages/react/src/modules/multimedia/VideoRecorder/useCameras.ts
+++ b/packages/react/src/modules/multimedia/VideoRecorder/useCameras.ts
@@ -1,0 +1,159 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+import { useEffect, useState } from 'react';
+
+import { useTranslation } from 'react-i18next';
+import { useBrowserInfo } from '../../../hooks';
+
+const VIDEO_HEIGHT = 9;
+const VIDEO_WIDTH = 16;
+
+export function useCameras() {
+  const { device } = useBrowserInfo(navigator.userAgent);
+  const { t } = useTranslation();
+
+  // List of available cameras.
+  const [inputDevices, setInputDevices] = useState<MediaDeviceInfo[]>([]);
+
+  // Constraints used to select which camera to use.
+  const [mediaStreamConstraints, setMediaStreamConstraints] =
+    useState<MediaStreamConstraints>({
+      audio: true,
+      video: {
+        facingMode: 'environment',
+        aspectRatio: VIDEO_WIDTH / VIDEO_HEIGHT,
+      },
+    });
+
+  // Video stream from the prefered camera. Need to be started by calling `startStreaming()`.
+  const [stream, setStream] = useState<MediaStream>();
+
+  useEffect(() => {
+    initInputDevices();
+  }, []);
+
+  // Enable video stream and stop streaming on clean up.
+  useEffect(() => {
+    if (!stream) {
+      startStreaming();
+    }
+    return () => {
+      if (stream) {
+        stream.getTracks().forEach((track) => track.stop());
+      }
+    };
+  }, [stream, inputDevices, mediaStreamConstraints]);
+
+  /** Detect available cameras. */
+  async function getVideoInputDevices(): Promise<MediaDeviceInfo[]> {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.filter((device) => device.kind === 'videoinput');
+  }
+
+  /** Initialize the inputDevices state. */
+  async function initInputDevices() {
+    const videoDevices = await getVideoInputDevices();
+    // Possible type: console, mobile, tablet, smarttv, wearable, embedded
+    switch (device.type) {
+      case 'mobile':
+      case 'tablet': {
+        const backCamera = {
+          deviceId: 'environment',
+          label: t('video.back.camera'),
+          groupId: '',
+          kind: 'videoinput',
+        } as MediaDeviceInfo;
+        const frontCamera = {
+          deviceId: 'user',
+          label: t('video.front.camera'),
+          groupId: '',
+          kind: 'videoinput',
+        } as MediaDeviceInfo;
+
+        if (videoDevices?.length > 1) {
+          // mobile/tablet has more than 1 camera
+          setInputDevices([backCamera, frontCamera]);
+        } else {
+          // else we let the system use the only one that exists (or none)
+          setInputDevices([backCamera]);
+        }
+        break;
+      }
+      default:
+        // "Desktop" or other future types => list all cameras without distinction.
+        setInputDevices(videoDevices);
+        break;
+    }
+  }
+
+  /**
+   * Try enable a stream with the selected constraints.
+   * The navigator may ask the user permission of using it.
+   */
+  const enableStream = async (
+    mediaStreamConstraints: MediaStreamConstraints,
+  ) => {
+    try {
+      const mediaStream: MediaStream =
+        await navigator.mediaDevices.getUserMedia(mediaStreamConstraints);
+      setStream(mediaStream);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  function setPreferedDevice(device?: MediaDeviceInfo) {
+    let mediaStreamConstraints: MediaStreamConstraints = {};
+    if (device?.deviceId) {
+      if (device?.deviceId === 'environment' || device?.deviceId === 'user') {
+        mediaStreamConstraints = {
+          audio: true,
+          video: {
+            aspectRatio: VIDEO_WIDTH / VIDEO_HEIGHT,
+            facingMode: device?.deviceId,
+          },
+        };
+      } else {
+        mediaStreamConstraints = {
+          audio: true,
+          video: {
+            aspectRatio: VIDEO_WIDTH / VIDEO_HEIGHT,
+            deviceId: device.deviceId,
+          },
+        };
+      }
+      setMediaStreamConstraints(mediaStreamConstraints);
+    } else {
+      console.error('Selected input device id is null');
+    }
+  }
+
+  const isStreaming = typeof stream !== 'undefined';
+
+  function startStreaming() {
+    console.log('startStreaming');
+    stopStreaming();
+    enableStream(mediaStreamConstraints);
+  }
+
+  function stopStreaming() {
+    if (isStreaming) {
+      stream.getTracks().forEach((track) => track.stop());
+      setStream(undefined);
+    }
+  }
+
+  return {
+    /** Readonly list (array) of available video input devices. */
+    inputDevices,
+    /** Select which input video device to use. */
+    setPreferedDevice,
+    /** Check if selected device is already streaming. */
+    isStreaming,
+    /** Start a video stream from the selected device. */
+    startStreaming,
+    /** The started streaming video. */
+    stream,
+    /** Stop the video stream. */
+    stopStreaming,
+  };
+}

--- a/packages/react/src/modules/multimedia/VideoRecorder/useCameras.ts
+++ b/packages/react/src/modules/multimedia/VideoRecorder/useCameras.ts
@@ -34,13 +34,14 @@ export function useCameras() {
   }
 
   /**
-   * Try enable a stream with the selected constraints.
+   * Try enabling a stream with the selected constraints.
    * The navigator may ask the user permission of using it.
    */
   async function enableStream(mediaStreamConstraints: MediaStreamConstraints) {
     try {
       const mediaStream: MediaStream =
         await navigator.mediaDevices.getUserMedia(mediaStreamConstraints);
+
       setStream((previousStream) => {
         previousStream?.getTracks().forEach((track) => track.stop());
         return mediaStream;


### PR DESCRIPTION
# Description

* Refactor VideoRecorder code => broke it into a hook + a dedicated toolbar component
* Fix a bug : on devices with many cameras, the camera selector was not showing up if the device was asking for user user consent (a promise was resolved, but without updating the UI)
* Optimize rendering

https://edifice-community.atlassian.net/browse/COCO-4479

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks
- [X] Multimedia

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
