### PR TITLE
feat: #ENABLING-723 adds Screeb integration with provider and hooks

### DIFF
--- a/apps/docs/.storybook/preview.tsx
+++ b/apps/docs/.storybook/preview.tsx
@@ -81,6 +81,7 @@ const preview: Preview = {
           'Client',
           'Layout',
           'Modules',
+          'Integrations',
         ],
       },
     },

--- a/apps/docs/src/stories/integrations/Screeb.mdx
+++ b/apps/docs/src/stories/integrations/Screeb.mdx
@@ -1,0 +1,39 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Integrations/Screeb/1. Overview" />
+
+# Screeb
+
+[Screeb](https://screeb.app) is a user feedback and survey platform. This guide explains how to integrate it in Edifice applications without coupling app code to the Screeb SDK directly.
+
+> **Rule**: never call Screeb SDK functions directly in your components, controllers, or screens. Always go through the bridge provided by the framework or the service pattern described here.
+
+---
+
+## Configuration
+
+Each application opts in to Screeb by adding two keys to its `publicConf` (configured via springboard/ENT):
+
+```json
+{
+  "screeb-app-id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "screeb-allowed-profiles": ["Teacher", "Personnel"]
+}
+```
+
+- `screeb-app-id` — your Screeb workspace/channel ID. **Required.** If absent, Screeb is completely disabled for that app (no script loaded, no network call).
+- `screeb-allowed-profiles` — list of profiles to track. **Optional.** When absent or empty, all profiles are tracked.
+
+---
+
+## Privacy
+
+User identifiers sent to Screeb are **hashed with SHA-256 and truncated to 16 hexadecimal characters**. The original `userId` is never transmitted. This applies to all integrations.
+
+---
+
+## Integration guides
+
+- **React (modern apps)** — `@edifice.io/react` — [React](?path=/docs/integrations-screeb-2-react--docs)
+- **AngularJS (legacy apps)** — `@screeb/sdk-browser` — [AngularJS](?path=/docs/integrations-screeb-4-angularjs--docs)
+- **React Native (mobile apps)** — `@screeb/react-native` — [Mobile](?path=/docs/integrations-screeb-3-mobile--docs)

--- a/apps/docs/src/stories/integrations/ScreebAngularJS.mdx
+++ b/apps/docs/src/stories/integrations/ScreebAngularJS.mdx
@@ -1,0 +1,158 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Integrations/Screeb/4. AngularJS" />
+
+# Screeb — AngularJS apps
+
+AngularJS apps use `@screeb/sdk-browser` directly via a dedicated service following the entcore `ng.service()` pattern.
+
+See [Screeb](?path=/docs/integrations-screeb-1-overview--docs) for the common configuration.
+
+---
+
+## Installation
+
+```bash
+npm install @screeb/sdk-browser
+```
+
+---
+
+## ScreebService
+
+Create `src/services/screeb.service.ts`:
+
+```typescript
+import {
+  eventTrack,
+  identityProperties,
+  identityReset,
+  init,
+  load,
+  messageStart,
+  surveyClose,
+  surveyStart,
+  targetingCheck,
+} from '@screeb/sdk-browser';
+import type { HooksMessageStart, HooksSurveyStart, PropertyRecord } from '@screeb/sdk-browser';
+import { ng, model } from 'entcore';
+
+async function hashUserId(userId: string): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(userId),
+  );
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 16);
+}
+
+export interface IScreebService {
+  init(appId: string): Promise<void>;
+  trackEvent(name: string, properties?: PropertyRecord): void;
+  triggerSurvey(surveyId: string, hooks?: HooksSurveyStart, hiddenFields?: PropertyRecord): void;
+  triggerMessage(messageId: string, hooks?: HooksMessageStart): void;
+  closeSurvey(): void;
+  forceTargetingCheck(): void;
+  setIdentityProperties(properties: PropertyRecord): void;
+  reset(): void;
+}
+
+export const screebService: IScreebService = {
+  async init(appId: string): Promise<void> {
+    await load();
+    const hashedId = await hashUserId(model.me.userId);
+    await init(appId, hashedId, { profile: model.me.type });
+  },
+
+  trackEvent(name: string, properties?: PropertyRecord): void {
+    eventTrack(name, properties);
+  },
+
+  triggerSurvey(surveyId: string, hooks?: HooksSurveyStart, hiddenFields?: PropertyRecord): void {
+    surveyStart(surveyId, undefined, undefined, hiddenFields, hooks);
+  },
+
+  triggerMessage(messageId: string, hooks?: HooksMessageStart): void {
+    messageStart(messageId, undefined, undefined, hooks);
+  },
+
+  closeSurvey(): void {
+    surveyClose();
+  },
+
+  forceTargetingCheck(): void {
+    targetingCheck();
+  },
+
+  setIdentityProperties(properties: PropertyRecord): void {
+    identityProperties(properties);
+  },
+
+  reset(): void {
+    identityReset();
+  },
+};
+
+export const ScreebService = ng.service('ScreebService', (): IScreebService => screebService);
+```
+
+---
+
+## Registration
+
+Add the export to `src/services/index.ts`:
+
+```typescript
+export * from './screeb.service';
+```
+
+The service is automatically registered with AngularJS when `app.ts` loads.
+
+---
+
+## Initialization
+
+Call `screebService.init()` once at app startup, after `model.me` is populated. The right place is typically the main controller's `$onInit` or a `.run()` block:
+
+```typescript
+import { screebService } from '../services';
+
+// In your main controller or .run() block:
+const SCREEB_APP_ID = window.SCREEB_APP_ID; // injected via server-side template
+
+if (SCREEB_APP_ID) {
+  screebService.init(SCREEB_APP_ID).catch((err) => {
+    console.error('Failed to initialize Screeb:', err);
+  });
+}
+```
+
+> The `screeb-app-id` can be injected into the page via a server-side template variable, similar to how `ENABLE_RBS` and other feature flags are handled in the HTML entry point.
+
+---
+
+## Usage in controllers
+
+```typescript
+import { screebService } from '../services';
+
+// Track an event
+screebService.trackEvent('calendar-event-created', { recurrence: true });
+
+// Trigger a survey with a callback
+screebService.triggerSurvey(
+  'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+  {
+    onSurveyCompleted: (payload) => console.log('Survey response:', payload),
+  },
+);
+
+// Force targeting re-evaluation after a key event
+screebService.trackEvent('tenth-event-this-month');
+screebService.forceTargetingCheck();
+
+// On logout
+screebService.reset();
+```

--- a/apps/docs/src/stories/integrations/ScreebMobile.mdx
+++ b/apps/docs/src/stories/integrations/ScreebMobile.mdx
@@ -1,0 +1,175 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Integrations/Screeb/3. Mobile" />
+
+# Screeb — Mobile apps (React Native)
+
+Mobile apps use `@screeb/react-native` directly. Unlike the web SDK, the React Native SDK does not require loading a script — the native module is bundled with the app.
+
+See [Screeb](?path=/docs/integrations-screeb-1-overview--docs) for the common configuration.
+
+---
+
+## Requirements
+
+- Android SDK v19+
+- iOS 11.0+, Swift ≥ 5.5.2, Xcode ≥ 13.2.1
+
+---
+
+## Installation
+
+```bash
+npm install @screeb/react-native
+```
+
+**Android** — add internet permission to `AndroidManifest.xml`:
+
+```xml
+<uses-permission android:name="android.permission.INTERNET" />
+```
+
+**iOS** — update pods after installation:
+
+```bash
+cd ios && pod update Screeb
+```
+
+---
+
+## Initialization
+
+Initialize Screeb once when the user session is available, typically in your root component or navigation entry point:
+
+```typescript
+import { useEffect } from 'react';
+import { initSdk, closeSdk } from '@screeb/react-native';
+
+async function hashUserId(userId: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(userId);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 16);
+}
+
+function App({ user, screebChannelId }) {
+  useEffect(() => {
+    if (!user || !screebChannelId) return;
+
+    hashUserId(user.id).then((hashedId) => {
+      initSdk(screebChannelId, hashedId, { profile: user.type });
+    });
+
+    return () => {
+      closeSdk();
+    };
+  }, [user, screebChannelId]);
+
+  // ...
+}
+```
+
+> `screebChannelId` should come from your app's remote configuration (equivalent to `screeb-app-id` in `publicConf` for web apps).
+
+---
+
+## API
+
+### `trackEvent`
+
+Sends a custom event with optional properties.
+
+```typescript
+import { trackEvent } from '@screeb/react-native';
+
+trackEvent('resource-published', { type: 'blog', word_count: 320 });
+```
+
+### `trackScreen`
+
+Tracks a screen visit. Specific to mobile — use this on each navigation change.
+
+```typescript
+import { trackScreen } from '@screeb/react-native';
+
+trackScreen('EditorScreen', { mode: 'creation' });
+```
+
+### `startSurvey`
+
+Starts a survey programmatically.
+
+> **Note:** hooks in the React Native SDK use a `HookMap` (string key → hook ID) rather than direct callbacks. Register your hook handlers with Screeb's dashboard and pass the hook IDs here.
+
+```typescript
+import { startSurvey } from '@screeb/react-native';
+
+startSurvey(
+  'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+  false,           // allowMultipleResponses
+  { context: 'editor' }, // hiddenFields
+);
+```
+
+### `startMessage`
+
+Starts a Screeb message (in-app banner).
+
+```typescript
+import { startMessage } from '@screeb/react-native';
+
+startMessage('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx');
+```
+
+### `closeSurvey`
+
+Closes the currently running survey. Optionally pass a survey ID to close a specific one.
+
+```typescript
+import { closeSurvey } from '@screeb/react-native';
+
+closeSurvey();
+```
+
+### `setProperties`
+
+Updates the current user's attributes in Screeb. Set a property to `null` to delete it.
+
+```typescript
+import { setProperties } from '@screeb/react-native';
+
+setProperties({ nb_resources: 42, last_feature: 'editor' });
+setProperties({ old_property: null }); // delete
+```
+
+### `setIdentity`
+
+Changes the current user identity (e.g. after a re-authentication). Closes running surveys.
+
+```typescript
+import { setIdentity } from '@screeb/react-native';
+
+setIdentity('<hashed-user-id>', { profile: 'Teacher' });
+```
+
+### `resetIdentity`
+
+Resets the current identity. Call this on logout.
+
+```typescript
+import { resetIdentity } from '@screeb/react-native';
+
+resetIdentity();
+```
+
+---
+
+## Differences from the web SDK
+
+- **Script loading** — Web requires `load()` / Mobile: not needed (native module)
+- **Screen tracking** — Web: not available / Mobile: `trackScreen()`
+- **Survey hooks** — Web: typed callbacks / Mobile: hook IDs via `HookMap`
+- **Close SDK** — Web: `close()` / Mobile: `closeSdk()`

--- a/apps/docs/src/stories/integrations/ScreebReact.mdx
+++ b/apps/docs/src/stories/integrations/ScreebReact.mdx
@@ -1,0 +1,126 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Integrations/Screeb/2. React" />
+
+# Screeb — React apps
+
+React apps use `EdificeScreebProvider` and the `useScreeb` hook from `@edifice.io/react`. No direct dependency on `@screeb/sdk-react` is needed in the application.
+
+See [Screeb](?path=/docs/integrations-screeb-1-overview--docs) for the common configuration.
+
+---
+
+## Setup
+
+`EdificeScreebProvider` must be placed inside `EdificeClientProvider`:
+
+```tsx
+import { EdificeClientProvider, EdificeScreebProvider } from '@edifice.io/react';
+
+root.render(
+  <QueryClientProvider client={queryClient}>
+    <EdificeClientProvider params={{ app: 'myapp' }}>
+      <EdificeScreebProvider>
+        <App />
+      </EdificeScreebProvider>
+    </EdificeClientProvider>
+  </QueryClientProvider>
+);
+```
+
+The provider automatically:
+
+- reads `screeb-app-id` and `screeb-allowed-profiles` from `publicConf`
+- loads the Screeb script only when the app is configured and the user's profile is allowed
+- initializes Screeb with a hashed user identity in a single call (no anonymous entry created)
+- resets the identity on logout so sessions are never shared across users on the same device
+
+### Conditional survey display
+
+Pass `onSurveyDisplayAllowed` to prevent a survey from showing when your app is in a specific state (e.g. a modal is already open):
+
+```tsx
+const [isModalOpen, setIsModalOpen] = useState(false);
+
+<EdificeScreebProvider
+  onSurveyDisplayAllowed={() => !isModalOpen}
+>
+  <App />
+</EdificeScreebProvider>
+```
+
+---
+
+## useScreeb
+
+```typescript
+import { useScreeb } from '@edifice.io/react';
+
+const {
+  trackEvent,
+  triggerSurvey,
+  triggerMessage,
+  closeSurvey,
+  forceTargetingCheck,
+  setIdentityProperties,
+} = useScreeb();
+```
+
+### `trackEvent`
+
+Sends a custom event. Events are used as targeting conditions in Screeb (e.g. "show survey after 3 publications").
+
+```typescript
+trackEvent('resource-published', { type: 'blog', word_count: 320 });
+```
+
+### `triggerSurvey`
+
+Starts a survey programmatically. Use `hooks` to react to user responses.
+
+```typescript
+triggerSurvey(
+  'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx',
+  {
+    onSurveyCompleted: (payload) => console.log('responses:', payload),
+    onSurveyHidden: (payload) => console.log('dismissed:', payload),
+  },
+  { context: 'editor' }, // optional hidden fields passed to Screeb
+);
+```
+
+### `triggerMessage`
+
+Starts a Screeb message (in-app banner or tooltip). Messages are distinct from surveys.
+
+```typescript
+triggerMessage('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', {
+  onMessageCompleted: (payload) => console.log('message completed', payload),
+});
+```
+
+### `closeSurvey`
+
+Closes the currently running survey programmatically.
+
+```typescript
+closeSurvey();
+```
+
+### `forceTargetingCheck`
+
+Forces the Screeb targeting engine to re-evaluate its rules immediately. Call this right after a `trackEvent` when you want the survey to appear without waiting for the next automatic cycle.
+
+```typescript
+trackEvent('fifth-login');
+forceTargetingCheck();
+```
+
+### `setIdentityProperties`
+
+Updates the current user's attributes in Screeb. Set a property to `null` to delete it.
+
+```typescript
+setIdentityProperties({ subscription_plan: 'pro', nb_resources: 42 });
+setIdentityProperties({ old_property: null }); // delete
+```

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -86,6 +86,7 @@
   },
   "dependencies": {
     "@ant-design/icons": "5.4.0",
+    "@screeb/sdk-react": "0.6.0",
     "@dnd-kit/core": "6.3.1",
     "@dnd-kit/sortable": "8.0.0",
     "@dnd-kit/utilities": "3.2.2",

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -22,6 +22,8 @@ export * from './useIsAdmlcOrAdmc';
 export * from './useKeyPress';
 export * from './useLibraryUrl';
 export * from './useMediaLibrary';
+export * from './usePublicConf';
+export * from './useScreeb';
 export * from './useScrollToTop';
 export * from './useTitle';
 export * from './useToast';

--- a/packages/react/src/hooks/usePublicConf/index.ts
+++ b/packages/react/src/hooks/usePublicConf/index.ts
@@ -1,0 +1,1 @@
+export { default as usePublicConf } from './usePublicConf';

--- a/packages/react/src/hooks/usePublicConf/usePublicConf.mdx
+++ b/packages/react/src/hooks/usePublicConf/usePublicConf.mdx
@@ -1,0 +1,50 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Hooks/usePublicConf" />
+
+# usePublicConf
+
+Generic hook to fetch the public configuration of an application from the server (`/<app>/conf/public`). The result is cached indefinitely since public conf does not change without a redeployment.
+
+## Usage
+
+```typescript
+import { usePublicConf } from '@edifice.io/react';
+
+type MyAppConf = {
+  'some-feature-flag'?: boolean;
+  'screeb-app-id'?: string;
+};
+
+const { data, isLoading, error } = usePublicConf<MyAppConf>('myapp');
+```
+
+## Parameters
+
+- `appCode` (`App`): The application code (e.g. `'actualites'`, `'blog'`).
+
+## Returns
+
+- `data` (`T | undefined`): The public configuration object for the app.
+- `isLoading` (`boolean`): `true` while the request is in progress.
+- `error` (`Error | null`): Set if the request failed.
+
+## Example
+
+```typescript
+import { useEdificeClient } from '@edifice.io/react';
+import { usePublicConf } from '@edifice.io/react';
+
+type AppConf = {
+  'screeb-app-id'?: string;
+};
+
+function MyComponent() {
+  const { appCode } = useEdificeClient();
+  const { data: conf, isLoading } = usePublicConf<AppConf>(appCode);
+
+  if (isLoading) return null;
+
+  return <div>{conf?.['screeb-app-id'] ?? 'Screeb not configured'}</div>;
+}
+```

--- a/packages/react/src/hooks/usePublicConf/usePublicConf.ts
+++ b/packages/react/src/hooks/usePublicConf/usePublicConf.ts
@@ -1,0 +1,10 @@
+import { App, odeServices } from '@edifice.io/client';
+import { useQuery } from '@tanstack/react-query';
+
+export default function usePublicConf<T>(appCode: App) {
+  return useQuery<T>({
+    queryKey: ['publicConf', appCode],
+    queryFn: () => odeServices.conf().getPublicConf<T>(appCode),
+    staleTime: Infinity,
+  });
+}

--- a/packages/react/src/hooks/useScreeb/index.ts
+++ b/packages/react/src/hooks/useScreeb/index.ts
@@ -1,0 +1,1 @@
+export { useScreeb, type ScreebProperties, type ScreebSurveyHooks } from './useScreeb';

--- a/packages/react/src/hooks/useScreeb/useScreeb.mdx
+++ b/packages/react/src/hooks/useScreeb/useScreeb.mdx
@@ -33,12 +33,33 @@ Configure your app's public conf (via springboard/ENT):
 
 `screeb-allowed-profiles` is optional — when absent or empty, all profiles are tracked.
 
+### Provider props
+
+- `onSurveyDisplayAllowed` (optional): callback called before a survey is displayed. Return `false` to prevent it from showing (e.g. when a modal is already open).
+
+```tsx
+<EdificeScreebProvider
+  onSurveyDisplayAllowed={({ survey }) => !isModalOpen}
+>
+  <App />
+</EdificeScreebProvider>
+```
+
+The identity is automatically reset when the user logs out, preventing cross-user contamination on shared devices.
+
 ## Usage
 
 ```typescript
 import { useScreeb } from '@edifice.io/react';
 
-const { trackEvent, triggerSurvey, setIdentityProperties } = useScreeb();
+const {
+  trackEvent,
+  triggerSurvey,
+  triggerMessage,
+  closeSurvey,
+  forceTargetingCheck,
+  setIdentityProperties,
+} = useScreeb();
 ```
 
 ## Return Value
@@ -76,6 +97,41 @@ triggerSurvey('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', {
 });
 ```
 
+### `triggerMessage`
+
+Starts a Screeb message (banner/tooltip) programmatically. Messages are distinct from surveys and are used for announcements or in-app guidance.
+
+```typescript
+triggerMessage(messageId: string, hooks?: ScreebMessageHooks): Promise<unknown>
+```
+
+```typescript
+triggerMessage('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', {
+  onMessageCompleted: (payload) => console.log('Message completed', payload),
+});
+```
+
+### `closeSurvey`
+
+Closes the currently running survey.
+
+```typescript
+closeSurvey(): Promise<unknown>
+```
+
+### `forceTargetingCheck`
+
+Forces the Screeb targeting engine to re-evaluate its rules immediately. Useful after a `trackEvent` when you want a survey to appear as soon as a threshold is reached, without waiting for the next automatic cycle.
+
+```typescript
+forceTargetingCheck(): Promise<unknown>
+```
+
+```typescript
+trackEvent('resource-published');
+forceTargetingCheck(); // trigger immediate evaluation
+```
+
 ### `setIdentityProperties`
 
 Updates the current user's attributes in Screeb. Set a property to `null` to delete it.
@@ -98,6 +154,14 @@ type ScreebSurveyHooks = {
   onSurveyStarted?: (data: unknown) => void;
   onSurveyCompleted?: (data: unknown) => void;
   onSurveyHidden?: (data: unknown) => void;
+  onQuestionReplied?: (data: unknown) => void;
+};
+
+type ScreebMessageHooks = {
+  onMessageShowed?: (data: unknown) => void;
+  onMessageStarted?: (data: unknown) => void;
+  onMessageCompleted?: (data: unknown) => void;
+  onMessageHidden?: (data: unknown) => void;
   onQuestionReplied?: (data: unknown) => void;
 };
 ```

--- a/packages/react/src/hooks/useScreeb/useScreeb.mdx
+++ b/packages/react/src/hooks/useScreeb/useScreeb.mdx
@@ -1,0 +1,103 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Hooks/useScreeb" />
+
+# useScreeb
+
+Hook to interact with the Screeb survey platform. Must be used inside an `EdificeScreebProvider`.
+
+Screeb is only active when the app's public conf contains a `screeb-app-id`. If this key is absent, or the current user's profile is not in `screeb-allowed-profiles`, the provider does nothing and this hook is a no-op.
+
+## Setup
+
+Wrap your app with `EdificeScreebProvider` (must be inside `EdificeClientProvider`):
+
+```tsx
+import { EdificeClientProvider, EdificeScreebProvider } from '@edifice.io/react';
+
+<EdificeClientProvider params={{ app: 'myapp' }}>
+  <EdificeScreebProvider>
+    <App />
+  </EdificeScreebProvider>
+</EdificeClientProvider>
+```
+
+Configure your app's public conf (via springboard/ENT):
+
+```json
+{
+  "screeb-app-id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "screeb-allowed-profiles": ["Teacher", "Personnel"]
+}
+```
+
+`screeb-allowed-profiles` is optional — when absent or empty, all profiles are tracked.
+
+## Usage
+
+```typescript
+import { useScreeb } from '@edifice.io/react';
+
+const { trackEvent, triggerSurvey, setIdentityProperties } = useScreeb();
+```
+
+## Return Value
+
+### `trackEvent`
+
+Sends a custom event to Screeb. Can be used as a targeting rule for survey display conditions.
+
+```typescript
+trackEvent(name: string, properties?: ScreebProperties): Promise<unknown>
+```
+
+```typescript
+trackEvent('falc-text-received', { source: 'editor', word_count: 42 });
+```
+
+### `triggerSurvey`
+
+Starts a survey programmatically. Use `hooks` to receive callbacks when the user interacts with the survey.
+
+```typescript
+triggerSurvey(
+  surveyId: string,
+  hooks?: ScreebSurveyHooks,
+  hiddenFields?: ScreebProperties,
+): Promise<unknown>
+```
+
+```typescript
+triggerSurvey('xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx', {
+  onSurveyShowed: (payload) => console.log('Survey shown', payload),
+  onSurveyCompleted: (payload) => console.log('Survey completed', payload),
+  onSurveyHidden: (payload) => console.log('Survey hidden', payload),
+  onQuestionReplied: (payload) => console.log('Question answered', payload),
+});
+```
+
+### `setIdentityProperties`
+
+Updates the current user's attributes in Screeb. Set a property to `null` to delete it.
+
+```typescript
+setIdentityProperties(properties: ScreebProperties): Promise<unknown>
+```
+
+```typescript
+setIdentityProperties({ last_feature_used: 'falc', nb_resources: 12 });
+```
+
+## Types
+
+```typescript
+type ScreebProperties = Record<string, string | number | boolean | Date | null>;
+
+type ScreebSurveyHooks = {
+  onSurveyShowed?: (data: unknown) => void;
+  onSurveyStarted?: (data: unknown) => void;
+  onSurveyCompleted?: (data: unknown) => void;
+  onSurveyHidden?: (data: unknown) => void;
+  onQuestionReplied?: (data: unknown) => void;
+};
+```

--- a/packages/react/src/hooks/useScreeb/useScreeb.ts
+++ b/packages/react/src/hooks/useScreeb/useScreeb.ts
@@ -1,24 +1,37 @@
 import {
+  HooksMessageStart,
   HooksSurveyStart,
   PropertyRecord,
 } from '@screeb/sdk-browser';
 import { useScreeb as useScreebSDK } from '@screeb/sdk-react';
 
+export type { HooksMessageStart as ScreebMessageHooks };
 export type { HooksSurveyStart as ScreebSurveyHooks };
 export type ScreebProperties = PropertyRecord;
 
 export function useScreeb() {
-  const { eventTrack, surveyStart, identityProperties } = useScreebSDK();
+  const {
+    eventTrack,
+    identityProperties,
+    messageStart,
+    surveyClose,
+    surveyStart,
+    targetingCheck,
+  } = useScreebSDK();
 
   return {
+    closeSurvey: () => surveyClose(),
+    forceTargetingCheck: () => targetingCheck(),
+    setIdentityProperties: (properties: ScreebProperties) =>
+      identityProperties(properties),
     trackEvent: (name: string, properties?: ScreebProperties) =>
       eventTrack(name, properties),
+    triggerMessage: (messageId: string, hooks?: HooksMessageStart) =>
+      messageStart(messageId, undefined, undefined, hooks),
     triggerSurvey: (
       surveyId: string,
       hooks?: HooksSurveyStart,
       hiddenFields?: ScreebProperties,
     ) => surveyStart(surveyId, undefined, undefined, hiddenFields, hooks),
-    setIdentityProperties: (properties: ScreebProperties) =>
-      identityProperties(properties),
   };
 }

--- a/packages/react/src/hooks/useScreeb/useScreeb.ts
+++ b/packages/react/src/hooks/useScreeb/useScreeb.ts
@@ -1,0 +1,24 @@
+import {
+  HooksSurveyStart,
+  PropertyRecord,
+} from '@screeb/sdk-browser';
+import { useScreeb as useScreebSDK } from '@screeb/sdk-react';
+
+export type { HooksSurveyStart as ScreebSurveyHooks };
+export type ScreebProperties = PropertyRecord;
+
+export function useScreeb() {
+  const { eventTrack, surveyStart, identityProperties } = useScreebSDK();
+
+  return {
+    trackEvent: (name: string, properties?: ScreebProperties) =>
+      eventTrack(name, properties),
+    triggerSurvey: (
+      surveyId: string,
+      hooks?: HooksSurveyStart,
+      hiddenFields?: ScreebProperties,
+    ) => surveyStart(surveyId, undefined, undefined, hiddenFields, hooks),
+    setIdentityProperties: (properties: ScreebProperties) =>
+      identityProperties(properties),
+  };
+}

--- a/packages/react/src/providers/EdificeScreebProvider/EdificeScreebProvider.tsx
+++ b/packages/react/src/providers/EdificeScreebProvider/EdificeScreebProvider.tsx
@@ -1,0 +1,67 @@
+import { type ReactNode, useEffect } from 'react';
+
+import { ScreebProvider, useScreeb as useScreebSDK } from '@screeb/sdk-react';
+
+import { useEdificeClient } from '../EdificeClientProvider/EdificeClientProvider.hook';
+import { usePublicConf } from '../../hooks/usePublicConf';
+
+type ScreebPublicConf = {
+  'screeb-app-id'?: string;
+  'screeb-allowed-profiles'?: string[];
+};
+
+async function hashUserId(userId: string): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(userId),
+  );
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+    .slice(0, 16);
+}
+
+const ScreebInitializer = ({ appId }: { appId: string }) => {
+  const { user } = useEdificeClient();
+  const { init } = useScreebSDK();
+
+  useEffect(() => {
+    if (!user) return;
+
+    hashUserId(user.userId)
+      .then((hashedId) =>
+        init(appId, hashedId, { profile: user.type }),
+      )
+      .catch((error) => {
+        console.error('Failed to initialize Screeb:', error);
+      });
+  }, [user, appId, init]);
+
+  return null;
+};
+
+export const EdificeScreebProvider = ({
+  children,
+}: {
+  children: ReactNode;
+}) => {
+  const { appCode, user, userProfile } = useEdificeClient();
+  const { data: publicConf } = usePublicConf<ScreebPublicConf>(appCode);
+
+  const appId = publicConf?.['screeb-app-id'];
+  const allowedProfiles = publicConf?.['screeb-allowed-profiles'];
+  const profileAllowed =
+    !allowedProfiles?.length ||
+    allowedProfiles.includes(userProfile?.[0] ?? '');
+
+  if (!appId || !user || !profileAllowed) {
+    return <>{children}</>;
+  }
+
+  return (
+    <ScreebProvider>
+      <ScreebInitializer appId={appId} />
+      {children}
+    </ScreebProvider>
+  );
+};

