### PR TITLE
feat(client): #COCO-4719, do not use BroadcastChannel in client

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lint": "turbo run lint --filter=./packages/**",
     "pre-commit": "pnpm run lint && pnpm run format && pnpm run test",
     "prepare": "husky install",
-    "test": "turbo run test --filter=./packages/react"
+    "test": "turbo run test --filter=./packages/react",
+    "test:client": "turbo run test --filter=./packages/client"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^3.2.0",

--- a/packages/client/src/ts/data/WebBroker.ts
+++ b/packages/client/src/ts/data/WebBroker.ts
@@ -1,10 +1,10 @@
-import { DataServiceProps, IEventBroker, SEND_ALL } from './interface';
 import {
-  ISubscription,
   IDataTrackEvent,
+  ISubscription,
   LAYER_NAME,
 } from '../notify/interfaces';
 import { IOdeServices } from '../services/OdeServices';
+import { DataServiceProps, IEventBroker, SEND_ALL } from './interface';
 
 export class WebBroker implements IEventBroker {
   private subscription?: ISubscription;
@@ -15,7 +15,7 @@ export class WebBroker implements IEventBroker {
     return this.odeServices.http();
   }
   private get events() {
-    return this.odeServices.notify().events();
+    return this.odeServices.notify().events<IDataTrackEvent>();
   }
 
   private dispatchEvent(

--- a/packages/client/src/ts/notify/Framework.ts
+++ b/packages/client/src/ts/notify/Framework.ts
@@ -1,7 +1,12 @@
 import { IGetConf, ITheme, IThemeOverrides } from '../configure/interfaces';
 import { IUserInfo } from '../session/interfaces';
 import { Subject } from './Subject';
-import { IPromisified, INotifyFramework } from './interfaces';
+import {
+  INotifyFramework,
+  IPromisified,
+  ISubject,
+  ISubjectMessage,
+} from './interfaces';
 
 type PromiseRegistry = { [name: string]: Promisified<any> };
 
@@ -39,14 +44,14 @@ export class Promisified<T> implements IPromisified<T> {
 class NotifyFramework implements INotifyFramework {
   //-------------------------------------
   private promises: PromiseRegistry = {};
-  private subject: Subject = new Subject();
+  private subject = new Subject<ISubjectMessage>();
 
-  private asyncData<T>(asyncDataName: string): Promisified<T> {
+  private asyncData<U>(asyncDataName: string): Promisified<U> {
     if (typeof this.promises[asyncDataName] === 'undefined') {
       this.promises[asyncDataName] =
-        new Promisified<T>() as unknown as Promisified<any>;
+        new Promisified<U>() as unknown as Promisified<any>;
     }
-    return this.promises[asyncDataName] as unknown as Promisified<T>;
+    return this.promises[asyncDataName] as unknown as Promisified<U>;
   }
 
   public onSessionReady(): IPromisified<IUserInfo> {
@@ -73,10 +78,10 @@ class NotifyFramework implements INotifyFramework {
     return new Promisified<T>();
   }
 
-  public events(): Subject {
-    return this.subject;
+  public events<T extends ISubjectMessage>(): ISubject<T> {
+    return this.subject as unknown as ISubject<T>;
   }
 }
 
 /** The whole framework is a singleton. */
-export const notify: NotifyFramework = new NotifyFramework();
+export const notify = new NotifyFramework();

--- a/packages/client/src/ts/notify/Observable.ts
+++ b/packages/client/src/ts/notify/Observable.ts
@@ -1,0 +1,28 @@
+import { ISubscription } from './interfaces';
+
+type MessageHandler<T> = (message: T) => void;
+
+export class Observable<T> {
+  private listeners: Array<MessageHandler<T>> = [];
+
+  private revokeHandler(handler: MessageHandler<T>) {
+    this.listeners = this.listeners.filter((fn) => fn !== handler);
+  }
+
+  public addEventListener(handler: MessageHandler<T>): ISubscription {
+    this.listeners.push(handler);
+    return {
+      revoke: () => {
+        this.revokeHandler(handler);
+      },
+    } as ISubscription;
+  }
+
+  public postMessage(message: T) {
+    this.listeners.forEach((fn) => fn(message));
+  }
+
+  public get subscriberCount() {
+    return this.listeners.length;
+  }
+}

