### PR TITLE
Adds UserRightsList component with bookmark support

### DIFF
--- a/apps/docs/public/mockServiceWorker.js
+++ b/apps/docs/public/mockServiceWorker.js
@@ -5,24 +5,23 @@
  * Mock Service Worker.
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
- * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.6.8';
-const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f';
+const PACKAGE_VERSION = '2.12.13';
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82';
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
 const activeClientIds = new Set();
 
-self.addEventListener('install', function () {
+addEventListener('install', function () {
   self.skipWaiting();
 });
 
-self.addEventListener('activate', function (event) {
+addEventListener('activate', function (event) {
   event.waitUntil(self.clients.claim());
 });
 
-self.addEventListener('message', async function (event) {
-  const clientId = event.source.id;
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id');
 
   if (!clientId || !self.clients) {
     return;
@@ -72,11 +71,6 @@ self.addEventListener('message', async function (event) {
       break;
     }
 
-    case 'MOCK_DEACTIVATE': {
-      activeClientIds.delete(clientId);
-      break;
-    }
-
     case 'CLIENT_CLOSED': {
       activeClientIds.delete(clientId);
 
@@ -94,69 +88,92 @@ self.addEventListener('message', async function (event) {
   }
 });
 
-self.addEventListener('fetch', function (event) {
-  const { request } = event;
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now();
 
   // Bypass navigation requests.
-  if (request.mode === 'navigate') {
+  if (event.request.mode === 'navigate') {
     return;
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
   // that cannot be handled by the worker. Bypass such requests.
-  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
     return;
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
-  // after it's been deleted (still remains active until the next reload).
+  // after it's been terminated (still remains active until the next reload).
   if (activeClientIds.size === 0) {
     return;
   }
 
-  // Generate unique request ID.
   const requestId = crypto.randomUUID();
-  event.respondWith(handleRequest(event, requestId));
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt));
 });
 
-async function handleRequest(event, requestId) {
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
   const client = await resolveMainClient(event);
-  const response = await getResponse(event, client, requestId);
+  const requestCloneForEvents = event.request.clone();
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  );
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    (async function () {
-      const responseClone = response.clone();
+    const serializedRequest = await serializeRequest(requestCloneForEvents);
 
-      sendToClient(
-        client,
-        {
-          type: 'RESPONSE',
-          payload: {
-            requestId,
-            isMockedResponse: IS_MOCKED_RESPONSE in response,
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone();
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
             type: responseClone.type,
             status: responseClone.status,
             statusText: responseClone.statusText,
-            body: responseClone.body,
             headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
           },
         },
-        [responseClone.body],
-      );
-    })();
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    );
   }
 
   return response;
 }
 
-// Resolve the main client for the given event.
-// Client that issues a request doesn't necessarily equal the client
-// that registered the worker. It's with the latter the worker should
-// communicate with during the response resolving phase.
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
 async function resolveMainClient(event) {
   const client = await self.clients.get(event.clientId);
 
@@ -184,12 +201,17 @@ async function resolveMainClient(event) {
     });
 }
 
-async function getResponse(event, client, requestId) {
-  const { request } = event;
-
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = request.clone();
+  const requestClone = event.request.clone();
 
   function passthrough() {
     // Cast the request headers to a new Headers instance
@@ -230,29 +252,18 @@ async function getResponse(event, client, requestId) {
   }
 
   // Notify the client that a request has been intercepted.
-  const requestBuffer = await request.arrayBuffer();
+  const serializedRequest = await serializeRequest(event.request);
   const clientMessage = await sendToClient(
     client,
     {
       type: 'REQUEST',
       payload: {
         id: requestId,
-        url: request.url,
-        mode: request.mode,
-        method: request.method,
-        headers: Object.fromEntries(request.headers.entries()),
-        cache: request.cache,
-        credentials: request.credentials,
-        destination: request.destination,
-        integrity: request.integrity,
-        redirect: request.redirect,
-        referrer: request.referrer,
-        referrerPolicy: request.referrerPolicy,
-        body: requestBuffer,
-        keepalive: request.keepalive,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
       },
     },
-    [requestBuffer],
+    [serializedRequest.body],
   );
 
   switch (clientMessage.type) {
@@ -268,6 +279,12 @@ async function getResponse(event, client, requestId) {
   return passthrough();
 }
 
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
     const channel = new MessageChannel();
@@ -280,14 +297,18 @@ function sendToClient(client, message, transferrables = []) {
       resolve(event.data);
     };
 
-    client.postMessage(
-      message,
-      [channel.port2].concat(transferrables.filter(Boolean)),
-    );
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ]);
   });
 }
 
-async function respondWithMock(response) {
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
   // Setting response status code to 0 is a no-op.
   // However, when responding with a "Response.error()", the produced Response
   // instance will have status code set to 0. Since it's not possible to create
@@ -304,4 +325,25 @@ async function respondWithMock(response) {
   });
 
   return mockedResponse;
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  };
 }

--- a/apps/docs/public/mockServiceWorker.js
+++ b/apps/docs/public/mockServiceWorker.js
@@ -7,42 +7,42 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.12.13';
-const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82';
-const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
-const activeClientIds = new Set();
+const PACKAGE_VERSION = '2.12.14'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
 
 addEventListener('install', function () {
-  self.skipWaiting();
-});
+  self.skipWaiting()
+})
 
 addEventListener('activate', function (event) {
-  event.waitUntil(self.clients.claim());
-});
+  event.waitUntil(self.clients.claim())
+})
 
 addEventListener('message', async function (event) {
-  const clientId = Reflect.get(event.source || {}, 'id');
+  const clientId = Reflect.get(event.source || {}, 'id')
 
   if (!clientId || !self.clients) {
-    return;
+    return
   }
 
-  const client = await self.clients.get(clientId);
+  const client = await self.clients.get(clientId)
 
   if (!client) {
-    return;
+    return
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   switch (event.data) {
     case 'KEEPALIVE_REQUEST': {
       sendToClient(client, {
         type: 'KEEPALIVE_RESPONSE',
-      });
-      break;
+      })
+      break
     }
 
     case 'INTEGRITY_CHECK_REQUEST': {
@@ -52,12 +52,12 @@ addEventListener('message', async function (event) {
           packageVersion: PACKAGE_VERSION,
           checksum: INTEGRITY_CHECKSUM,
         },
-      });
-      break;
+      })
+      break
     }
 
     case 'MOCK_ACTIVATE': {
-      activeClientIds.add(clientId);
+      activeClientIds.add(clientId)
 
       sendToClient(client, {
         type: 'MOCKING_ENABLED',
@@ -67,33 +67,33 @@ addEventListener('message', async function (event) {
             frameType: client.frameType,
           },
         },
-      });
-      break;
+      })
+      break
     }
 
     case 'CLIENT_CLOSED': {
-      activeClientIds.delete(clientId);
+      activeClientIds.delete(clientId)
 
       const remainingClients = allClients.filter((client) => {
-        return client.id !== clientId;
-      });
+        return client.id !== clientId
+      })
 
       // Unregister itself when there are no more clients
       if (remainingClients.length === 0) {
-        self.registration.unregister();
+        self.registration.unregister()
       }
 
-      break;
+      break
     }
   }
-});
+})
 
 addEventListener('fetch', function (event) {
-  const requestInterceptedAt = Date.now();
+  const requestInterceptedAt = Date.now()
 
   // Bypass navigation requests.
   if (event.request.mode === 'navigate') {
-    return;
+    return
   }
 
   // Opening the DevTools triggers the "only-if-cached" request
@@ -102,19 +102,19 @@ addEventListener('fetch', function (event) {
     event.request.cache === 'only-if-cached' &&
     event.request.mode !== 'same-origin'
   ) {
-    return;
+    return
   }
 
   // Bypass all requests when there are no active clients.
   // Prevents the self-unregistered worked from handling requests
   // after it's been terminated (still remains active until the next reload).
   if (activeClientIds.size === 0) {
-    return;
+    return
   }
 
-  const requestId = crypto.randomUUID();
-  event.respondWith(handleRequest(event, requestId, requestInterceptedAt));
-});
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
 
 /**
  * @param {FetchEvent} event
@@ -122,23 +122,23 @@ addEventListener('fetch', function (event) {
  * @param {number} requestInterceptedAt
  */
 async function handleRequest(event, requestId, requestInterceptedAt) {
-  const client = await resolveMainClient(event);
-  const requestCloneForEvents = event.request.clone();
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
   const response = await getResponse(
     event,
     client,
     requestId,
     requestInterceptedAt,
-  );
+  )
 
   // Send back the response clone for the "response:*" life-cycle events.
   // Ensure MSW is active and ready to handle the message, otherwise
   // this message will pend indefinitely.
   if (client && activeClientIds.has(client.id)) {
-    const serializedRequest = await serializeRequest(requestCloneForEvents);
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
 
     // Clone the response so both the client and the library could consume it.
-    const responseClone = response.clone();
+    const responseClone = response.clone()
 
     sendToClient(
       client,
@@ -160,10 +160,10 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
         },
       },
       responseClone.body ? [serializedRequest.body, responseClone.body] : [],
-    );
+    )
   }
 
-  return response;
+  return response
 }
 
 /**
@@ -175,30 +175,30 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
  * @returns {Promise<Client | undefined>}
  */
 async function resolveMainClient(event) {
-  const client = await self.clients.get(event.clientId);
+  const client = await self.clients.get(event.clientId)
 
   if (activeClientIds.has(event.clientId)) {
-    return client;
+    return client
   }
 
   if (client?.frameType === 'top-level') {
-    return client;
+    return client
   }
 
   const allClients = await self.clients.matchAll({
     type: 'window',
-  });
+  })
 
   return allClients
     .filter((client) => {
       // Get only those clients that are currently visible.
-      return client.visibilityState === 'visible';
+      return client.visibilityState === 'visible'
     })
     .find((client) => {
       // Find the client ID that's recorded in the
       // set of clients that have registered the worker.
-      return activeClientIds.has(client.id);
-    });
+      return activeClientIds.has(client.id)
+    })
 }
 
 /**
@@ -211,36 +211,36 @@ async function resolveMainClient(event) {
 async function getResponse(event, client, requestId, requestInterceptedAt) {
   // Clone the request because it might've been already used
   // (i.e. its body has been read and sent to the client).
-  const requestClone = event.request.clone();
+  const requestClone = event.request.clone()
 
   function passthrough() {
     // Cast the request headers to a new Headers instance
     // so the headers can be manipulated with.
-    const headers = new Headers(requestClone.headers);
+    const headers = new Headers(requestClone.headers)
 
     // Remove the "accept" header value that marked this request as passthrough.
     // This prevents request alteration and also keeps it compliant with the
     // user-defined CORS policies.
-    const acceptHeader = headers.get('accept');
+    const acceptHeader = headers.get('accept')
     if (acceptHeader) {
-      const values = acceptHeader.split(',').map((value) => value.trim());
+      const values = acceptHeader.split(',').map((value) => value.trim())
       const filteredValues = values.filter(
         (value) => value !== 'msw/passthrough',
-      );
+      )
 
       if (filteredValues.length > 0) {
-        headers.set('accept', filteredValues.join(', '));
+        headers.set('accept', filteredValues.join(', '))
       } else {
-        headers.delete('accept');
+        headers.delete('accept')
       }
     }
 
-    return fetch(requestClone, { headers });
+    return fetch(requestClone, { headers })
   }
 
   // Bypass mocking when the client is not active.
   if (!client) {
-    return passthrough();
+    return passthrough()
   }
 
   // Bypass initial page load requests (i.e. static assets).
@@ -248,11 +248,11 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
   // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
   // and is not ready to handle requests.
   if (!activeClientIds.has(client.id)) {
-    return passthrough();
+    return passthrough()
   }
 
   // Notify the client that a request has been intercepted.
-  const serializedRequest = await serializeRequest(event.request);
+  const serializedRequest = await serializeRequest(event.request)
   const clientMessage = await sendToClient(
     client,
     {
@@ -264,19 +264,19 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
       },
     },
     [serializedRequest.body],
-  );
+  )
 
   switch (clientMessage.type) {
     case 'MOCK_RESPONSE': {
-      return respondWithMock(clientMessage.data);
+      return respondWithMock(clientMessage.data)
     }
 
     case 'PASSTHROUGH': {
-      return passthrough();
+      return passthrough()
     }
   }
 
-  return passthrough();
+  return passthrough()
 }
 
 /**
@@ -287,21 +287,21 @@ async function getResponse(event, client, requestId, requestInterceptedAt) {
  */
 function sendToClient(client, message, transferrables = []) {
   return new Promise((resolve, reject) => {
-    const channel = new MessageChannel();
+    const channel = new MessageChannel()
 
     channel.port1.onmessage = (event) => {
       if (event.data && event.data.error) {
-        return reject(event.data.error);
+        return reject(event.data.error)
       }
 
-      resolve(event.data);
-    };
+      resolve(event.data)
+    }
 
     client.postMessage(message, [
       channel.port2,
       ...transferrables.filter(Boolean),
-    ]);
-  });
+    ])
+  })
 }
 
 /**
@@ -314,17 +314,17 @@ function respondWithMock(response) {
   // instance will have status code set to 0. Since it's not possible to create
   // a Response instance with status code 0, handle that use-case separately.
   if (response.status === 0) {
-    return Response.error();
+    return Response.error()
   }
 
-  const mockedResponse = new Response(response.body, response);
+  const mockedResponse = new Response(response.body, response)
 
   Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
     value: true,
     enumerable: true,
-  });
+  })
 
-  return mockedResponse;
+  return mockedResponse
 }
 
 /**
@@ -345,5 +345,5 @@ async function serializeRequest(request) {
     referrerPolicy: request.referrerPolicy,
     body: await request.arrayBuffer(),
     keepalive: request.keepalive,
-  };
+  }
 }

--- a/package.json
+++ b/package.json
@@ -85,5 +85,10 @@
   "packageManager": "pnpm@9.12.2",
   "engines": {
     "node": "20 || 22"
+  },
+  "msw": {
+    "workerDirectory": [
+      "apps/docs/public"
+    ]
   }
 }

--- a/packages/bootstrap/src/components/_index.scss
+++ b/packages/bootstrap/src/components/_index.scss
@@ -47,6 +47,7 @@
 @forward 'toast';
 @forward 'toolbar';
 @forward 'treeview';
+@forward 'user-rights-list';
 @forward 'validate-mail';
 @forward 'widget/';
 @forward 'multimedia/';

--- a/packages/bootstrap/src/components/_user-rights-list.scss
+++ b/packages/bootstrap/src/components/_user-rights-list.scss
@@ -1,0 +1,3 @@
+.user-rights-list {
+  display: block;
+}

--- a/packages/react/src/components/Tree/components/SortableTree.tsx
+++ b/packages/react/src/components/Tree/components/SortableTree.tsx
@@ -11,7 +11,7 @@ import { CSSProperties, Ref, forwardRef } from 'react';
 import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { IconFolder, IconRafterRight } from '../../../modules/icons/components';
-import { mergeRefs } from '../../../utilities';
+import { getRotateTransitionStyle, mergeRefs } from '../../../utilities';
 import { useTree } from '../hooks/useTree';
 import { useTreeSortable } from '../hooks/useTreeSortable';
 import {
@@ -239,9 +239,7 @@ const TreeNode = forwardRef(
               >
                 <IconRafterRight
                   width={16}
-                  style={{
-                    transform: expanded ? 'rotate(90deg)' : '',
-                  }}
+                  style={getRotateTransitionStyle(expanded, { degrees: 90 })}
                 />
               </div>
             )}

--- a/packages/react/src/components/Tree/components/Tree.tsx
+++ b/packages/react/src/components/Tree/components/Tree.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import { Ref, forwardRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IconFolder, IconRafterRight } from '../../../modules/icons/components';
+import { getRotateTransitionStyle } from '../../../utilities';
 import { useTree } from '../hooks/useTree';
 import { TreeNodeProps, TreeProps } from '../types';
 
@@ -140,9 +141,7 @@ export const TreeNode = forwardRef(
               >
                 <IconRafterRight
                   width={16}
-                  style={{
-                    transform: expanded ? 'rotate(90deg)' : '',
-                  }}
+                  style={getRotateTransitionStyle(expanded, { degrees: 90 })}
                 />
               </div>
             ) : (

--- a/packages/react/src/components/UserRightsList/SaveBookmark.tsx
+++ b/packages/react/src/components/UserRightsList/SaveBookmark.tsx
@@ -49,7 +49,6 @@ export const SaveBookmark = ({ onSave }: SaveBookmarkProps) => {
         </div>
         <Button
           data-testid="common-save-bookmark-save-button"
-          type="button"
           color="primary"
           variant="ghost"
           disabled={bookmarkName.length === 0 || isSaving}

--- a/packages/react/src/components/UserRightsList/SaveBookmark.tsx
+++ b/packages/react/src/components/UserRightsList/SaveBookmark.tsx
@@ -1,0 +1,62 @@
+/**
+ * Form to save the current sharing configuration as a bookmark.
+ * Input for the bookmark name and a save button that calls onSave.
+ */
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IconSave } from '../../modules/icons/components';
+import { Button } from '../Button';
+import { FormControl } from '../Form';
+
+interface SaveBookmarkProps {
+  onSave: (bookmarkName: string) => Promise<void>;
+}
+
+export const SaveBookmark = ({ onSave }: SaveBookmarkProps) => {
+  const [bookmarkName, setBookmarkName] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const { t } = useTranslation();
+
+  const handleBookmarkNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setBookmarkName(e.target.value);
+  };
+
+  const handleSaveClick = async () => {
+    setIsSaving(true);
+    await onSave(bookmarkName);
+    setIsSaving(false);
+  };
+
+  return (
+    <div className="mt-16">
+      <FormControl
+        id="bookmarkName"
+        className="d-flex flex-wrap align-items-center gap-16"
+      >
+        <div className="flex-fill">
+          <FormControl.Input
+            data-testid="common-save-bookmark-name-input"
+            value={bookmarkName}
+            onChange={handleBookmarkNameChange}
+            placeholder={t('explorer.modal.share.sharebookmark.placeholder')}
+            size="sm"
+            type="text"
+          />
+        </div>
+        <Button
+          data-testid="common-save-bookmark-save-button"
+          type="button"
+          color="primary"
+          variant="ghost"
+          disabled={bookmarkName.length === 0 || isSaving}
+          leftIcon={<IconSave />}
+          onClick={handleSaveClick}
+          className="text-nowrap"
+          isLoading={isSaving}
+        >
+          {t('explorer.modal.share.sharebookmark.save')}
+        </Button>
+      </FormControl>
+    </div>
+  );
+};

