### PR TITLE
fix: #IMPULS-5842 relaxes `prosemirror` subdependency versions

### DIFF
--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -157,10 +157,7 @@
     "@tiptap/html": "2.11.0",
     "@tiptap/pm": "2.11.0",
     "@tiptap/starter-kit": "2.11.0",
-    "prosemirror-model": "1.25.4",
-    "prosemirror-state": "1.4.4",
-    "prosemirror-transform": "1.11.0",
-    "prosemirror-view": "1.41.5",
+    "prosemirror-state": "^1.4.3",
     "vite": "catalog:",
     "vite-plugin-dts": "catalog:"
   },


### PR DESCRIPTION
# Description

The explicit version pins for several `prosemirror-*` subdependencies within `packages/extensions/package.json` have been relaxed. This includes removing the fixed versions for `prosemirror-model`, `prosemirror-transform`, and `prosemirror-view`. Additionally, `prosemirror-state` has been updated from a fixed version (`1.4.4`) to a caret range (`^1.4.3`), allowing for minor version updates.

This change aims to resolve potential dependency conflicts or resolution issues with `@tiptap` packages by providing more flexibility in how these core `prosemirror` subdependencies are managed.

https://edifice-community.atlassian.net/browse/IMPULS-5842

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

Relates to IMPULS-5842