--- a/packages/client/src/ts/notify/Observable.ts
+++ b/packages/client/src/ts/notify/Observable.ts
@@ -15,7 +15,7 @@ export class Observable<T> {
       revoke: () => {
         this.revokeHandler(handler);
       },
-    } as ISubscription;
+    };
   }
 
   public postMessage(message: T) {

--- a/packages/client/src/ts/notify/Subject.spec.ts
+++ b/packages/client/src/ts/notify/Subject.spec.ts
@@ -1,0 +1,35 @@
+import { EVENT_NAME, IHttpErrorEvent, LAYER_NAME } from './interfaces';
+import { Subject } from './Subject';
+
+describe('Subject', () => {
+  const subject: Subject<IHttpErrorEvent> = new Subject();
+
+  const mockedHttpError: IHttpErrorEvent = {
+    name: EVENT_NAME.ERROR_OCCURED,
+    data: { response: { status: 404, statusText: 'Not found' } },
+  };
+
+  it('should revoke subscriptions correctly', () => {
+    const subscription = subject.subscribe(LAYER_NAME.TRANSPORT, () => {});
+    expect(subject.getSubscriberCountFor(LAYER_NAME.TRANSPORT)).toStrictEqual(
+      1,
+    );
+    subscription.revoke();
+    expect(subject.getSubscriberCountFor(LAYER_NAME.TRANSPORT)).toStrictEqual(
+      0,
+    );
+  });
+
+  it('should observe HTTP error events correctly', () => {
+    let observedHttpError: IHttpErrorEvent | undefined = undefined;
+
+    const subscription = subject.subscribe(LAYER_NAME.TRANSPORT, (message) => {
+      observedHttpError = message;
+    });
+    subject.publish(LAYER_NAME.TRANSPORT, mockedHttpError);
+
+    expect(observedHttpError).toStrictEqual(mockedHttpError);
+
+    subscription.revoke();
+  });
+});

--- a/packages/client/src/ts/notify/interfaces.ts
+++ b/packages/client/src/ts/notify/interfaces.ts
@@ -1,7 +1,7 @@
 import { IGetConf, ITheme, IThemeOverrides } from '../configure/interfaces';
 import { IUserInfo } from '../session/interfaces';
-import { notify } from './Framework';
 import { IHttpParams, IHttpResponse } from '../transport/interfaces';
+import { notify } from './Framework';
 
 //-------------------------------------
 export abstract class NotifyFrameworkFactory {
@@ -57,7 +57,7 @@ export interface INotifyFramework {
    * By definition, an event can occur multiple times (otherwise it is a one-time "process", see above) and be watched by many targets.
    * => We model it as a subject with many potential subscribers.
    */
-  events(): ISubject;
+  events<T extends ISubjectMessage>(): ISubject<T>;
 }
 
 //-------------------------------------
@@ -101,14 +101,14 @@ export interface ISubscription {
 }
 /** Generic typing of a subject. */
 //-------------------------------------
-export interface ISubject {
+export interface ISubject<T extends ISubjectMessage> {
   subscribe(
     layer: Omit<LayerName, TransportLayer | WebDataLayer>,
-    handler: <T extends ISubjectMessage>(message: T) => void,
+    handler: (message: T) => void,
   ): ISubscription;
   publish(
     layer: Omit<LayerName, TransportLayer | WebDataLayer>,
-    message: ISubjectMessage,
+    message: T,
   ): void;
 }
 
@@ -122,15 +122,6 @@ export interface IHttpErrorEvent extends ISubjectMessage {
     payload?: any;
   };
 }
-/** Overloaded typing of a subject, dedicated to transport errors. */
-//-------------------------------------
-export declare interface ISubject {
-  publish(layer: TransportLayer, message: IHttpErrorEvent): void;
-  subscribe(
-    layer: TransportLayer,
-    handler: (message: IHttpErrorEvent) => void,
-  ): ISubscription;
-}
 
 /** Typing of tracked events on a DATA layer. */
 //-------------------------------------
@@ -142,13 +133,4 @@ export interface IDataTrackEvent extends ISubjectMessage {
     'userId'?: string;
     [key: string]: any;
   };
-}
-/** Overloaded typing of a subject, dedicated to tracking web data events. */
-//-------------------------------------
-export declare interface ISubject {
-  publish(layer: WebDataLayer, message: IDataTrackEvent): void;
-  subscribe(
-    layer: WebDataLayer,
-    handler: (message: IDataTrackEvent) => void,
-  ): ISubscription;
 }

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ESNext",
     "useDefineForClassFields": true,
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext"],
     "moduleResolution": "Node",
     "strict": true,
     "resolveJsonModule": true,

--- a/packages/react/src/hooks/useHttpErrorToast/useHttpErrorToast.ts
+++ b/packages/react/src/hooks/useHttpErrorToast/useHttpErrorToast.ts
@@ -6,39 +6,45 @@ import { useTranslation } from 'react-i18next';
 import { useToast } from '../..';
 import { CustomToastOptions } from '../../hooks/useToast/useToast';
 
-const useHttpErrorToast = (options?: CustomToastOptions) => {
+export const useHttpErrorToast = ({
+  active = true,
+  ...options
+}: {
+  active?: boolean;
+} & CustomToastOptions) => {
   const message = useRef<string>();
   const toast = useToast();
   const { t } = useTranslation();
 
   useEffect(() => {
-    const subscription = odeServices
-      .notify()
-      .events()
-      .subscribe(LAYER_NAME.TRANSPORT, (event) => {
-        if (!event?.data) return;
-        const { response } = event.data;
-        const i18nKey =
-          // The payload may include the i18n key of the error message to show,
-          event.data.payload?.error ||
-          // otherwise, try showing the translation of some known HTTP error code.
-          ([400, 401, 403, 404, 408, 413, 500, 504].includes(response?.status)
-            ? `e${event.data.response.status}`
-            : undefined) ||
-          // otherwise try showing the statusText (may be technical, in english),
-          response?.statusText;
-        // Do not display empty toasts
-        if (typeof i18nKey !== 'string') return;
-        message.current = t(i18nKey);
-        toast.error(
-          React.createElement('div', { children: [message.current] }),
-          options,
-        );
-      });
+    if (active) {
+      const subscription = odeServices
+        .notify()
+        .events()
+        .subscribe(LAYER_NAME.TRANSPORT, (event) => {
+          if (!event?.data) return;
+          const { response } = event.data;
+          const i18nKey =
+            // The payload may include the i18n key of the error message to show,
+            event.data.payload?.error ||
+            // otherwise, try showing the translation of some known HTTP error code.
+            ([400, 401, 403, 404, 408, 413, 500, 504].includes(response?.status)
+              ? `e${event.data.response.status}`
+              : undefined) ||
+            // otherwise try showing the statusText (may be technical, in english),
+            response?.statusText;
+          // Do not display empty toasts
+          if (typeof i18nKey !== 'string') return;
+          message.current = t(i18nKey);
+          toast.error(
+            React.createElement('div', { children: [message.current] }),
+            options,
+          );
+        });
 
-    return () => subscription.revoke();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [t, toast]);
+      return () => subscription.revoke();
+    }
+  }, [t, toast, active]);
 
   return message.current;
 };

--- a/packages/react/src/hooks/useHttpErrorToast/useHttpErrorToast.ts
+++ b/packages/react/src/hooks/useHttpErrorToast/useHttpErrorToast.ts
@@ -18,6 +18,7 @@ export const useHttpErrorToast = ({
 
   useEffect(() => {
     if (active) {
+      // Subscribe to HTTP error events
       const subscription = odeServices
         .notify()
         .events()
@@ -42,7 +43,10 @@ export const useHttpErrorToast = ({
           );
         });
 
+      // return cleaning function
       return () => subscription.revoke();
+    } else {
+      // Do nothing => no cleaning function to return
     }
   }, [t, toast, active]);
 

--- a/packages/react/src/modules/multimedia/MediaLibrary/MediaLibrary.tsx
+++ b/packages/react/src/modules/multimedia/MediaLibrary/MediaLibrary.tsx
@@ -219,9 +219,6 @@ const MediaLibrary = forwardRef(
       ...refModal.current,
     }));
 
