### PR TITLE
fix(client): #IMP-5441, regression when moving from client framework to service

### DIFF
--- a/packages/client/src/ts/session/Service.ts
+++ b/packages/client/src/ts/session/Service.ts
@@ -61,10 +61,10 @@ export class SessionService {
       this.getBookmarks(user),
     ]);
 
+    const { type: personType, ...personWithoutType } = person || {};
     const userDescription = {
-      ...(person || {}),
-      type: undefined, // Remove undesired "type" field
-      profiles: person?.type || ['Guest'], // "type" field from /userbook/api/person becomes "profiles"
+      ...personWithoutType,
+      profiles: personType || ['Guest'], // "type" field from /userbook/api/person becomes "profiles"
       ...description, // Inject other fields (also the correct "type")
     };
 

--- a/packages/client/src/ts/session/Service.ts
+++ b/packages/client/src/ts/session/Service.ts
@@ -2,10 +2,12 @@ import { App, ERROR_CODE } from '../globals';
 import {
   GetUserProfileOptions,
   IGetSession,
+  IPerson,
   IQuotaAndUsage,
   IUserDescription,
   IUserInfo,
   IWebApp,
+  PersonApiResult,
   UserProfile,
 } from './interfaces';
 
@@ -40,12 +42,15 @@ export class SessionService {
   }
 
   async getSession(): Promise<IGetSession> {
-    const user = await this.getUser();
+    const [user, person] = await Promise.all([
+      this.getUser(),
+      this.getPerson(),
+    ]);
 
     const [
       currentLanguage,
       quotaAndUsage,
-      userDescription,
+      description,
       userProfile,
       bookmarkedApps,
     ] = await Promise.all([
@@ -55,6 +60,13 @@ export class SessionService {
       this.getUserProfile(),
       this.getBookmarks(user),
     ]);
+
+    const userDescription = {
+      ...(person || {}),
+      type: undefined, // Remove undesired "type" field
+      profiles: person?.type || ['Guest'], // "type" field from /userbook/api/person becomes "profiles"
+      ...description, // Inject other fields (also the correct "type")
+    };
 
     return {
       user,
@@ -260,21 +272,30 @@ export class SessionService {
   async getUserProfile(
     options: Partial<GetUserProfileOptions> = {},
   ): Promise<UserProfile> {
-    const { options: httpOptions = {}, params = {} } = options;
+    const person = await this.getPerson(options);
+    return person?.type || ['Guest'];
+  }
 
+  private async getPerson(
+    options: Partial<GetUserProfileOptions> = {},
+  ): Promise<(IPerson & { type: UserProfile }) | null> {
+    const { options: httpOptions = {}, params = {} } = options;
     const queryParams = new URLSearchParams(params).toString();
     const url = `/userbook/api/person${queryParams ? `?${queryParams}` : ''}`;
 
-    const { response, value } = await this.cache.httpGet<any>(url, httpOptions);
+    const { response, value } = await this.cache.httpGet<PersonApiResult>(
+      url,
+      httpOptions,
+    );
     if (
       response.status < 200 ||
       response.status >= 300 ||
       typeof value === 'string'
     ) {
       // Backend tries to redirect the user => not logged in !
-      return ['Guest'];
+      return null;
     }
-    return value?.result?.[0]?.type || ['Guest'];
+    return value?.result?.[0] || null;
   }
 
   public async isAdml(): Promise<boolean> {

--- a/packages/client/src/ts/session/Service.ts
+++ b/packages/client/src/ts/session/Service.ts
@@ -278,7 +278,7 @@ export class SessionService {
 
   private async getPerson(
     options: Partial<GetUserProfileOptions> = {},
-  ): Promise<(IPerson & { type: UserProfile }) | null> {
+  ): Promise<IPerson | null> {
     const { options: httpOptions = {}, params = {} } = options;
     const queryParams = new URLSearchParams(params).toString();
     const url = `/userbook/api/person${queryParams ? `?${queryParams}` : ''}`;

--- a/packages/client/src/ts/session/interfaces.ts
+++ b/packages/client/src/ts/session/interfaces.ts
@@ -345,7 +345,28 @@ export interface IGetSession {
   bookmarkedApps: IWebApp[];
 }
 
+export type IPerson = Pick<
+  IUserDescription,
+  | 'address'
+  | 'birthdate'
+  | 'displayName'
+  | 'email'
+  | 'id'
+  | 'login'
+  | 'mobile'
+  | 'photo'
+  | 'relatedId'
+  | 'relatedName'
+  | 'relatedType'
+  | 'schools'
+  | 'tel'
+  | 'userId'
+  | 'visibleInfos'
+> & {
+  type: UserProfile;
+};
+
 export type PersonApiResult = {
   status: 'ok' | string;
-  result: Array<IUserDescription>;
+  result: Array<IPerson>;
 };


### PR DESCRIPTION
# Description

Une régression a été introduite lors du portage de `ode-ts-client` vers `@edifice.io/client`.

Elle impacte la disponibilité des champs de `IUserDescription` qui sont issus de l'API `GET /userbook/api/person`
et sans correctif, obligerait le widget SchoolSpace à recharger ces données déjà requêtées.

Cette PR rétablit les valeurs manquantes dans la session, tout en conservant le typage de l'API actuel.


## Which Package changed?

Please check the name of the package you changed

- [X] Client
- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