--- a/packages/react/src/providers/EdificeScreebProvider/EdificeScreebProvider.tsx
+++ b/packages/react/src/providers/EdificeScreebProvider/EdificeScreebProvider.tsx
@@ -1,5 +1,6 @@
 import { type ReactNode, useEffect } from 'react';
 
+import { HooksInit } from '@screeb/sdk-browser';
 import { ScreebProvider, useScreeb as useScreebSDK } from '@screeb/sdk-react';
 
 import { useEdificeClient } from '../EdificeClientProvider/EdificeClientProvider.hook';
@@ -8,6 +9,11 @@ import { usePublicConf } from '../../hooks/usePublicConf';
 type ScreebPublicConf = {
   'screeb-app-id'?: string;
   'screeb-allowed-profiles'?: string[];
+};
+
+export type EdificeScreebProviderProps = {
+  children: ReactNode;
+  onSurveyDisplayAllowed?: HooksInit['onSurveyDisplayAllowed'];
 };
 
 async function hashUserId(userId: string): Promise<string> {
@@ -21,30 +27,43 @@ async function hashUserId(userId: string): Promise<string> {
     .slice(0, 16);
 }
 
-const ScreebInitializer = ({ appId }: { appId: string }) => {
+const ScreebInitializer = ({
+  appId,
+  onSurveyDisplayAllowed,
+}: {
+  appId: string;
+  onSurveyDisplayAllowed?: HooksInit['onSurveyDisplayAllowed'];
+}) => {
   const { user } = useEdificeClient();
-  const { init } = useScreebSDK();
+  const { init, identityReset } = useScreebSDK();
 
   useEffect(() => {
     if (!user) return;
 
+    const hooks: HooksInit | undefined = onSurveyDisplayAllowed
+      ? { version: '1.0.0', onSurveyDisplayAllowed }
+      : undefined;
+
     hashUserId(user.userId)
-      .then((hashedId) =>
-        init(appId, hashedId, { profile: user.type }),
-      )
+      .then((hashedId) => init(appId, hashedId, { profile: user.type }, hooks))
       .catch((error) => {
         console.error('Failed to initialize Screeb:', error);
       });
-  }, [user, appId, init]);
+  }, [user, appId, init, onSurveyDisplayAllowed]);
+
+  useEffect(() => {
+    return () => {
+      identityReset();
+    };
+  }, [identityReset]);
 
   return null;
 };
 
 export const EdificeScreebProvider = ({
   children,
-}: {
-  children: ReactNode;
-}) => {
+  onSurveyDisplayAllowed,
+}: EdificeScreebProviderProps) => {
   const { appCode, user, userProfile } = useEdificeClient();
   const { data: publicConf } = usePublicConf<ScreebPublicConf>(appCode);
 
@@ -60,7 +79,10 @@ export const EdificeScreebProvider = ({
 
   return (
     <ScreebProvider>
-      <ScreebInitializer appId={appId} />
+      <ScreebInitializer
+        appId={appId}
+        onSurveyDisplayAllowed={onSurveyDisplayAllowed}
+      />
       {children}
     </ScreebProvider>
   );

--- a/packages/react/src/providers/EdificeScreebProvider/index.ts
+++ b/packages/react/src/providers/EdificeScreebProvider/index.ts
@@ -1,0 +1,1 @@
+export { EdificeScreebProvider } from './EdificeScreebProvider';

--- a/packages/react/src/providers/index.ts
+++ b/packages/react/src/providers/index.ts
@@ -5,3 +5,5 @@ export * from './EdificeClientProvider/EdificeClientProvider.hook';
 export * from './EdificeThemeProvider/EdificeThemeProvider';
 export * from './EdificeThemeProvider/EdificeThemeProvider.context';
 export * from './EdificeThemeProvider/EdificeThemeProvider.hook';
+export * from './EdificeScreebProvider/EdificeScreebProvider';
+export * from './MockedProvider/MockedProvider';


### PR DESCRIPTION
# Description

Implements a robust and privacy-aware integration for Screeb, a user feedback and survey platform, across Edifice applications. This change introduces a standardized way to configure and interact with Screeb, ensuring consistent behavior and preventing direct SDK coupling in application code.

The `EdificeScreebProvider` handles conditional loading, user ID hashing (for privacy), profile-based filtering via `publicConf`, and identity management on user login/logout. The `useScreeb` hook provides a simplified API for React applications to track events, trigger surveys and messages, and manage user properties. Additionally, a new `usePublicConf` hook is introduced to fetch application configurations. Extensive documentation is included for React, AngularJS, and React Native integration.

https://edifice-community.atlassian.net/browse/ENABLING-723

## Which Package changed?

- [ ] Components
- [ ] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

- [x] Doc (PATCH)
- [x] New feature (MINOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

Relates to #ENABLING-723