-    // HTTP errors toasts
-    useHttpErrorToast({ isDismissible: true, duration: Infinity });
-
     const { t } = useTranslation();
 
     const workspaceCreateWorkflow = useHasWorkflow(
@@ -232,6 +229,13 @@ const MediaLibrary = forwardRef(
     );
 
     const [type, setType] = useState<MediaLibraryType | null>(null);
+
+    // HTTP errors toasts
+    useHttpErrorToast({
+      active: !!type,
+      isDismissible: true,
+      duration: Infinity,
+    });
 
     const availableTabs: {
       [tabname in AvailableTab]: TabsItemProps & MediaLibraryTabProps;


### PR DESCRIPTION
# Description

Un problème survient lorsqu’un éditeur riche (par exemple, dans la messagerie) est ouvert dans un onglet, et qu’une erreur HTTP 401 se produit dans un second onglet du navigateur utilisant le framework.

En effet, MediaLibrary utilise un [hook générique afin de capter toutes les erreurs HTTP](https://github.com/edificeio/edifice-frontend-framework/blob/7db2a9ccf92b9a8364eec3cd322ee93ebf988635/packages/react/src/modules/multimedia/MediaLibrary/MediaLibrary.tsx#L223) pouvant se produire lors de l’utilisation du service “transport”.

Cette PR vise à : 
* abandonner l'usage des `BroadcastChannel` dans le package client, qui doit rester indépendant du DOM.
* ajouter une propriété `active` au hook `useHttpErrorToast` permettant d’activer ou non le toaster.


## Which Package changed?

Please check the name of the package you changed

- [X] Client
- [ ] Components
- [ ] Core
- [ ] Icons
- [X] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [X] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
