### PR TITLE
fix(bootstrap, react): #COCO-4642 add css max height on onboarding mo…

### DIFF
--- a/packages/bootstrap/src/components/_index.scss
+++ b/packages/bootstrap/src/components/_index.scss
@@ -52,3 +52,4 @@
 @forward 'widget/';
 @forward 'multimedia/';
 @forward 'views/';
+@forward 'modals/';

--- a/packages/bootstrap/src/components/modals/_index.scss
+++ b/packages/bootstrap/src/components/modals/_index.scss
@@ -1,0 +1,1 @@
+@forward 'onboarding-modal';

--- a/packages/bootstrap/src/components/modals/_onboarding-modal.scss
+++ b/packages/bootstrap/src/components/modals/_onboarding-modal.scss
@@ -1,0 +1,4 @@
+#onboarding-modal .onboarding-modal-image {
+  max-height: 140px;
+  width: auto;
+}

--- a/packages/bootstrap/src/components/modals/_onboarding-modal.scss
+++ b/packages/bootstrap/src/components/modals/_onboarding-modal.scss
@@ -1,4 +1,6 @@
 #onboarding-modal .onboarding-modal-image {
+  height: auto;
   max-height: 140px;
+  max-width: 100%;
   width: auto;
 }

--- a/packages/react/src/modules/modals/OnboardingModal/OnboardingModal.tsx
+++ b/packages/react/src/modules/modals/OnboardingModal/OnboardingModal.tsx
@@ -174,7 +174,7 @@ const OnboardingModalInner = <T = boolean,>(
                     <Image
                       width="270"
                       height="140"
-                      className="mx-auto my-12"
+                      className="mx-auto my-12 onboarding-modal-image"
                       loading="lazy"
                       src={item.src}
                       alt={t(item.alt)}


### PR DESCRIPTION
# Description

Adds scoped styling so onboarding modal illustrations (incl. PNGs) are constrained in size and render with improved 
aspect handling.
Ticket https://edifice-community.atlassian.net/browse/COCO-4642

Changes:

- Add a dedicated onboarding-modal-image class to the onboarding modal <Image>.
- Introduce Bootstrap SCSS for onboarding modal image sizing (max-height, width: auto).
- Wire the new modal SCSS into the Bootstrap build via @forward index updates.

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