--- a/packages/react/src/components/UserRightsList/SaveBookmark.tsx
+++ b/packages/react/src/components/UserRightsList/SaveBookmark.tsx
@@ -23,8 +23,12 @@ export const SaveBookmark = ({ onSave }: SaveBookmarkProps) => {
 
   const handleSaveClick = async () => {
     setIsSaving(true);
-    await onSave(bookmarkName);
-    setIsSaving(false);
+    try {
+      await onSave(bookmarkName);
+      setBookmarkName('');
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (

--- a/packages/react/src/components/UserRightsList/UserRightsBookmarkRow.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsBookmarkRow.tsx
@@ -46,9 +46,10 @@ const UserRightsBookmarkRow = ({
           color="tertiary"
           variant="ghost"
           className="fw-normal ps-0"
+          aria-expanded={bookmark.isExpanded}
           rightIcon={
             <IconRafterDown
-              title={t('show')}
+              title={bookmark.isExpanded ? t('hide') : t('show')}
               className="w-16 min-w-0"
               style={{
                 transition: 'rotate 0.2s ease-out',
@@ -72,6 +73,7 @@ const UserRightsBookmarkRow = ({
               onToggleRight(bookmark.id, rightName as ResourceRightName)
             }
             disabled={isReadOnly}
+            aria-label={`${bookmark.name} - ${rightName}`}
           />
         </td>
       ))}
@@ -82,7 +84,7 @@ const UserRightsBookmarkRow = ({
             color="tertiary"
             onClick={() => onDelete(bookmark.id)}
             icon={<IconClose />}
-            title={t('close')}
+            title={`${t('close')} ${bookmark.name}`}
             variant="ghost"
             type="button"
           />

--- a/packages/react/src/components/UserRightsList/UserRightsBookmarkRow.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsBookmarkRow.tsx
@@ -1,0 +1,95 @@
+/**
+ * Bookmark header row in the rights list.
+ * Displays a collapsible row with batch-edit checkboxes that affect all users in the bookmark.
+ */
+import { useTranslation } from 'react-i18next';
+import {
+  IconBookmark,
+  IconClose,
+  IconRafterDown,
+} from '../../modules/icons/components';
+import { Button, IconButton } from '../Button';
+import { Checkbox } from '../Checkbox';
+import {
+  BookmarkState,
+  ResourceRightName,
+  ResourceRights,
+} from './types/types';
+
+interface UserRightsBookmarkRowProps {
+  bookmark: BookmarkState;
+  resourceRights: ResourceRights;
+  isReadOnly: boolean;
+  onToggleRight: (bookmarkId: string, rightName: ResourceRightName) => void;
+  onDelete: (bookmarkId: string) => void;
+  onToggleExpand: (bookmarkId: string) => void;
+}
+
+const UserRightsBookmarkRow = ({
+  bookmark,
+  resourceRights,
+  isReadOnly,
+  onToggleRight,
+  onDelete,
+  onToggleExpand,
+}: UserRightsBookmarkRowProps) => {
+  const { t } = useTranslation();
+
+  return (
+    <tr data-testid="user-rights-list-bookmark-row">
+      <td>
+        <IconBookmark />
+      </td>
+      <td>
+        <Button
+          type="button"
+          color="tertiary"
+          variant="ghost"
+          className="fw-normal ps-0"
+          rightIcon={
+            <IconRafterDown
+              title={t('show')}
+              className="w-16 min-w-0"
+              style={{
+                transition: 'rotate 0.2s ease-out',
+                rotate: bookmark.isExpanded ? '-180deg' : '0deg',
+              }}
+            />
+          }
+          onClick={() => onToggleExpand(bookmark.id)}
+        >
+          {bookmark.name}
+        </Button>
+      </td>
+      {Object.entries(resourceRights).map(([rightName]) => (
+        <td
+          key={rightName}
+          data-testid={`user-rights-list-bookmark-${rightName}-checkbox`}
+        >
+          <Checkbox
+            checked={bookmark.permission.includes(rightName)}
+            onChange={() =>
+              onToggleRight(bookmark.id, rightName as ResourceRightName)
+            }
+            disabled={isReadOnly}
+          />
+        </td>
+      ))}
+      <td>
+        {!isReadOnly && (
+          <IconButton
+            data-testid="user-rights-list-bookmark-close-button"
+            color="tertiary"
+            onClick={() => onDelete(bookmark.id)}
+            icon={<IconClose />}
+            title={t('close')}
+            variant="ghost"
+            type="button"
+          />
+        )}
+      </td>
+    </tr>
+  );
+};
+
+export default UserRightsBookmarkRow;

--- a/packages/react/src/components/UserRightsList/UserRightsBookmarkRow.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsBookmarkRow.tsx
@@ -8,6 +8,7 @@ import {
   IconClose,
   IconRafterDown,
 } from '../../modules/icons/components';
+import { getRotateTransitionStyle } from '../../utilities';
 import { Button, IconButton } from '../Button';
 import { Checkbox } from '../Checkbox';
 import {
@@ -50,10 +51,7 @@ const UserRightsBookmarkRow = ({
             <IconRafterDown
               title={bookmark.isExpanded ? t('hide') : t('show')}
               className="w-16 min-w-0"
-              style={{
-                transition: 'rotate 0.2s ease-out',
-                rotate: bookmark.isExpanded ? '-180deg' : '0deg',
-              }}
+              style={getRotateTransitionStyle(bookmark.isExpanded)}
             />
           }
           onClick={() => onToggleExpand(bookmark.id)}

--- a/packages/react/src/components/UserRightsList/UserRightsBookmarkRow.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsBookmarkRow.tsx
@@ -42,7 +42,6 @@ const UserRightsBookmarkRow = ({
       </td>
       <td>
         <Button
-          type="button"
           color="tertiary"
           variant="ghost"
           className="fw-normal ps-0"
@@ -63,10 +62,7 @@ const UserRightsBookmarkRow = ({
         </Button>
       </td>
       {Object.entries(resourceRights).map(([rightName]) => (
-        <td
-          key={rightName}
-          data-testid={`user-rights-list-bookmark-${rightName}-checkbox`}
-        >
+        <td key={rightName}>
           <Checkbox
             checked={bookmark.permission.includes(rightName)}
             onChange={() =>
@@ -74,6 +70,7 @@ const UserRightsBookmarkRow = ({
             }
             disabled={isReadOnly}
             aria-label={`${bookmark.name} - ${rightName}`}
+            data-testid={`user-rights-list-bookmark-${rightName}-checkbox`}
           />
         </td>
       ))}
@@ -86,7 +83,6 @@ const UserRightsBookmarkRow = ({
             icon={<IconClose />}
             title={`${t('close')} ${bookmark.name}`}
             variant="ghost"
-            type="button"
           />
         )}
       </td>

--- a/packages/react/src/components/UserRightsList/UserRightsItem.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsItem.tsx
@@ -14,6 +14,8 @@ interface UserRightsItemProps {
   item: SharingItem;
   resourceRights: ResourceRights;
   isReadOnly: boolean;
+  isDeletable?: boolean;
+  rowClassName?: string;
   onChange?: (item: SharingItem, rightName: ResourceRightName) => void;
   onDeleteItem?: (item: SharingItem) => void;
 }
@@ -22,6 +24,8 @@ const UserRightsItem = ({
   item,
   resourceRights,
   isReadOnly,
+  isDeletable = true,
+  rowClassName,
   onChange,
   onDeleteItem,
 }: UserRightsItemProps) => {
@@ -37,7 +41,11 @@ const UserRightsItem = ({
   };
 
   return (
-    <tr key={item.recipientId} data-testid="user-rights-list-item-row">
+    <tr
+      key={item.recipientId}
+      data-testid="user-rights-list-item-row"
+      className={rowClassName}
+    >
       <td>
         <Avatar
           src={getAvatarURL(
@@ -63,7 +71,7 @@ const UserRightsItem = ({
         </td>
       ))}
       <td>
-        {!isReadOnly && (
+        {!isReadOnly && isDeletable && (
           <IconButton
             data-testid="user-rights-list-close-button"
             color="tertiary"

--- a/packages/react/src/components/UserRightsList/UserRightsItem.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsItem.tsx
@@ -1,0 +1,82 @@
+/**
+ * A single row in the rights list: avatar, name, one checkbox per right, remove button.
+ * Used for the owner (read-only) and for each sharing (editable when not readOnly).
+ */
+import { useTranslation } from 'react-i18next';
+import { useDirectory } from '../../hooks';
+import { IconClose } from '../../modules/icons/components';
+import { Avatar } from '../Avatar';
+import { IconButton } from '../Button';
+import { Checkbox } from '../Checkbox';
+import { ResourceRightName, ResourceRights, SharingItem } from './types/types';
+
+interface UserRightsItemProps {
+  item: SharingItem;
+  resourceRights: ResourceRights;
+  isReadOnly: boolean;
+  onChange?: (item: SharingItem, rightName: ResourceRightName) => void;
+  onDeleteItem?: (item: SharingItem) => void;
+}
+
+const UserRightsItem = ({
+  item,
+  resourceRights,
+  isReadOnly,
+  onChange,
+  onDeleteItem,
+}: UserRightsItemProps) => {
+  const { getAvatarURL } = useDirectory();
+  const { t } = useTranslation();
+
+  const handleChange = (rightName: ResourceRightName) => {
+    onChange?.(item, rightName);
+  };
+
+  const handleDeleteItem = () => {
+    onDeleteItem?.(item);
+  };
+
+  return (
+    <tr key={item.recipientId} data-testid="user-rights-list-item-row">
+      <td>
+        <Avatar
+          src={getAvatarURL(
+            item.recipientId,
+            item.recipientType === 'bookmark' ? 'group' : item.recipientType,
+          )}
+          size="xs"
+          alt={item.displayName}
+          variant="circle"
+        />
+      </td>
+      <td>{item.displayName}</td>
+      {Object.entries(resourceRights).map(([rightName]) => (
+        <td
+          key={rightName}
+          data-testid={`user-rights-list-item-${rightName}-checkbox`}
+        >
+          <Checkbox
+            checked={item.permission.includes(rightName)}
+            onChange={() => handleChange(rightName as ResourceRightName)}
+            disabled={isReadOnly}
+          />
+        </td>
+      ))}
+      <td>
+        {!isReadOnly && (
+          <IconButton
+            data-testid="user-rights-list-close-button"
+            color="tertiary"
+            onClick={() => handleDeleteItem()}
+            icon={<IconClose />}
+            title={t('close')}
+            variant="ghost"
+            type="button"
+          />
+        )}
+      </td>
+    </tr>
+  );
+};
+
+export default UserRightsItem;

--- a/packages/react/src/components/UserRightsList/UserRightsItem.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsItem.tsx
@@ -16,6 +16,7 @@ interface UserRightsItemProps {
   isReadOnly: boolean;
   isDeletable?: boolean;
   rowClassName?: string;
+  bookmarkName?: string;
   onChange?: (item: SharingItem, rightName: ResourceRightName) => void;
   onDeleteItem?: (item: SharingItem) => void;
 }
@@ -26,6 +27,7 @@ const UserRightsItem = ({
   isReadOnly,
   isDeletable = true,
   rowClassName,
+  bookmarkName,
   onChange,
   onDeleteItem,
 }: UserRightsItemProps) => {
@@ -42,16 +44,15 @@ const UserRightsItem = ({
 
   return (
     <tr
-      key={item.recipientId}
       data-testid="user-rights-list-item-row"
       className={rowClassName}
+      aria-label={
+        bookmarkName ? `${item.displayName} - ${bookmarkName}` : undefined
+      }
     >
       <td>
         <Avatar
-          src={getAvatarURL(
-            item.recipientId,
-            item.recipientType === 'bookmark' ? 'group' : item.recipientType,
-          )}
+          src={getAvatarURL(item.recipientId, item.recipientType)}
           size="xs"
           alt={item.displayName}
           variant="circle"
@@ -67,6 +68,7 @@ const UserRightsItem = ({
             checked={item.permission.includes(rightName)}
             onChange={() => handleChange(rightName as ResourceRightName)}
             disabled={isReadOnly}
+            aria-label={`${item.displayName} - ${rightName}`}
           />
         </td>
       ))}
@@ -77,7 +79,7 @@ const UserRightsItem = ({
             color="tertiary"
             onClick={() => handleDeleteItem()}
             icon={<IconClose />}
-            title={t('close')}
+            title={`${t('close')} ${item.displayName}`}
             variant="ghost"
             type="button"
           />

--- a/packages/react/src/components/UserRightsList/UserRightsItem.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsItem.tsx
@@ -8,6 +8,7 @@ import { IconClose } from '../../modules/icons/components';
 import { Avatar } from '../Avatar';
 import { IconButton } from '../Button';
 import { Checkbox } from '../Checkbox';
+import { AvatarType } from '../../types';
 import { ResourceRightName, ResourceRights, SharingItem } from './types/types';
 
 interface UserRightsItemProps {
@@ -52,7 +53,7 @@ const UserRightsItem = ({
     >
       <td>
         <Avatar
-          src={getAvatarURL(item.recipientId, item.recipientType)}
+          src={getAvatarURL(item.recipientId, item.recipientType as AvatarType)}
           size="xs"
           alt={item.displayName}
           variant="circle"

--- a/packages/react/src/components/UserRightsList/UserRightsList.spec.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.spec.tsx
@@ -1,0 +1,398 @@
+import { createRef } from 'react';
+import { act, render, screen } from '~/setup';
+import { UserRightsList, UserRightsListRef } from './UserRightsList';
+import type { BookmarkInput, ResourceRights, SharingItem } from './types/types';
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const mockResourceRights: ResourceRights = {
+  read: { priority: 1, default: true, requires: [], excludes: [] },
+  contrib: {
+    priority: 2,
+    default: false,
+    requires: ['read'],
+    excludes: [],
+  },
+  publish: {
+    priority: 3,
+    default: false,
+    requires: ['contrib', 'read'],
+    excludes: [],
+  },
+  manager: {
+    priority: 4,
+    default: false,
+    requires: ['publish', 'contrib', 'read'],
+    excludes: [],
+  },
+  comment: {
+    priority: 5,
+    default: false,
+    requires: ['read'],
+    excludes: [],
+  },
+};
+
+const mockSharings: SharingItem[] = [
+  {
+    recipientId: 'user-1',
+    recipientType: 'user',
+    permission: ['read'],
+    displayName: 'Marie Dupont',
+  },
+  {
+    recipientId: 'user-2',
+    recipientType: 'user',
+    permission: ['read', 'comment'],
+    displayName: 'Jean Martin',
+  },
+];
+
+const mockBookmark: BookmarkInput = {
+  id: 'bookmark-1',
+  name: 'Parents CE2',
+  users: [
+    { id: 'bk-user-1', displayName: 'Alice Durand' },
+    { id: 'bk-user-2', displayName: 'Bob Leroy' },
+  ],
+};
+
+const defaultProps = {
+  resourceRights: mockResourceRights,
+  isReadOnly: false,
+  isLoading: false,
+  ownerId: '91c22b66-ba1b-4fde-a3fe-95219cc18d4a',
+  isCreating: true,
+  initialSharings: mockSharings,
+  onChange: vi.fn(),
+  onAddItems: vi.fn(),
+  onDeleteItems: vi.fn(),
+};
+
+function renderList(
+  overrides: Partial<React.ComponentProps<typeof UserRightsList>> = {},
+  ref?: React.RefObject<UserRightsListRef>,
+) {
+  return render(<UserRightsList ref={ref} {...defaultProps} {...overrides} />);
+}
+
+function getRows() {
+  return screen.getAllByTestId('user-rights-list-item-row');
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('UserRightsList', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders the owner row and initial sharings', () => {
+      renderList();
+      const rows = getRows();
+      // owner + 2 sharings
+      expect(rows.length).toBe(3);
+      expect(screen.getByText('Marie Dupont')).toBeInTheDocument();
+      expect(screen.getByText('Jean Martin')).toBeInTheDocument();
+    });
+
+    it('renders a loading state instead of the table', () => {
+      renderList({ isLoading: true });
+      expect(screen.queryAllByTestId('user-rights-list-item-row')).toHaveLength(
+        0,
+      );
+    });
+
+    it('disables checkboxes and hides delete buttons when read-only', () => {
+      renderList({ isReadOnly: true });
+      const checkboxes = screen.getAllByRole('checkbox');
+      checkboxes.forEach((checkbox) => {
+        expect(checkbox).toBeDisabled();
+      });
+      expect(
+        screen.queryByTestId('user-rights-list-close-button'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Rights toggle', () => {
+    it('calls onChange when toggling a right on a user', async () => {
+      const onChange = vi.fn();
+      const { user } = renderList({ onChange });
+
+      const contribCheckbox = screen.getByLabelText('Marie Dupont - contrib');
+      await user.click(contribCheckbox);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      const updatedItems: SharingItem[] = onChange.mock.calls[0][0];
+      const marie = updatedItems.find((item) => item.recipientId === 'user-1');
+      expect(marie?.permission).toContain('contrib');
+      expect(marie?.permission).toContain('read');
+    });
+
+    it('transitively removes dependent rights when unchecking a required right', async () => {
+      const onChange = vi.fn();
+      const { user } = renderList({
+        onChange,
+        initialSharings: [
+          {
+            recipientId: 'user-1',
+            recipientType: 'user',
+            permission: ['read', 'contrib', 'publish'],
+            displayName: 'Marie Dupont',
+          },
+        ],
+      });
+
+      // Uncheck read → should also remove contrib and publish
+      const readCheckbox = screen.getByLabelText('Marie Dupont - read');
+      await user.click(readCheckbox);
+
+      const updatedItems: SharingItem[] = onChange.mock.calls[0][0];
+      const marie = updatedItems.find((item) => item.recipientId === 'user-1');
+      expect(marie?.permission).not.toContain('read');
+      expect(marie?.permission).not.toContain('contrib');
+      expect(marie?.permission).not.toContain('publish');
+    });
+  });
+
+  describe('Delete item', () => {
+    it('removes a user and calls onDeleteItems', async () => {
+      const onChange = vi.fn();
+      const onDeleteItems = vi.fn();
+      const { user } = renderList({ onChange, onDeleteItems });
+
+      const deleteButton = screen.getByTitle(/close Marie Dupont/i);
+      await user.click(deleteButton);
+
+      expect(onDeleteItems).toHaveBeenCalledTimes(1);
+      expect(onDeleteItems).toHaveBeenCalledWith([
+        expect.objectContaining({ recipientId: 'user-1' }),
+      ]);
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('Add item via ref', () => {
+    it('adds a user via ref.addItem', () => {
+      const onAddItems = vi.fn();
+      const ref = createRef<UserRightsListRef>();
+      renderList({ onAddItems }, ref);
+
+      act(() => {
+        ref.current?.addItem({
+          recipientId: 'user-new',
+          recipientType: 'user',
+          permission: ['read'],
+          displayName: 'Nouvel utilisateur',
+        });
+      });
+
+      expect(screen.getByText('Nouvel utilisateur')).toBeInTheDocument();
+      expect(onAddItems).toHaveBeenCalledWith([
+        expect.objectContaining({ recipientId: 'user-new' }),
+      ]);
+    });
+
+    it('ignores duplicate recipientId', () => {
+      const onAddItems = vi.fn();
+      const ref = createRef<UserRightsListRef>();
+      renderList({ onAddItems }, ref);
+
+      act(() => {
+        ref.current?.addItem({
+          recipientId: 'user-1',
+          recipientType: 'user',
+          permission: ['read'],
+          displayName: 'Duplicate Marie',
+        });
+      });
+
+      expect(screen.queryByText('Duplicate Marie')).not.toBeInTheDocument();
+      expect(onAddItems).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Bookmark support', () => {
+    it('adds a bookmark via ref and displays the bookmark row', () => {
+      const onAddItems = vi.fn();
+      const ref = createRef<UserRightsListRef>();
+      renderList({ onAddItems }, ref);
+
+      act(() => {
+        ref.current?.addItem(mockBookmark);
+      });
+
+      expect(
+        screen.getByTestId('user-rights-list-bookmark-row'),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Parents CE2')).toBeInTheDocument();
+      // Users are not visible (collapsed by default)
+      expect(screen.queryByText('Alice Durand')).not.toBeInTheDocument();
+      // onAddItems called with all bookmark users
+      expect(onAddItems).toHaveBeenCalledWith([
+        expect.objectContaining({ recipientId: 'bk-user-1' }),
+        expect.objectContaining({ recipientId: 'bk-user-2' }),
+      ]);
+    });
+
+    it('expands bookmark to show users', async () => {
+      const ref = createRef<UserRightsListRef>();
+      const { user } = renderList({}, ref);
+
+      act(() => {
+        ref.current?.addItem(mockBookmark);
+      });
+
+      const expandButton = screen.getByText('Parents CE2');
+      await user.click(expandButton);
+
+      expect(screen.getByText('Alice Durand')).toBeInTheDocument();
+      expect(screen.getByText('Bob Leroy')).toBeInTheDocument();
+    });
+
+    it('does not show delete button on bookmark users', async () => {
+      const ref = createRef<UserRightsListRef>();
+      const { user } = renderList({}, ref);
+
+      act(() => {
+        ref.current?.addItem(mockBookmark);
+      });
+
+      await user.click(screen.getByText('Parents CE2'));
+
+      // Regular users have delete buttons, bookmark users do not
+      const userDeleteButtons = screen.getAllByTestId(
+        'user-rights-list-close-button',
+      );
+      expect(userDeleteButtons).toHaveLength(2);
+      // Bookmark row has its own delete button
+      expect(
+        screen.getByTestId('user-rights-list-bookmark-close-button'),
+      ).toBeInTheDocument();
+    });
+
+    it('toggles a right on the bookmark row and applies to all its users', async () => {
+      const onChange = vi.fn();
+      const ref = createRef<UserRightsListRef>();
+      const { user } = renderList({ onChange }, ref);
+
+      act(() => {
+        ref.current?.addItem(mockBookmark);
+      });
+      onChange.mockClear();
+
+      const contribCheckbox = screen.getByLabelText('Parents CE2 - contrib');
+      await user.click(contribCheckbox);
+
+      expect(onChange).toHaveBeenCalled();
+      const updatedItems: SharingItem[] = onChange.mock.calls[0][0];
+      const bookmarkUsers = updatedItems.filter((item) =>
+        ['bk-user-1', 'bk-user-2'].includes(item.recipientId),
+      );
+      bookmarkUsers.forEach((bookmarkUser) => {
+        expect(bookmarkUser.permission).toContain('contrib');
+        expect(bookmarkUser.permission).toContain('read');
+      });
+    });
+
+    it('deletes a bookmark and removes all its users', async () => {
+      const onDeleteItems = vi.fn();
+      const onChange = vi.fn();
+      const ref = createRef<UserRightsListRef>();
+      const { user } = renderList({ onDeleteItems, onChange }, ref);
+
+      act(() => {
+        ref.current?.addItem(mockBookmark);
+      });
+      onDeleteItems.mockClear();
+
+      const bookmarkDeleteButton = screen.getByTestId(
+        'user-rights-list-bookmark-close-button',
+      );
+      await user.click(bookmarkDeleteButton);
+
+      expect(
+        screen.queryByTestId('user-rights-list-bookmark-row'),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Alice Durand')).not.toBeInTheDocument();
+      expect(onDeleteItems).toHaveBeenCalledWith([
+        expect.objectContaining({ recipientId: 'bk-user-1' }),
+        expect.objectContaining({ recipientId: 'bk-user-2' }),
+      ]);
+    });
+
+    it('ignores duplicate bookmark', () => {
+      const onAddItems = vi.fn();
+      const ref = createRef<UserRightsListRef>();
+      renderList({ onAddItems }, ref);
+
+      act(() => {
+        ref.current?.addItem(mockBookmark);
+      });
+      onAddItems.mockClear();
+
+      act(() => {
+        ref.current?.addItem(mockBookmark);
+      });
+
+      expect(onAddItems).not.toHaveBeenCalled();
+      expect(
+        screen.getAllByTestId('user-rights-list-bookmark-row'),
+      ).toHaveLength(1);
+    });
+
+    it('skips bookmark users that already exist in the list', () => {
+      const onAddItems = vi.fn();
+      const ref = createRef<UserRightsListRef>();
+      const bookmarkWithExistingUser: BookmarkInput = {
+        id: 'bookmark-overlap',
+        name: 'Overlap Bookmark',
+        users: [
+          { id: 'user-1', displayName: 'Marie Dupont' },
+          { id: 'new-user', displayName: 'New User' },
+        ],
+      };
+      renderList({ onAddItems }, ref);
+
+      act(() => {
+        ref.current?.addItem(bookmarkWithExistingUser);
+      });
+
+      // Only new-user should have been added
+      expect(onAddItems).toHaveBeenCalledWith([
+        expect.objectContaining({ recipientId: 'new-user' }),
+      ]);
+    });
+  });
+
+  describe('Save bookmark', () => {
+    it('shows save bookmark form when button is clicked', async () => {
+      const onSaveBookmark = vi.fn().mockResolvedValue(undefined);
+      const { user } = renderList({ onSaveBookmark });
+
+      const showButton = screen.getByTestId(
+        'common-user-rights-list-share-bookmark-show-button',
+      );
+      await user.click(showButton);
+
+      expect(
+        screen.getByTestId('common-save-bookmark-name-input'),
+      ).toBeInTheDocument();
+    });
+
+    it('hides save bookmark button when onSaveBookmark is not provided', () => {
+      renderList({ onSaveBookmark: undefined });
+      expect(
+        screen.queryByTestId(
+          'common-user-rights-list-share-bookmark-show-button',
+        ),
+      ).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
@@ -1,0 +1,128 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import type { ComponentRef } from 'react';
+import { useRef } from 'react';
+import { UserRightsList } from './UserRightsList';
+import type { ResourceRights, SharingItem } from './types/types';
+
+const mockResourceRights: ResourceRights = {
+  read: { priority: 1, default: true, requires: [], excludes: [] },
+  contrib: {
+    priority: 2,
+    default: false,
+    requires: ['read'],
+    excludes: [],
+  },
+  publish: {
+    priority: 3,
+    default: false,
+    requires: ['contrib'],
+    excludes: [],
+  },
+  manager: {
+    priority: 4,
+    default: false,
+    requires: ['publish'],
+    excludes: [],
+  },
+  comment: {
+    priority: 5,
+    default: false,
+    requires: ['read'],
+    excludes: [],
+  },
+};
+
+const mockInitialSharings: SharingItem[] = [
+  {
+    recipientId: 'user-1',
+    recipientType: 'user',
+    permission: ['read', 'contrib', 'publish'],
+    displayName: 'Marie Dupont',
+  },
+  {
+    recipientId: 'user-2',
+    recipientType: 'user',
+    permission: ['read', 'comment'],
+    displayName: 'Jean Martin',
+  },
+  {
+    recipientId: 'group-1',
+    recipientType: 'group',
+    permission: ['read'],
+    displayName: 'Classe 3ème A',
+  },
+];
+
+const meta: Meta<typeof UserRightsList> = {
+  title: 'Components/UserRightsList',
+  component: UserRightsList,
+  decorators: [(Story) => <div style={{ minHeight: '200px' }}>{Story()}</div>],
+  args: {
+    resourceRights: mockResourceRights,
+    isReadOnly: false,
+    isLoading: false,
+    ownerId: '91c22b66-ba1b-4fde-a3fe-95219cc18d4a', // packages/config/src/msw/mocks/directory.ts
+    isCreating: true,
+    initialSharings: mockInitialSharings,
+    onChange: fn(),
+    onAddItem: fn(),
+    onDeleteItem: fn(),
+    onSaveBookmark: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof UserRightsList>;
+
+export const Default: Story = {};
+
+export const ReadOnly: Story = {
+  args: {
+    isReadOnly: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    initialSharings: [],
+  },
+};
+
+export const WithoutSaveBookmark: Story = {
+  args: {
+    onSaveBookmark: undefined,
+  },
+};
+
+export const WithRef: Story = {
+  render: (args) => {
+    const ref = useRef<ComponentRef<typeof UserRightsList>>(null);
+    return (
+      <div>
+        <UserRightsList {...args} ref={ref} />
+        <button
+          type="button"
+          onClick={() => {
+            ref.current?.addItem({
+              recipientId: 'user-new',
+              recipientType: 'user',
+              permission: ['read'],
+              displayName: 'Nouvel utilisateur',
+            });
+          }}
+          style={{ marginTop: '1rem' }}
+        >
+          Ajouter via ref
+        </button>
+      </div>
+    );
+  },
+};

--- a/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import type { ComponentRef } from 'react';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { UserRightsList } from './UserRightsList';
-import type { ResourceRights, SharingItem } from './types/types';
+import type { BookmarkInput, ResourceRights, SharingItem } from './types/types';
 
 const mockResourceRights: ResourceRights = {
   read: { priority: 1, default: true, requires: [], excludes: [] },
@@ -16,13 +16,13 @@ const mockResourceRights: ResourceRights = {
   publish: {
     priority: 3,
     default: false,
-    requires: ['contrib'],
+    requires: ['contrib', 'read'],
     excludes: [],
   },
   manager: {
     priority: 4,
     default: false,
-    requires: ['publish'],
+    requires: ['publish', 'contrib', 'read'],
     excludes: [],
   },
   comment: {
@@ -121,6 +121,77 @@ export const WithRef: Story = {
           style={{ marginTop: '1rem' }}
         >
           Ajouter via ref
+        </button>
+      </div>
+    );
+  },
+};
+
+const mockBookmark1: BookmarkInput = {
+  id: '_9a1d29c3d2864ed8a3d72198fadf4a96',
+  name: 'Parents délégués CE2',
+  notVisibleCount: 0,
+  groups: [],
+  users: [
+    {
+      displayName: 'CARPENTIER Béatrice',
+      profile: 'Relative',
+      id: 'c0824335-ab0e-41fb-9ed3-d5c28a93087d',
+      activationCode: false,
+    },
+    {
+      displayName: 'ROUSTIN Christophe',
+      profile: 'Relative',
+      id: '6a7495f8-bec7-4f68-b891-0b05c6e8e0ce',
+      activationCode: false,
+    },
+  ],
+};
+
+const mockBookmark2: BookmarkInput = {
+  id: '_b7e3f1a2c4d5e6f7a8b9c0d1e2f3a4b5',
+  name: 'Équipe pédagogique CM1',
+  notVisibleCount: 0,
+  groups: [],
+  users: [
+    {
+      displayName: 'DURAND Sophie',
+      profile: 'Teacher',
+      id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      activationCode: false,
+    },
+    {
+      displayName: 'MOREAU Philippe',
+      profile: 'Teacher',
+      id: 'f9e8d7c6-b5a4-3210-fedc-ba9876543210',
+      activationCode: false,
+    },
+    {
+      displayName: 'LEFEBVRE Claire',
+      profile: 'Teacher',
+      id: 'd4c3b2a1-0987-6543-210f-edcba9876543',
+      activationCode: false,
+    },
+  ],
+};
+
+export const WithBookmark: Story = {
+  render: (args) => {
+    const ref = useRef<ComponentRef<typeof UserRightsList>>(null);
+    useEffect(() => {
+      ref.current?.addItem(mockBookmark1);
+    }, []);
+    return (
+      <div>
+        <UserRightsList {...args} ref={ref} />
+        <button
+          type="button"
+          onClick={() => {
+            ref.current?.addItem(mockBookmark2);
+          }}
+          style={{ marginTop: '1rem' }}
+        >
+          Ajouter un bookmark
         </button>
       </div>
     );

--- a/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
@@ -5,6 +5,10 @@ import { useEffect, useRef } from 'react';
 import { UserRightsList } from './UserRightsList';
 import type { BookmarkInput, ResourceRights, SharingItem } from './types/types';
 
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
 const mockResourceRights: ResourceRights = {
   read: { priority: 1, default: true, requires: [], excludes: [] },
   contrib: {
@@ -54,79 +58,6 @@ const mockInitialSharings: SharingItem[] = [
   },
 ];
 
-const meta: Meta<typeof UserRightsList> = {
-  title: 'Components/UserRightsList',
-  component: UserRightsList,
-  decorators: [(Story) => <div style={{ minHeight: '200px' }}>{Story()}</div>],
-  args: {
-    resourceRights: mockResourceRights,
-    isReadOnly: false,
-    isLoading: false,
-    ownerId: '91c22b66-ba1b-4fde-a3fe-95219cc18d4a', // packages/config/src/msw/mocks/directory.ts
-    isCreating: true,
-    initialSharings: mockInitialSharings,
-    onChange: fn(),
-    onAddItem: fn(),
-    onDeleteItem: fn(),
-    onSaveBookmark: fn(),
-  },
-};
-
-export default meta;
-
-type Story = StoryObj<typeof UserRightsList>;
-
-export const Default: Story = {};
-
-export const ReadOnly: Story = {
-  args: {
-    isReadOnly: true,
-  },
-};
-
-export const Loading: Story = {
-  args: {
-    isLoading: true,
-  },
-};
-
-export const Empty: Story = {
-  args: {
-    initialSharings: [],
-  },
-};
-
-export const WithoutSaveBookmark: Story = {
-  args: {
-    onSaveBookmark: undefined,
-  },
-};
-
-export const WithRef: Story = {
-  render: (args) => {
-    const ref = useRef<ComponentRef<typeof UserRightsList>>(null);
-    return (
-      <div>
-        <UserRightsList {...args} ref={ref} />
-        <button
-          type="button"
-          onClick={() => {
-            ref.current?.addItem({
-              recipientId: 'user-new',
-              recipientType: 'user',
-              permission: ['read'],
-              displayName: 'Nouvel utilisateur',
-            });
-          }}
-          style={{ marginTop: '1rem' }}
-        >
-          Ajouter via ref
-        </button>
-      </div>
-    );
-  },
-};
-
 const mockBookmark1: BookmarkInput = {
   id: '_9a1d29c3d2864ed8a3d72198fadf4a96',
   name: 'Parents délégués CE2',
@@ -175,6 +106,112 @@ const mockBookmark2: BookmarkInput = {
   ],
 };
 
+// ---------------------------------------------------------------------------
+// Meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta<typeof UserRightsList> = {
+  title: 'Components/UserRightsList',
+  component: UserRightsList,
+  decorators: [(Story) => <div style={{ minHeight: '200px' }}>{Story()}</div>],
+  args: {
+    resourceRights: mockResourceRights,
+    isReadOnly: false,
+    isLoading: false,
+    ownerId: '91c22b66-ba1b-4fde-a3fe-95219cc18d4a',
+    isCreating: true,
+    initialSharings: mockInitialSharings,
+    onChange: fn(),
+    onAddItems: fn(),
+    onDeleteItems: fn(),
+    onSaveBookmark: fn(),
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The UserRightsList component displays a table of sharing permissions for a resource. ' +
+          'Each row represents a user, group, or bookmark with checkboxes for each right (read, contrib, publish, manager, comment). ' +
+          'Rights support dependencies (requires/excludes) and transitive removal. ' +
+          'Items can be added externally via a ref (`addItem`), which accepts either a `SharingItem` (user/group) or a `BookmarkInput` (group of users). ' +
+          'Bookmarks appear as collapsible rows at the top of the list; toggling a right on a bookmark applies it to all its users. ' +
+          'Parent notifications use batch callbacks (`onAddItems`, `onDeleteItems`) for efficient handling of bulk operations like bookmark insertion/deletion. ' +
+          'The component also supports saving the current sharing configuration as a bookmark via `onSaveBookmark`.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof UserRightsList>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Default editable list with pre-populated users and a group. */
+export const Default: Story = {};
+
+/** All rows are read-only: checkboxes are disabled and delete buttons are hidden. */
+export const ReadOnly: Story = {
+  args: {
+    isReadOnly: true,
+  },
+};
+
+/** Displays a loading spinner instead of the table. */
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+  },
+};
+
+/** Empty list with only the owner row visible. */
+export const Empty: Story = {
+  args: {
+    initialSharings: [],
+  },
+};
+
+/** Hides the "Save as bookmark" button when onSaveBookmark is not provided. */
+export const WithoutSaveBookmark: Story = {
+  args: {
+    onSaveBookmark: undefined,
+  },
+};
+
+/** Demonstrates adding a user programmatically via the ref's `addItem` method. */
+export const WithRef: Story = {
+  render: (args) => {
+    const ref = useRef<ComponentRef<typeof UserRightsList>>(null);
+    return (
+      <div>
+        <UserRightsList {...args} ref={ref} />
+        <button
+          type="button"
+          onClick={() => {
+            ref.current?.addItem({
+              recipientId: 'user-new',
+              recipientType: 'user',
+              permission: ['read'],
+              displayName: 'Nouvel utilisateur',
+            });
+          }}
+          style={{ marginTop: '1rem' }}
+        >
+          Ajouter via ref
+        </button>
+      </div>
+    );
+  },
+};
+
+/**
+ * Demonstrates bookmark support.
+ * A first bookmark is loaded on mount; a second can be added via the button.
+ * Bookmarks are collapsible rows whose right toggles apply to all their users.
+ */
 export const WithBookmark: Story = {
   render: (args) => {
     const ref = useRef<ComponentRef<typeof UserRightsList>>(null);

--- a/packages/react/src/components/UserRightsList/UserRightsList.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.tsx
@@ -1,0 +1,198 @@
+/**
+ * Sharing rights list for a resource.
+ * Displays the owner, shared users/groups with their permissions,
+ * and optionally a block to save the configuration as a bookmark.
+ */
+import { forwardRef, useImperativeHandle, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { IconBookmark, IconRafterDown } from '../../modules/icons/components';
+import { useEdificeClient } from '../../providers';
+import { Button } from '../Button';
+import { LoadingScreen } from '../LoadingScreen';
+import { SharingItem } from '../UserSearch';
+import { VisuallyHidden } from '../VisuallyHidden';
+import { useRights } from './hooks/useRights';
+import { SaveBookmark } from './SaveBookmark';
+import { ResourceRightName, ResourceRights } from './types/types';
+import UserRightsItem from './UserRightsItem';
+
+interface UserRightsListProps {
+  resourceRights: ResourceRights;
+  isReadOnly: boolean;
+  isLoading: boolean;
+  ownerId: string;
+  isCreating: boolean;
+  initialSharings?: SharingItem[];
+  onChange: (value: SharingItem[]) => void;
+  onAddItem: (value: SharingItem) => void;
+  onDeleteItem: (value: SharingItem) => void;
+  onSaveBookmark?: (
+    bookmarkName: string,
+    items: SharingItem[],
+  ) => Promise<void>;
+}
+
+interface UserRightsListRef {
+  addItem: (item: SharingItem) => void;
+}
+
+export const UserRightsList = forwardRef<
+  UserRightsListRef,
+  UserRightsListProps
+>(
+  (
+    {
+      resourceRights,
+      isReadOnly = true,
+      isLoading = false,
+      ownerId,
+      isCreating = false,
+      initialSharings = [],
+      onChange,
+      onAddItem,
+      onDeleteItem,
+      onSaveBookmark,
+    },
+    ref,
+  ) => {
+    const [items, setItems] = useState<SharingItem[]>(initialSharings ?? []);
+    const [showBookmarkInput, setBookmarkInput] = useState<boolean>(false);
+    const { t } = useTranslation();
+    const { user } = useEdificeClient();
+    const { toggleRight, getOwnerItem } = useRights(resourceRights);
+
+    const ownerItem = getOwnerItem(ownerId, user, isCreating);
+
+    /** Adds a sharing to the list and notifies the parent. */
+    const handleAddItem = (item: SharingItem) => {
+      setItems((prev) => [...prev, item]);
+      onAddItem(item);
+    };
+
+    /** Removes a sharing from the list and notifies the parent. */
+    const handleDeleteItem = (item: SharingItem) => {
+      setItems((prev) =>
+        prev.filter((i) => i.recipientId !== item.recipientId),
+      );
+      onDeleteItem(item);
+    };
+
+    /** Updates a sharing's permissions (toggle right) and notifies the parent. */
+    const handleChange = (item: SharingItem, rightName: ResourceRightName) => {
+      const updatedItem = toggleRight(item, rightName);
+      setItems((prevItems) => {
+        const nextItems = prevItems.map((prevItem) =>
+          prevItem.recipientId === item.recipientId ? updatedItem : prevItem,
+        );
+        onChange(nextItems);
+        return nextItems;
+      });
+    };
+
+    /** Triggers bookmark save with the entered name and current list. */
+    const handleOnSaveBookmark = (bookmarkName: string) => {
+      if (!onSaveBookmark) {
+        return Promise.resolve();
+      }
+      return onSaveBookmark(bookmarkName, items);
+    };
+
+    const toggleBookmarkInput = () => {
+      setBookmarkInput((prev) => !prev);
+    };
+
+    /** Exposes addItem so a sharing can be added from outside (e.g. via ref). */
+    useImperativeHandle(ref, () => ({
+      addItem: handleAddItem,
+    }));
+
+    return (
+      <div className="user-rights-list">
+        {isLoading ? (
+          <LoadingScreen />
+        ) : (
+          <>
+            <div className="table-responsive">
+              <table className="table border align-middle">
+                <thead>
+                  <tr>
+                    <th scope="col" className="w-32">
+                      <VisuallyHidden>
+                        {t('explorer.modal.share.avatar.shared.alt')}
+                      </VisuallyHidden>
+                    </th>
+                    <th scope="col">
+                      <VisuallyHidden>
+                        {t('explorer.modal.share.search.placeholder')}
+                      </VisuallyHidden>
+                    </th>
+                    {Object.entries(resourceRights).map(([rightName]) => (
+                      <th key={rightName}>{rightName}</th>
+                    ))}
+                    {!isReadOnly && (
+                      <th scope="col">
+                        <VisuallyHidden>{t('close')}</VisuallyHidden>
+                      </th>
+                    )}
+                  </tr>
+                </thead>
+                <tbody>
+                  {/* Add a disabled line about the resource owner. */}
+                  <UserRightsItem
+                    key={ownerItem?.recipientId}
+                    item={ownerItem}
+                    resourceRights={resourceRights}
+                    isReadOnly={true}
+                  />
+                  {items.map((item) => (
+                    <UserRightsItem
+                      key={item.recipientId}
+                      item={item}
+                      resourceRights={resourceRights}
+                      isReadOnly={
+                        isReadOnly ||
+                        ownerItem?.recipientId === item.recipientId
+                      }
+                      onChange={handleChange}
+                      onDeleteItem={handleDeleteItem}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            {onSaveBookmark && (
+              <div className="mt-16">
+                <Button
+                  data-testid="common-user-rights-list-share-bookmark-show-button"
+                  color="tertiary"
+                  leftIcon={<IconBookmark />}
+                  rightIcon={
+                    <IconRafterDown
+                      title={t('show')}
+                      className="w-16 min-w-0"
+                      style={{
+                        transition: 'rotate 0.2s ease-out',
+                        rotate: showBookmarkInput ? '-180deg' : '0deg',
+                      }}
+                    />
+                  }
+                  type="button"
+                  variant="ghost"
+                  className="fw-normal"
+                  onClick={() => toggleBookmarkInput()}
+                >
+                  {t('share.save.sharebookmark')}
+                </Button>
+                {showBookmarkInput && (
+                  <SaveBookmark onSave={handleOnSaveBookmark} />
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    );
+  },
+);
+
+UserRightsList.displayName = 'UserRightsList';

--- a/packages/react/src/components/UserRightsList/UserRightsList.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from 'react-i18next';
 import { IconBookmark, IconRafterDown } from '../../modules/icons/components';
 import { useEdificeClient } from '../../providers';
 import { SharingItem } from '../../types';
+import { getRotateTransitionStyle } from '../../utilities';
 import { Button } from '../Button';
 import { LoadingScreen } from '../LoadingScreen';
 import { VisuallyHidden } from '../VisuallyHidden';
@@ -249,10 +250,7 @@ export const UserRightsList = forwardRef<
                     <IconRafterDown
                       title={t('show')}
                       className="w-16 min-w-0"
-                      style={{
-                        transition: 'rotate 0.2s ease-out',
-                        rotate: showBookmarkInput ? '-180deg' : '0deg',
-                      }}
+                      style={getRotateTransitionStyle(showBookmarkInput)}
                     />
                   }
                   type="button"

--- a/packages/react/src/components/UserRightsList/UserRightsList.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.tsx
@@ -4,23 +4,26 @@
  * and optionally a block to save the configuration as a bookmark.
  * Supports adding bookmarks which appear as collapsible groups of users.
  */
-import { Fragment, forwardRef, useImperativeHandle, useState } from 'react';
+import {
+  Fragment,
+  forwardRef,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useTranslation } from 'react-i18next';
 import { IconBookmark, IconRafterDown } from '../../modules/icons/components';
 import { useEdificeClient } from '../../providers';
 import { Button } from '../Button';
 import { LoadingScreen } from '../LoadingScreen';
-import { SharingItem } from '../UserSearch';
+import { SharingItem } from '../../types';
 import { VisuallyHidden } from '../VisuallyHidden';
-import { useRights } from './hooks/useRights';
+import { useBookmarkEntries } from './hooks/useBookmarkEntries';
+import { createRightsHelpers } from './helpers/rightsHelpers';
+import { useSharingItems } from './hooks/useSharingItems';
 import { SaveBookmark } from './SaveBookmark';
-import {
-  BookmarkInput,
-  BookmarkState,
-  ResourceRightName,
-  ResourceRights,
-  isBookmarkInput,
-} from './types/types';
+import { BookmarkInput, ResourceRights, isBookmarkInput } from './types/types';
 import UserRightsBookmarkRow from './UserRightsBookmarkRow';
 import UserRightsItem from './UserRightsItem';
 
@@ -32,15 +35,15 @@ interface UserRightsListProps {
   isCreating: boolean;
   initialSharings?: SharingItem[];
   onChange: (value: SharingItem[]) => void;
-  onAddItem: (value: SharingItem) => void;
-  onDeleteItem: (value: SharingItem) => void;
+  onAddItems: (value: SharingItem[]) => void;
+  onDeleteItems: (value: SharingItem[]) => void;
   onSaveBookmark?: (
     bookmarkName: string,
     items: SharingItem[],
   ) => Promise<void>;
 }
 
-interface UserRightsListRef {
+export interface UserRightsListRef {
   addItem: (item: SharingItem | BookmarkInput) => void;
 }
 
@@ -57,178 +60,92 @@ export const UserRightsList = forwardRef<
       isCreating = false,
       initialSharings = [],
       onChange,
-      onAddItem,
-      onDeleteItem,
+      onAddItems,
+      onDeleteItems,
       onSaveBookmark,
     },
     ref,
   ) => {
-    const [items, setItems] = useState<SharingItem[]>(initialSharings ?? []);
-    const [bookmarkEntries, setBookmarkEntries] = useState<BookmarkState[]>([]);
     const [showBookmarkInput, setBookmarkInput] = useState<boolean>(false);
+    const tableRef = useRef<HTMLTableElement>(null);
     const { t } = useTranslation();
     const { user } = useEdificeClient();
-    const { applyRight, toggleRight, getOwnerItem } = useRights(resourceRights);
+    const { applyRight, toggleRight, getOwnerItem } = useMemo(
+      () => createRightsHelpers(resourceRights),
+      [resourceRights],
+    );
 
     const ownerItem = getOwnerItem(ownerId, user, isCreating);
 
-    const bookmarkUserIds = new Set(bookmarkEntries.flatMap((b) => b.userIds));
-    const regularItems = items.filter(
-      (i) => !bookmarkUserIds.has(i.recipientId),
+    const sharingItems = useSharingItems({
+      initialSharings,
+      toggleRight,
+      applyRight,
+      onChange,
+      onAddItems,
+      onDeleteItems,
+    });
+
+    const itemsByRecipientId = useMemo(
+      () => new Map(sharingItems.items.map((item) => [item.recipientId, item])),
+      [sharingItems.items],
     );
 
-    const getDefaultPermissions = (): string[] =>
-      Object.entries(resourceRights)
-        .filter(([, def]) => def.default)
-        .map(([name]) => name);
+    const existingRecipientIds = useMemo(
+      () => new Set(itemsByRecipientId.keys()),
+      [itemsByRecipientId],
+    );
 
-    /** Adds a sharing item or a bookmark to the list. */
+    const bookmarks = useBookmarkEntries({
+      resourceRights,
+      existingRecipientIds,
+      toggleRight,
+      addItems: sharingItems.addItems,
+      deleteItemsByIds: sharingItems.deleteItemsByIds,
+      applyRightToIds: sharingItems.applyRightToIds,
+    });
+
+    const regularItems = useMemo(
+      () =>
+        sharingItems.items.filter(
+          (item) => !bookmarks.bookmarkUserIds.has(item.recipientId),
+        ),
+      [sharingItems.items, bookmarks.bookmarkUserIds],
+    );
+
+    const focusTable = () => {
+      tableRef.current?.focus();
+    };
+
     const handleAddItem = (item: SharingItem | BookmarkInput) => {
       if (isBookmarkInput(item)) {
-        handleAddBookmark(item);
+        bookmarks.addBookmark(item);
       } else {
-        setItems((prev) => [...prev, item]);
-        onAddItem(item);
+        sharingItems.addItem(item);
       }
     };
 
-    /** Adds a bookmark: creates user SharingItems and a BookmarkState entry. */
-    const handleAddBookmark = (bookmark: BookmarkInput) => {
-      const defaultPermissions = getDefaultPermissions();
-
-      const newUsers: SharingItem[] = bookmark.users.map((u) => ({
-        recipientId: u.id,
-        recipientType: 'user' as const,
-        displayName: u.displayName,
-        permission: [...defaultPermissions],
-      }));
-
-      const bookmarkState: BookmarkState = {
-        id: bookmark.id,
-        name: bookmark.name,
-        permission: [...defaultPermissions],
-        userIds: bookmark.users.map((u) => u.id),
-        isExpanded: false,
-      };
-
-      setItems((prev) => {
-        const nextItems = [...prev, ...newUsers];
-        onChange(nextItems);
-        return nextItems;
-      });
-      setBookmarkEntries((prev) => [...prev, bookmarkState]);
-
-      newUsers.forEach((u) => onAddItem(u));
-    };
-
-    /** Removes a sharing from the list and notifies the parent. */
     const handleDeleteItem = (item: SharingItem) => {
-      setItems((prev) => {
-        const nextItems = prev.filter(
-          (i) => i.recipientId !== item.recipientId,
-        );
-        onChange(nextItems);
-        return nextItems;
-      });
-      onDeleteItem(item);
+      sharingItems.deleteItem(item);
+      focusTable();
     };
 
-    /** Removes a bookmark and all its associated users. */
     const handleDeleteBookmark = (bookmarkId: string) => {
-      const bookmark = bookmarkEntries.find((b) => b.id === bookmarkId);
-      if (!bookmark) return;
-
-      const userIdsToRemove = new Set(bookmark.userIds);
-      const removedItems = items.filter((i) =>
-        userIdsToRemove.has(i.recipientId),
-      );
-
-      setItems((prev) => {
-        const nextItems = prev.filter(
-          (i) => !userIdsToRemove.has(i.recipientId),
-        );
-        onChange(nextItems);
-        return nextItems;
-      });
-      setBookmarkEntries((prev) => prev.filter((b) => b.id !== bookmarkId));
-
-      removedItems.forEach((item) => onDeleteItem(item));
+      bookmarks.deleteBookmark(bookmarkId);
+      focusTable();
     };
 
-    /** Updates a sharing's permissions (toggle right) and notifies the parent. */
-    const handleChange = (item: SharingItem, rightName: ResourceRightName) => {
-      const updatedItem = toggleRight(item, rightName);
-      setItems((prevItems) => {
-        const nextItems = prevItems.map((prevItem) =>
-          prevItem.recipientId === item.recipientId ? updatedItem : prevItem,
-        );
-        onChange(nextItems);
-        return nextItems;
-      });
-    };
-
-    /** Toggles a right on a bookmark row, applying the change to all its users. */
-    const handleBookmarkRightChange = (
-      bookmarkId: string,
-      rightName: ResourceRightName,
-    ) => {
-      const bookmark = bookmarkEntries.find((b) => b.id === bookmarkId);
-      if (!bookmark) return;
-
-      const hasRight = bookmark.permission.includes(rightName);
-      const shouldAdd = !hasRight;
-
-      // Toggle the bookmark's own permission display
-      const fakeItem: SharingItem = {
-        recipientId: bookmark.id,
-        recipientType: 'bookmark',
-        displayName: bookmark.name,
-        permission: bookmark.permission,
-      };
-      const toggledBookmark = toggleRight(fakeItem, rightName);
-
-      setBookmarkEntries((prev) =>
-        prev.map((b) =>
-          b.id === bookmarkId
-            ? { ...b, permission: toggledBookmark.permission }
-            : b,
-        ),
-      );
-
-      // Apply the same change to all users of this bookmark
-      const userIdsSet = new Set(bookmark.userIds);
-      setItems((prev) => {
-        const nextItems = prev.map((item) => {
-          if (!userIdsSet.has(item.recipientId)) return item;
-          return applyRight(item, rightName, shouldAdd);
-        });
-        onChange(nextItems);
-        return nextItems;
-      });
-    };
-
-    /** Toggles the expanded/collapsed state of a bookmark. */
-    const handleToggleBookmarkExpand = (bookmarkId: string) => {
-      setBookmarkEntries((prev) =>
-        prev.map((b) =>
-          b.id === bookmarkId ? { ...b, isExpanded: !b.isExpanded } : b,
-        ),
-      );
-    };
-
-    /** Triggers bookmark save with the entered name and current list. */
     const handleOnSaveBookmark = (bookmarkName: string) => {
       if (!onSaveBookmark) {
         return Promise.resolve();
       }
-      return onSaveBookmark(bookmarkName, items);
+      return onSaveBookmark(bookmarkName, sharingItems.items);
     };
 
     const toggleBookmarkInput = () => {
       setBookmarkInput((prev) => !prev);
     };
 
-    /** Exposes addItem so a sharing or bookmark can be added from outside (e.g. via ref). */
     useImperativeHandle(ref, () => ({
       addItem: handleAddItem,
     }));
@@ -240,7 +157,12 @@ export const UserRightsList = forwardRef<
         ) : (
           <>
             <div className="table-responsive">
-              <table className="table border align-middle">
+              <table
+                ref={tableRef}
+                tabIndex={-1}
+                className="table border align-middle"
+                aria-label="Liste des droits de partage"
+              >
                 <thead>
                   <tr>
                     <th scope="col" className="w-32">
@@ -272,21 +194,19 @@ export const UserRightsList = forwardRef<
                     isReadOnly={true}
                   />
                   {/* Bookmark entries with their associated users. */}
-                  {bookmarkEntries.map((bookmark) => (
+                  {bookmarks.bookmarkEntries.map((bookmark) => (
                     <Fragment key={bookmark.id}>
                       <UserRightsBookmarkRow
                         bookmark={bookmark}
                         resourceRights={resourceRights}
                         isReadOnly={isReadOnly}
-                        onToggleRight={handleBookmarkRightChange}
+                        onToggleRight={bookmarks.toggleBookmarkRight}
                         onDelete={handleDeleteBookmark}
-                        onToggleExpand={handleToggleBookmarkExpand}
+                        onToggleExpand={bookmarks.toggleExpand}
                       />
                       {bookmark.isExpanded &&
                         bookmark.userIds.map((userId) => {
-                          const item = items.find(
-                            (i) => i.recipientId === userId,
-                          );
+                          const item = itemsByRecipientId.get(userId);
                           if (!item) return null;
                           return (
                             <UserRightsItem
@@ -296,7 +216,8 @@ export const UserRightsList = forwardRef<
                               isReadOnly={isReadOnly}
                               isDeletable={false}
                               rowClassName="bg-light"
-                              onChange={handleChange}
+                              bookmarkName={bookmark.name}
+                              onChange={sharingItems.changeRight}
                             />
                           );
                         })}
@@ -312,7 +233,7 @@ export const UserRightsList = forwardRef<
                         isReadOnly ||
                         ownerItem?.recipientId === item.recipientId
                       }
-                      onChange={handleChange}
+                      onChange={sharingItems.changeRight}
                       onDeleteItem={handleDeleteItem}
                     />
                   ))}

--- a/packages/react/src/components/UserRightsList/UserRightsList.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.tsx
@@ -15,12 +15,12 @@ import {
 import { useTranslation } from 'react-i18next';
 import { IconBookmark, IconRafterDown } from '../../modules/icons/components';
 import { useEdificeClient } from '../../providers';
+import { SharingItem } from '../../types';
 import { Button } from '../Button';
 import { LoadingScreen } from '../LoadingScreen';
-import { SharingItem } from '../../types';
 import { VisuallyHidden } from '../VisuallyHidden';
-import { useBookmarkEntries } from './hooks/useBookmarkEntries';
 import { createRightsHelpers } from './helpers/rightsHelpers';
+import { useBookmarkEntries } from './hooks/useBookmarkEntries';
 import { useSharingItems } from './hooks/useSharingItems';
 import { SaveBookmark } from './SaveBookmark';
 import { BookmarkInput, ResourceRights, isBookmarkInput } from './types/types';
@@ -161,7 +161,6 @@ export const UserRightsList = forwardRef<
                 ref={tableRef}
                 tabIndex={-1}
                 className="table border align-middle"
-                aria-label="Liste des droits de partage"
               >
                 <thead>
                   <tr>

--- a/packages/react/src/components/UserRightsList/UserRightsList.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.tsx
@@ -2,8 +2,9 @@
  * Sharing rights list for a resource.
  * Displays the owner, shared users/groups with their permissions,
  * and optionally a block to save the configuration as a bookmark.
+ * Supports adding bookmarks which appear as collapsible groups of users.
  */
-import { forwardRef, useImperativeHandle, useState } from 'react';
+import { Fragment, forwardRef, useImperativeHandle, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { IconBookmark, IconRafterDown } from '../../modules/icons/components';
 import { useEdificeClient } from '../../providers';
@@ -13,7 +14,14 @@ import { SharingItem } from '../UserSearch';
 import { VisuallyHidden } from '../VisuallyHidden';
 import { useRights } from './hooks/useRights';
 import { SaveBookmark } from './SaveBookmark';
-import { ResourceRightName, ResourceRights } from './types/types';
+import {
+  BookmarkInput,
+  BookmarkState,
+  ResourceRightName,
+  ResourceRights,
+  isBookmarkInput,
+} from './types/types';
+import UserRightsBookmarkRow from './UserRightsBookmarkRow';
 import UserRightsItem from './UserRightsItem';
 
 interface UserRightsListProps {
@@ -33,7 +41,7 @@ interface UserRightsListProps {
 }
 
 interface UserRightsListRef {
-  addItem: (item: SharingItem) => void;
+  addItem: (item: SharingItem | BookmarkInput) => void;
 }
 
 export const UserRightsList = forwardRef<
@@ -56,25 +64,95 @@ export const UserRightsList = forwardRef<
     ref,
   ) => {
     const [items, setItems] = useState<SharingItem[]>(initialSharings ?? []);
+    const [bookmarkEntries, setBookmarkEntries] = useState<BookmarkState[]>([]);
     const [showBookmarkInput, setBookmarkInput] = useState<boolean>(false);
     const { t } = useTranslation();
     const { user } = useEdificeClient();
-    const { toggleRight, getOwnerItem } = useRights(resourceRights);
+    const { applyRight, toggleRight, getOwnerItem } = useRights(resourceRights);
 
     const ownerItem = getOwnerItem(ownerId, user, isCreating);
 
-    /** Adds a sharing to the list and notifies the parent. */
-    const handleAddItem = (item: SharingItem) => {
-      setItems((prev) => [...prev, item]);
-      onAddItem(item);
+    const bookmarkUserIds = new Set(bookmarkEntries.flatMap((b) => b.userIds));
+    const regularItems = items.filter(
+      (i) => !bookmarkUserIds.has(i.recipientId),
+    );
+
+    const getDefaultPermissions = (): string[] =>
+      Object.entries(resourceRights)
+        .filter(([, def]) => def.default)
+        .map(([name]) => name);
+
+    /** Adds a sharing item or a bookmark to the list. */
+    const handleAddItem = (item: SharingItem | BookmarkInput) => {
+      if (isBookmarkInput(item)) {
+        handleAddBookmark(item);
+      } else {
+        setItems((prev) => [...prev, item]);
+        onAddItem(item);
+      }
+    };
+
+    /** Adds a bookmark: creates user SharingItems and a BookmarkState entry. */
+    const handleAddBookmark = (bookmark: BookmarkInput) => {
+      const defaultPermissions = getDefaultPermissions();
+
+      const newUsers: SharingItem[] = bookmark.users.map((u) => ({
+        recipientId: u.id,
+        recipientType: 'user' as const,
+        displayName: u.displayName,
+        permission: [...defaultPermissions],
+      }));
+
+      const bookmarkState: BookmarkState = {
+        id: bookmark.id,
+        name: bookmark.name,
+        permission: [...defaultPermissions],
+        userIds: bookmark.users.map((u) => u.id),
+        isExpanded: false,
+      };
+
+      setItems((prev) => {
+        const nextItems = [...prev, ...newUsers];
+        onChange(nextItems);
+        return nextItems;
+      });
+      setBookmarkEntries((prev) => [...prev, bookmarkState]);
+
+      newUsers.forEach((u) => onAddItem(u));
     };
 
     /** Removes a sharing from the list and notifies the parent. */
     const handleDeleteItem = (item: SharingItem) => {
-      setItems((prev) =>
-        prev.filter((i) => i.recipientId !== item.recipientId),
-      );
+      setItems((prev) => {
+        const nextItems = prev.filter(
+          (i) => i.recipientId !== item.recipientId,
+        );
+        onChange(nextItems);
+        return nextItems;
+      });
       onDeleteItem(item);
+    };
+
+    /** Removes a bookmark and all its associated users. */
+    const handleDeleteBookmark = (bookmarkId: string) => {
+      const bookmark = bookmarkEntries.find((b) => b.id === bookmarkId);
+      if (!bookmark) return;
+
+      const userIdsToRemove = new Set(bookmark.userIds);
+      const removedItems = items.filter((i) =>
+        userIdsToRemove.has(i.recipientId),
+      );
+
+      setItems((prev) => {
+        const nextItems = prev.filter(
+          (i) => !userIdsToRemove.has(i.recipientId),
+        );
+        onChange(nextItems);
+        return nextItems;
+      });
+      setBookmarkEntries((prev) => prev.filter((b) => b.id !== bookmarkId));
+
+      removedItems.forEach((item) => onDeleteItem(item));
     };
 
     /** Updates a sharing's permissions (toggle right) and notifies the parent. */
@@ -89,6 +167,55 @@ export const UserRightsList = forwardRef<
       });
     };
 
+    /** Toggles a right on a bookmark row, applying the change to all its users. */
+    const handleBookmarkRightChange = (
+      bookmarkId: string,
+      rightName: ResourceRightName,
+    ) => {
+      const bookmark = bookmarkEntries.find((b) => b.id === bookmarkId);
+      if (!bookmark) return;
+
+      const hasRight = bookmark.permission.includes(rightName);
+      const shouldAdd = !hasRight;
+
+      // Toggle the bookmark's own permission display
+      const fakeItem: SharingItem = {
+        recipientId: bookmark.id,
+        recipientType: 'bookmark',
+        displayName: bookmark.name,
+        permission: bookmark.permission,
+      };
+      const toggledBookmark = toggleRight(fakeItem, rightName);
+
+      setBookmarkEntries((prev) =>
+        prev.map((b) =>
+          b.id === bookmarkId
+            ? { ...b, permission: toggledBookmark.permission }
+            : b,
+        ),
+      );
+
+      // Apply the same change to all users of this bookmark
+      const userIdsSet = new Set(bookmark.userIds);
+      setItems((prev) => {
+        const nextItems = prev.map((item) => {
+          if (!userIdsSet.has(item.recipientId)) return item;
+          return applyRight(item, rightName, shouldAdd);
+        });
+        onChange(nextItems);
+        return nextItems;
+      });
+    };
+
+    /** Toggles the expanded/collapsed state of a bookmark. */
+    const handleToggleBookmarkExpand = (bookmarkId: string) => {
+      setBookmarkEntries((prev) =>
+        prev.map((b) =>
+          b.id === bookmarkId ? { ...b, isExpanded: !b.isExpanded } : b,
+        ),
+      );
+    };
+
     /** Triggers bookmark save with the entered name and current list. */
     const handleOnSaveBookmark = (bookmarkName: string) => {
       if (!onSaveBookmark) {
@@ -101,7 +228,7 @@ export const UserRightsList = forwardRef<
       setBookmarkInput((prev) => !prev);
     };
 
-    /** Exposes addItem so a sharing can be added from outside (e.g. via ref). */
+    /** Exposes addItem so a sharing or bookmark can be added from outside (e.g. via ref). */
     useImperativeHandle(ref, () => ({
       addItem: handleAddItem,
     }));
@@ -137,14 +264,46 @@ export const UserRightsList = forwardRef<
                   </tr>
                 </thead>
                 <tbody>
-                  {/* Add a disabled line about the resource owner. */}
+                  {/* Owner row (always read-only). */}
                   <UserRightsItem
                     key={ownerItem?.recipientId}
                     item={ownerItem}
                     resourceRights={resourceRights}
                     isReadOnly={true}
                   />
-                  {items.map((item) => (
+                  {/* Bookmark entries with their associated users. */}
+                  {bookmarkEntries.map((bookmark) => (
+                    <Fragment key={bookmark.id}>
+                      <UserRightsBookmarkRow
+                        bookmark={bookmark}
+                        resourceRights={resourceRights}
+                        isReadOnly={isReadOnly}
+                        onToggleRight={handleBookmarkRightChange}
+                        onDelete={handleDeleteBookmark}
+                        onToggleExpand={handleToggleBookmarkExpand}
+                      />
+                      {bookmark.isExpanded &&
+                        bookmark.userIds.map((userId) => {
+                          const item = items.find(
+                            (i) => i.recipientId === userId,
+                          );
+                          if (!item) return null;
+                          return (
+                            <UserRightsItem
+                              key={item.recipientId}
+                              item={item}
+                              resourceRights={resourceRights}
+                              isReadOnly={isReadOnly}
+                              isDeletable={false}
+                              rowClassName="bg-light"
+                              onChange={handleChange}
+                            />
+                          );
+                        })}
+                    </Fragment>
+                  ))}
+                  {/* Regular (non-bookmark) items. */}
+                  {regularItems.map((item) => (
                     <UserRightsItem
                       key={item.recipientId}
                       item={item}

--- a/packages/react/src/components/UserRightsList/helpers/rightsHelpers.tsx
+++ b/packages/react/src/components/UserRightsList/helpers/rightsHelpers.tsx
@@ -33,7 +33,7 @@ export const createRightsHelpers = (resourceRights: ResourceRights) => {
     return {
       recipientId: user.userId ?? '',
       recipientType: 'user',
-      displayName: user.firstName + ' ' + user.lastName,
+      displayName: user.username,
       permission: Object.keys(resourceRights),
     };
   };

--- a/packages/react/src/components/UserRightsList/helpers/rightsHelpers.tsx
+++ b/packages/react/src/components/UserRightsList/helpers/rightsHelpers.tsx
@@ -1,8 +1,13 @@
+/**
+ * Pure utility functions for permission manipulation.
+ * Handles right toggle with requires/excludes logic and transitive removal.
+ */
 import { IUserInfo } from '@edifice.io/client';
-import { SharingItem } from 'src/components/UserSearch';
+import { SharingItem } from '../../../types';
 import { ResourceRightName, ResourceRights } from '../types/types';
 
-export const useRights = (resourceRights: ResourceRights) => {
+export const createRightsHelpers = (resourceRights: ResourceRights) => {
+  /** Builds a SharingItem representing the resource owner with all rights. */
   const getOwnerItem = (
     ownerId: string,
     user: IUserInfo | undefined,
@@ -26,13 +31,18 @@ export const useRights = (resourceRights: ResourceRights) => {
 
   const createOwnerItem = (user: IUserInfo): SharingItem => {
     return {
-      recipientId: user?.userId ?? '',
+      recipientId: user.userId ?? '',
       recipientType: 'user',
-      displayName: user?.firstName + ' ' + user?.lastName,
+      displayName: user.firstName + ' ' + user.lastName,
       permission: Object.keys(resourceRights),
     };
   };
 
+  /**
+   * Sets a right on or off for an item.
+   * When adding: includes required rights and removes excluded ones.
+   * When removing: transitively removes all rights that depend on the removed one.
+   */
   const applyRight = (
     item: SharingItem,
     rightName: ResourceRightName,
@@ -46,29 +56,29 @@ export const useRights = (resourceRights: ResourceRights) => {
       newPermission = [
         ...new Set([
           ...item.permission.filter(
-            (p) => !excludes.includes(p as ResourceRightName),
+            (perm) => !excludes.includes(perm as ResourceRightName),
           ),
           ...requires,
           rightName,
         ]),
       ];
     } else {
-      // Retrait : retirer ce droit + tous les droits qui en dépendent (transitivité)
+      // Collect this right + all rights that transitively depend on it
       const toRemove = new Set<string>([rightName]);
       let changed = true;
       while (changed) {
         changed = false;
-        for (const [name, def] of Object.entries(resourceRights)) {
+        for (const [name, definition] of Object.entries(resourceRights)) {
           if (
             !toRemove.has(name) &&
-            def.requires.some((r) => toRemove.has(r))
+            definition.requires.some((required) => toRemove.has(required))
           ) {
             toRemove.add(name);
             changed = true;
           }
         }
       }
-      newPermission = item.permission.filter((p) => !toRemove.has(p));
+      newPermission = item.permission.filter((perm) => !toRemove.has(perm));
     }
 
     return {
@@ -77,6 +87,7 @@ export const useRights = (resourceRights: ResourceRights) => {
     };
   };
 
+  /** Toggles a right: adds it if absent, removes it (with dependents) if present. */
   const toggleRight = (
     item: SharingItem,
     rightName: ResourceRightName,

--- a/packages/react/src/components/UserRightsList/hooks/useBookmarkEntries.tsx
+++ b/packages/react/src/components/UserRightsList/hooks/useBookmarkEntries.tsx
@@ -1,0 +1,141 @@
+/**
+ * Hook managing bookmark entries in the rights list.
+ * A bookmark groups multiple users: batch right toggle, bulk delete,
+ * and expand/collapse are handled here. Item mutations are delegated
+ * to the sharing items hook via the provided callbacks.
+ */
+import { useMemo, useState } from 'react';
+import { SharingItem } from '../../../types';
+import {
+  BookmarkInput,
+  BookmarkState,
+  ResourceRightName,
+  ResourceRights,
+} from '../types/types';
+
+interface UseBookmarkEntriesParams {
+  resourceRights: ResourceRights;
+  existingRecipientIds: Set<string>;
+  toggleRight: (item: SharingItem, rightName: ResourceRightName) => SharingItem;
+  addItems: (items: SharingItem[]) => void;
+  deleteItemsByIds: (ids: Set<string>) => void;
+  applyRightToIds: (
+    ids: Set<string>,
+    rightName: ResourceRightName,
+    shouldAdd: boolean,
+  ) => void;
+}
+
+export const useBookmarkEntries = ({
+  resourceRights,
+  existingRecipientIds,
+  toggleRight,
+  addItems,
+  deleteItemsByIds,
+  applyRightToIds,
+}: UseBookmarkEntriesParams) => {
+  const [bookmarkEntries, setBookmarkEntries] = useState<BookmarkState[]>([]);
+
+  const bookmarkUserIds = useMemo(
+    () => new Set(bookmarkEntries.flatMap((entry) => entry.userIds)),
+    [bookmarkEntries],
+  );
+
+  const getDefaultPermissions = (): string[] =>
+    Object.entries(resourceRights)
+      .filter(([, definition]) => definition.default)
+      .map(([name]) => name);
+
+  /** Converts a BookmarkInput into a BookmarkState and creates SharingItems for its users.
+   *  Ignores if bookmark already exists. Skips users already present in the items list. */
+  const addBookmark = (bookmark: BookmarkInput) => {
+    if (bookmarkEntries.some((entry) => entry.id === bookmark.id)) return;
+
+    const defaultPermissions = getDefaultPermissions();
+
+    // Only include users not already present in the sharing list
+    const newBookmarkUsers = bookmark.users.filter(
+      (bookmarkUser) => !existingRecipientIds.has(bookmarkUser.id),
+    );
+
+    const newUsers: SharingItem[] = newBookmarkUsers.map((bookmarkUser) => ({
+      recipientId: bookmarkUser.id,
+      recipientType: 'user' as const,
+      displayName: bookmarkUser.displayName,
+      permission: [...defaultPermissions],
+    }));
+
+    const bookmarkState: BookmarkState = {
+      id: bookmark.id,
+      name: bookmark.name,
+      permission: [...defaultPermissions],
+      userIds: newBookmarkUsers.map((bookmarkUser) => bookmarkUser.id),
+      isExpanded: false,
+    };
+
+    setBookmarkEntries((prev) => [...prev, bookmarkState]);
+    addItems(newUsers);
+  };
+
+  /** Removes a bookmark and deletes all its associated users from the items list. */
+  const deleteBookmark = (bookmarkId: string) => {
+    const bookmark = bookmarkEntries.find((entry) => entry.id === bookmarkId);
+    if (!bookmark) return;
+
+    setBookmarkEntries((prev) =>
+      prev.filter((entry) => entry.id !== bookmarkId),
+    );
+    deleteItemsByIds(new Set(bookmark.userIds));
+  };
+
+  /** Toggles a right on the bookmark row and applies the same change to all its users. */
+  const toggleBookmarkRight = (
+    bookmarkId: string,
+    rightName: ResourceRightName,
+  ) => {
+    const bookmark = bookmarkEntries.find((entry) => entry.id === bookmarkId);
+    if (!bookmark) return;
+
+    const hasRight = bookmark.permission.includes(rightName);
+    const shouldAdd = !hasRight;
+
+    // Use toggleRight to compute the bookmark's new permission set (with requires/excludes)
+    const bookmarkAsSharingItem: SharingItem = {
+      recipientId: bookmark.id,
+      recipientType: 'bookmark',
+      displayName: bookmark.name,
+      permission: bookmark.permission,
+    };
+    const toggledBookmark = toggleRight(bookmarkAsSharingItem, rightName);
+
+    setBookmarkEntries((prev) =>
+      prev.map((entry) =>
+        entry.id === bookmarkId
+          ? { ...entry, permission: toggledBookmark.permission }
+          : entry,
+      ),
+    );
+
+    applyRightToIds(new Set(bookmark.userIds), rightName, shouldAdd);
+  };
+
+  /** Toggles the expanded/collapsed state of a bookmark. */
+  const toggleExpand = (bookmarkId: string) => {
+    setBookmarkEntries((prev) =>
+      prev.map((entry) =>
+        entry.id === bookmarkId
+          ? { ...entry, isExpanded: !entry.isExpanded }
+          : entry,
+      ),
+    );
+  };
+
+  return {
+    bookmarkEntries,
+    bookmarkUserIds,
+    addBookmark,
+    deleteBookmark,
+    toggleBookmarkRight,
+    toggleExpand,
+  };
+};

--- a/packages/react/src/components/UserRightsList/hooks/useRights.tsx
+++ b/packages/react/src/components/UserRightsList/hooks/useRights.tsx
@@ -1,0 +1,73 @@
+import { IUserInfo } from '@edifice.io/client';
+import { SharingItem } from 'src/components/UserSearch';
+import { ResourceRightName, ResourceRights } from '../types/types';
+
+export const useRights = (resourceRights: ResourceRights) => {
+  const getOwnerItem = (
+    ownerId: string,
+    user: IUserInfo | undefined,
+    isCreating: boolean,
+  ): SharingItem => {
+    if ((!ownerId && user && isCreating) || (user && ownerId === user.userId)) {
+      return createOwnerItem(user);
+    }
+
+    if (!ownerId) {
+      throw new Error('Owner ID or user is required');
+    }
+
+    return {
+      recipientId: ownerId,
+      recipientType: 'user',
+      displayName: 'owner',
+      permission: Object.keys(resourceRights),
+    };
+  };
+
+  const createOwnerItem = (user: IUserInfo): SharingItem => {
+    return {
+      recipientId: user?.userId ?? '',
+      recipientType: 'user',
+      displayName: user?.firstName + ' ' + user?.lastName,
+      permission: Object.keys(resourceRights),
+    };
+  };
+
+  const toggleRight = (
+    item: SharingItem,
+    rightName: ResourceRightName,
+  ): SharingItem => {
+    const { requires, excludes } = resourceRights[rightName];
+    const hasRight = item.permission.includes(rightName);
+    const addRight = !hasRight;
+
+    let newPermission: string[];
+
+    if (addRight) {
+      // Ajout : retirer les excludes, ajouter les requires + le droit sélectionné
+      newPermission = [
+        ...new Set([
+          ...item.permission.filter(
+            (p) => !excludes.includes(p as ResourceRightName),
+          ),
+          ...requires,
+          rightName,
+        ]),
+      ];
+    } else {
+      // Retrait : seul ce droit est retiré
+      newPermission = item.permission.filter((p) => p !== rightName);
+    }
+
+    return {
+      ...item,
+      permission: newPermission,
+    };
+  };
+
+  return {
+    toggleRight,
+    createOwnerItem,
+    getOwnerItem,
+  };
+};

--- a/packages/react/src/components/UserRightsList/hooks/useRights.tsx
+++ b/packages/react/src/components/UserRightsList/hooks/useRights.tsx
@@ -33,18 +33,16 @@ export const useRights = (resourceRights: ResourceRights) => {
     };
   };
 
-  const toggleRight = (
+  const applyRight = (
     item: SharingItem,
     rightName: ResourceRightName,
+    add: boolean,
   ): SharingItem => {
     const { requires, excludes } = resourceRights[rightName];
-    const hasRight = item.permission.includes(rightName);
-    const addRight = !hasRight;
 
     let newPermission: string[];
 
-    if (addRight) {
-      // Ajout : retirer les excludes, ajouter les requires + le droit sélectionné
+    if (add) {
       newPermission = [
         ...new Set([
           ...item.permission.filter(
@@ -55,8 +53,22 @@ export const useRights = (resourceRights: ResourceRights) => {
         ]),
       ];
     } else {
-      // Retrait : seul ce droit est retiré
-      newPermission = item.permission.filter((p) => p !== rightName);
+      // Retrait : retirer ce droit + tous les droits qui en dépendent (transitivité)
+      const toRemove = new Set<string>([rightName]);
+      let changed = true;
+      while (changed) {
+        changed = false;
+        for (const [name, def] of Object.entries(resourceRights)) {
+          if (
+            !toRemove.has(name) &&
+            def.requires.some((r) => toRemove.has(r))
+          ) {
+            toRemove.add(name);
+            changed = true;
+          }
+        }
+      }
+      newPermission = item.permission.filter((p) => !toRemove.has(p));
     }
 
     return {
@@ -65,7 +77,16 @@ export const useRights = (resourceRights: ResourceRights) => {
     };
   };
 
+  const toggleRight = (
+    item: SharingItem,
+    rightName: ResourceRightName,
+  ): SharingItem => {
+    const hasRight = item.permission.includes(rightName);
+    return applyRight(item, rightName, !hasRight);
+  };
+
   return {
+    applyRight,
     toggleRight,
     createOwnerItem,
     getOwnerItem,

--- a/packages/react/src/components/UserRightsList/hooks/useSharingItems.tsx
+++ b/packages/react/src/components/UserRightsList/hooks/useSharingItems.tsx
@@ -101,10 +101,11 @@ export const useSharingItems = ({
     shouldAdd: boolean,
   ) => {
     setItems((prev) => {
-      const nextItems = prev.map((sharing) => {
-        if (!ids.has(sharing.recipientId)) return sharing;
-        return applyRight(sharing, rightName, shouldAdd);
-      });
+      const nextItems = prev.map((sharing) =>
+        ids.has(sharing.recipientId)
+          ? applyRight(sharing, rightName, shouldAdd)
+          : sharing,
+      );
       onChange(nextItems);
       return nextItems;
     });

--- a/packages/react/src/components/UserRightsList/hooks/useSharingItems.tsx
+++ b/packages/react/src/components/UserRightsList/hooks/useSharingItems.tsx
@@ -1,0 +1,122 @@
+/**
+ * Hook managing the list of SharingItems (users/groups) and their permissions.
+ * Handles add, delete, individual right toggle, and batch right application.
+ */
+import { useState } from 'react';
+import { SharingItem } from '../../../types';
+import { ResourceRightName } from '../types/types';
+
+interface UseSharingItemsParams {
+  initialSharings: SharingItem[];
+  toggleRight: (item: SharingItem, rightName: ResourceRightName) => SharingItem;
+  applyRight: (
+    item: SharingItem,
+    rightName: ResourceRightName,
+    add: boolean,
+  ) => SharingItem;
+  onChange: (value: SharingItem[]) => void;
+  onAddItems: (value: SharingItem[]) => void;
+  onDeleteItems: (value: SharingItem[]) => void;
+}
+
+export const useSharingItems = ({
+  initialSharings,
+  toggleRight,
+  applyRight,
+  onChange,
+  onAddItems,
+  onDeleteItems,
+}: UseSharingItemsParams) => {
+  const [items, setItems] = useState<SharingItem[]>(initialSharings ?? []);
+
+  /** Adds a single item, ignores if recipientId already exists. */
+  const addItem = (item: SharingItem) => {
+    setItems((prev) => {
+      const existingIds = new Set(prev.map((sharing) => sharing.recipientId));
+      if (existingIds.has(item.recipientId)) return prev;
+      const nextItems = [...prev, item];
+      onChange(nextItems);
+      onAddItems([item]);
+      return nextItems;
+    });
+  };
+
+  /** Adds multiple items at once, filtering out duplicates. */
+  const addItems = (newItems: SharingItem[]) => {
+    setItems((prev) => {
+      const existingIds = new Set(prev.map((sharing) => sharing.recipientId));
+      const uniqueItems = newItems.filter(
+        (newItem) => !existingIds.has(newItem.recipientId),
+      );
+      if (uniqueItems.length === 0) return prev;
+      const nextItems = [...prev, ...uniqueItems];
+      onChange(nextItems);
+      onAddItems(uniqueItems);
+      return nextItems;
+    });
+  };
+
+  /** Removes a single item by recipientId. */
+  const deleteItem = (item: SharingItem) => {
+    setItems((prev) => {
+      const nextItems = prev.filter(
+        (sharing) => sharing.recipientId !== item.recipientId,
+      );
+      if (nextItems.length === prev.length) return prev;
+      onChange(nextItems);
+      onDeleteItems([item]);
+      return nextItems;
+    });
+  };
+
+  /** Removes multiple items by their recipientIds (used when deleting a bookmark). */
+  const deleteItemsByIds = (ids: Set<string>) => {
+    setItems((prev) => {
+      const nextItems = prev.filter((sharing) => !ids.has(sharing.recipientId));
+      const removedItems = prev.filter((sharing) =>
+        ids.has(sharing.recipientId),
+      );
+      onChange(nextItems);
+      onDeleteItems(removedItems);
+      return nextItems;
+    });
+  };
+
+  /** Toggles a single right on a specific item. */
+  const changeRight = (item: SharingItem, rightName: ResourceRightName) => {
+    const updatedItem = toggleRight(item, rightName);
+    setItems((prevItems) => {
+      const nextItems = prevItems.map((prevItem) =>
+        prevItem.recipientId === item.recipientId ? updatedItem : prevItem,
+      );
+      onChange(nextItems);
+      return nextItems;
+    });
+  };
+
+  /** Forces a right on/off for a set of items (used for bookmark batch toggle). */
+  const applyRightToIds = (
+    ids: Set<string>,
+    rightName: ResourceRightName,
+    shouldAdd: boolean,
+  ) => {
+    setItems((prev) => {
+      const nextItems = prev.map((sharing) => {
+        if (!ids.has(sharing.recipientId)) return sharing;
+        return applyRight(sharing, rightName, shouldAdd);
+      });
+      onChange(nextItems);
+      return nextItems;
+    });
+  };
+
+  return {
+    items,
+    addItem,
+    addItems,
+    deleteItem,
+    deleteItemsByIds,
+    changeRight,
+    applyRightToIds,
+  };
+};

--- a/packages/react/src/components/UserRightsList/index.ts
+++ b/packages/react/src/components/UserRightsList/index.ts
@@ -1,0 +1,1 @@
+export * from './UserRightsList';

--- a/packages/react/src/components/UserRightsList/index.ts
+++ b/packages/react/src/components/UserRightsList/index.ts
@@ -1,1 +1,2 @@
 export * from './UserRightsList';
+export type { BookmarkInput, BookmarkUser } from './types/types';

--- a/packages/react/src/components/UserRightsList/types/types.tsx
+++ b/packages/react/src/components/UserRightsList/types/types.tsx
@@ -3,6 +3,7 @@
  * Liste des rights pour une resource
  */
 
+import type { SharingItem } from '../../../types';
 export type { SearchResultType, SharingItem } from '../../../types';
 
 export type ResourceRightName =

--- a/packages/react/src/components/UserRightsList/types/types.tsx
+++ b/packages/react/src/components/UserRightsList/types/types.tsx
@@ -27,3 +27,32 @@ export interface SharingItem {
 }
 
 export type SearchResultType = 'user' | 'group' | 'bookmark';
+
+export interface BookmarkUser {
+  id: string;
+  displayName: string;
+  profile?: string;
+  activationCode?: boolean;
+}
+
+export interface BookmarkInput {
+  id: string;
+  name: string;
+  notVisibleCount?: number;
+  groups?: { id: string; displayName: string }[];
+  users: BookmarkUser[];
+}
+
+export interface BookmarkState {
+  id: string;
+  name: string;
+  permission: string[];
+  userIds: string[];
+  isExpanded: boolean;
+}
+
+export function isBookmarkInput(
+  item: SharingItem | BookmarkInput,
+): item is BookmarkInput {
+  return 'users' in item && Array.isArray((item as BookmarkInput).users);
+}

--- a/packages/react/src/components/UserRightsList/types/types.tsx
+++ b/packages/react/src/components/UserRightsList/types/types.tsx
@@ -1,0 +1,29 @@
+/**
+ * Resource Rights
+ * Liste des rights pour une resource
+ */
+
+export type ResourceRightName =
+  | 'read'
+  | 'contrib'
+  | 'publish'
+  | 'manager'
+  | 'comment';
+
+export type ResourceRightDefinition = {
+  priority: number;
+  default: boolean;
+  requires: ResourceRightName[];
+  excludes: ResourceRightName[];
+};
+
+export type ResourceRights = Record<ResourceRightName, ResourceRightDefinition>;
+
+export interface SharingItem {
+  recipientId: string;
+  recipientType: SearchResultType;
+  permission: string[];
+  displayName: string;
+}
+
+export type SearchResultType = 'user' | 'group' | 'bookmark';

--- a/packages/react/src/components/UserRightsList/types/types.tsx
+++ b/packages/react/src/components/UserRightsList/types/types.tsx
@@ -3,6 +3,8 @@
  * Liste des rights pour une resource
  */
 
+export type { SearchResultType, SharingItem } from '../../../types';
+
 export type ResourceRightName =
   | 'read'
   | 'contrib'
@@ -18,15 +20,6 @@ export type ResourceRightDefinition = {
 };
 
 export type ResourceRights = Record<ResourceRightName, ResourceRightDefinition>;
-
-export interface SharingItem {
-  recipientId: string;
-  recipientType: SearchResultType;
-  permission: string[];
-  displayName: string;
-}
-
-export type SearchResultType = 'user' | 'group' | 'bookmark';
 
 export interface BookmarkUser {
   id: string;

--- a/packages/react/src/components/UserSearch/UserSearch.spec.tsx
+++ b/packages/react/src/components/UserSearch/UserSearch.spec.tsx
@@ -1,6 +1,7 @@
-import { act, fireEvent, render, screen, waitFor } from '~/setup';
 import { createRef } from 'react';
-import { UserSearch, type UserSearchRef } from './UserSearch';
+import { act, fireEvent, render, screen, waitFor } from '~/setup';
+import { UserSearch } from './UserSearch';
+import type { UserSearchRef } from './types/types';
 import type { Visible } from './types/visible';
 import { VisibleType } from './types/visible';
 

--- a/packages/react/src/components/UserSearch/types/types.ts
+++ b/packages/react/src/components/UserSearch/types/types.ts
@@ -1,5 +1,8 @@
 import type { ReactNode } from 'react';
+import { SearchResultType, SharingItem } from '../../../types';
 import { Visible } from './visible';
+
+export type { SearchResultType, SharingItem };
 
 export interface UserSearchProps {
   placeholder?: string;
@@ -18,18 +21,9 @@ export interface SearchResponse {
   results: Visible[];
 }
 
-export type SearchResultType = 'user' | 'group' | 'bookmark';
-
 export interface SearchResultBase {
   id: string;
   displayName: string;
   icon: ReactNode;
   type: SearchResultType;
-}
-
-export interface SharingItem {
-  recipientId: string;
-  recipientType: SearchResultType;
-  permission: string[];
-  displayName: string;
 }

--- a/packages/react/src/components/index.ts
+++ b/packages/react/src/components/index.ts
@@ -52,5 +52,6 @@ export * from './Toolbar';
 export * from './Tooltip';
 export * from './Tree';
 export * from './TreeView';
+export * from './UserRightsList';
 export * from './UserSearch';
 export * from './VisuallyHidden';

--- a/packages/react/src/hooks/useDirectory/useDirectory.ts
+++ b/packages/react/src/hooks/useDirectory/useDirectory.ts
@@ -1,15 +1,13 @@
 import { ID, odeServices } from '@edifice.io/client';
+import { AvatarType } from '../../types';
 
 const useDirectory = () => {
-  function getAvatarURL(
-    userId: ID,
-    type: 'user' | 'group',
-  ): string | undefined {
+  function getAvatarURL(userId: ID, type: AvatarType): string | undefined {
     if (userId === '') return undefined;
     return odeServices.directory().getAvatarUrl(userId, type);
   }
 
-  function getUserbookURL(userId: ID, type: 'user' | 'group'): string {
+  function getUserbookURL(userId: ID, type: AvatarType): string {
     return odeServices.directory().getDirectoryUrl(userId, type);
   }
 

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -2,4 +2,8 @@ export { type Size } from './size';
 export { type Status } from './status';
 export { type TreeData } from './treedata';
 export { type Color } from './color';
-export { type SearchResultType, type SharingItem } from './sharing';
+export {
+  type AvatarType,
+  type SearchResultType,
+  type SharingItem,
+} from './sharing';

--- a/packages/react/src/types/index.ts
+++ b/packages/react/src/types/index.ts
@@ -2,3 +2,4 @@ export { type Size } from './size';
 export { type Status } from './status';
 export { type TreeData } from './treedata';
 export { type Color } from './color';
+export { type SearchResultType, type SharingItem } from './sharing';

--- a/packages/react/src/types/sharing.ts
+++ b/packages/react/src/types/sharing.ts
@@ -1,4 +1,5 @@
-export type SearchResultType = 'user' | 'group' | 'bookmark';
+export type AvatarType = 'user' | 'group';
+export type SearchResultType = AvatarType | 'bookmark';
 
 export interface SharingItem {
   recipientId: string;

--- a/packages/react/src/types/sharing.ts
+++ b/packages/react/src/types/sharing.ts
@@ -1,0 +1,8 @@
+export type SearchResultType = 'user' | 'group' | 'bookmark';
+
+export interface SharingItem {
+  recipientId: string;
+  recipientType: SearchResultType;
+  permission: string[];
+  displayName: string;
+}

--- a/packages/react/src/utilities/index.ts
+++ b/packages/react/src/utilities/index.ts
@@ -2,3 +2,4 @@ export * from './check-user-rights';
 export * from './emptyscreen-mapping';
 export * from './react-query';
 export * from './refs';
+export * from './rotate-transition-style';

--- a/packages/react/src/utilities/rotate-transition-style/get-rotate-transition-style.ts
+++ b/packages/react/src/utilities/rotate-transition-style/get-rotate-transition-style.ts
@@ -1,0 +1,14 @@
+import type { CSSProperties } from 'react';
+
+export function getRotateTransitionStyle(
+  isOpen: boolean,
+  {
+    degrees = -180,
+    duration = 0.2,
+  }: { degrees?: number; duration?: number } = {},
+): CSSProperties {
+  return {
+    transition: `rotate ${duration}s ease-out`,
+    rotate: isOpen ? `${degrees}deg` : '0deg',
+  };
+}

--- a/packages/react/src/utilities/rotate-transition-style/index.ts
+++ b/packages/react/src/utilities/rotate-transition-style/index.ts
@@ -1,0 +1,1 @@
+export * from './get-rotate-transition-style';


### PR DESCRIPTION
# Description

Implements a new `UserRightsList` component in the React package to manage resource sharing permissions. This component displays users and groups with their respective access rights, and significantly introduces support for defining and applying permissions via bookmarks. It incorporates complex logic to handle right dependencies (e.g., `requires` and `excludes`), ensuring accurate and consistent permission assignments.

The `UserRightsList` component is designed to be highly configurable, supporting read-only modes, loading states, and programmatic item additions via a ref. Bookmarks are displayed as collapsible rows, allowing batch-editing of permissions for all contained users.

Additionally, this pull request includes an update to the Mock Service Worker (`msw`) to version `2.12.13`, along with related code refinements in `mockServiceWorker.js` and a new `msw` configuration in `package.json`.

This feature addresses the need for a robust and user-friendly interface for managing resource sharing and bookmarking configurations.

Related to issues ENABLING-652 and ENABLING-643.

## Which Package changed?

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings