### PR TITLE
feat: #ENABLING-821 adds HomeCard component for homepage sections

### DIFF
--- a/packages/bootstrap/src/components/homepage/_home-card.scss
+++ b/packages/bootstrap/src/components/homepage/_home-card.scss
@@ -1,0 +1,59 @@
+.home-card {
+  --home-card-padding: var(--primitive-spacer-16);
+  --home-card-gap: var(--primitive-spacer-16);
+  --home-card-background: var(--primitive-white);
+
+  display: flex;
+  flex-direction: column;
+  gap: var(--home-card-gap);
+  padding: var(--home-card-padding);
+  background: var(--home-card-background);
+  border-radius: var(--primitive-border-radius-2xl);
+  box-shadow: 0 4px 10px 0 rgb(0 0 0 / 18%);
+
+  // ---- Variants ----
+  &--user {
+    --home-card-padding: var(--primitive-spacer-16);
+    --home-card-gap: var(--primitive-spacer-16);
+  }
+
+  &--primary {
+    --home-card-padding: var(--primitive-spacer-8) var(--primitive-spacer-16)
+      var(--primitive-spacer-16) var(--primitive-spacer-16);
+    --home-card-gap: var(--primitive-spacer-8);
+  }
+
+  &--secondary {
+    --home-card-padding: var(--primitive-spacer-8) var(--primitive-spacer-16)
+      var(--primitive-spacer-16) var(--primitive-spacer-16);
+    --home-card-gap: var(--primitive-spacer-4);
+    --home-card-background: var(--primitive-grey-100);
+
+    box-shadow: none;
+  }
+
+  // ---- Header ----
+  &-header-title {
+    margin: 0;
+    color: var(--primitive-grey-900);
+    font-family: var(--font-family-title);
+    font-size: var(--primitive-font-size-s);
+    font-weight: var(--font-weight-bold);
+    line-height: var(--primitive-font-lineheight-s);
+  }
+
+  // Title style override for the "secondary" variant
+  &--secondary & {
+    &-header-title {
+      font-family: var(--font-family-body);
+      font-size: var(--primitive-font-size-small);
+      line-height: var(--primitive-font-lineheight-2xs);
+    }
+  }
+
+  // ---- Content ----
+  &-content {
+    display: flex;
+    flex-direction: column;
+  }
+}

--- a/packages/bootstrap/src/components/homepage/_index.scss
+++ b/packages/bootstrap/src/components/homepage/_index.scss
@@ -3,3 +3,4 @@
 @forward 'header';
 @forward 'last-infos-list';
 @forward 'last-infos';
+@forward 'home-card';

--- a/packages/react/src/components/ButtonBeta/stories/ButtonBeta.stories.tsx
+++ b/packages/react/src/components/ButtonBeta/stories/ButtonBeta.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 
 import {
   IconAddUser,

--- a/packages/react/src/components/Dropdown/stories/Dropdown.SearchInput.stories.tsx
+++ b/packages/react/src/components/Dropdown/stories/Dropdown.SearchInput.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 
 import Dropdown from '../Dropdown';
 

--- a/packages/react/src/components/PageLayout/PageLayout.stories.tsx
+++ b/packages/react/src/components/PageLayout/PageLayout.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 
 import AppHeader from '../AppHeader/AppHeader';
 import Breadcrumb from '../Breadcrumb/Breadcrumb';

--- a/packages/react/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/Pagination/Pagination.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { Pagination } from './Pagination';
 

--- a/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import type { ComponentRef } from 'react';
 import { useEffect, useRef } from 'react';

--- a/packages/react/src/components/UserSearch/UserSearch.stories.tsx
+++ b/packages/react/src/components/UserSearch/UserSearch.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import { useRef, useState } from 'react';
 import { UserSearch, type UserSearchRef } from './UserSearch';

--- a/packages/react/src/modules/homepage/components/Header/Header.stories.tsx
+++ b/packages/react/src/modules/homepage/components/Header/Header.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 
 import Header from './Header';
 

--- a/packages/react/src/modules/homepage/components/HomeCard/HomeCard.spec.tsx
+++ b/packages/react/src/modules/homepage/components/HomeCard/HomeCard.spec.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from '~/setup';
+import HomeCard from './HomeCard';
+
+describe('HomeCard', () => {
+  it('renders with default "user" variant and base class', () => {
+    render(
+      <HomeCard>
+        <HomeCard.Content>content</HomeCard.Content>
+      </HomeCard>,
+    );
+
+    const card = screen.getByTestId('home-card');
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveClass('home-card');
+    expect(card).toHaveClass('home-card--user');
+    expect(card).toHaveAttribute('data-variant', 'user');
+  });
+
+  it.each(['user', 'primary', 'secondary'] as const)(
+    'applies the variant class for "%s"',
+    (variant) => {
+      render(
+        <HomeCard variant={variant}>
+          <HomeCard.Content>content</HomeCard.Content>
+        </HomeCard>,
+      );
+
+      const card = screen.getByTestId('home-card');
+      expect(card).toHaveClass(`home-card--${variant}`);
+      expect(card).toHaveAttribute('data-variant', variant);
+    },
+  );
+
+  it('renders children when provided', () => {
+    render(
+      <HomeCard>
+        <HomeCard.Header title="My title" />
+        <HomeCard.Content>My content</HomeCard.Content>
+      </HomeCard>,
+    );
+
+    expect(screen.getByText('My title')).toBeInTheDocument();
+    expect(screen.getByText('My content')).toBeInTheDocument();
+  });
+
+  it('forwards a custom className', () => {
+    render(
+      <HomeCard className="extra-class">
+        <HomeCard.Content>content</HomeCard.Content>
+      </HomeCard>,
+    );
+
+    expect(screen.getByTestId('home-card')).toHaveClass('extra-class');
+  });
+
+  it('renders default header from headerProps when no children are passed', () => {
+    render(
+      <HomeCard
+        headerProps={{
+          title: 'From props',
+          actionLabel: 'Action',
+          onActionClick: () => {},
+        }}
+      />,
+    );
+
+    expect(screen.getByText('From props')).toBeInTheDocument();
+    expect(screen.getByTestId('home-card-header-action')).toBeInTheDocument();
+  });
+});
+
+describe('HomeCard.Header', () => {
+  it('renders the title', () => {
+    render(<HomeCard.Header title="Hello" />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Hello').tagName).toBe('H3');
+  });
+
+  it('does not render the action button when no callback is provided', () => {
+    render(<HomeCard.Header title="Hello" actionLabel="See more" />);
+    expect(
+      screen.queryByTestId('home-card-header-action'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the action button when no label is provided', () => {
+    render(<HomeCard.Header title="Hello" onActionClick={() => {}} />);
+    expect(
+      screen.queryByTestId('home-card-header-action'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders the action button and calls the callback when clicked', async () => {
+    const onActionClick = vi.fn();
+    const { user } = render(
+      <HomeCard.Header
+        title="Hello"
+        actionLabel="See more"
+        onActionClick={onActionClick}
+      />,
+    );
+
+    const button = screen.getByTestId('home-card-header-action');
+    expect(button).toHaveTextContent('See more');
+
+    await user.click(button);
+    expect(onActionClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the action button with the ghost ButtonBeta variant', () => {
+    render(
+      <HomeCard.Header
+        title="Hello"
+        actionLabel="See more"
+        onActionClick={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('home-card-header-action')).toHaveClass(
+      'btn-beta--ghost',
+    );
+  });
+});
+
+describe('HomeCard.Content', () => {
+  it('renders its children inside the content wrapper', () => {
+    const { container } = render(
+      <HomeCard.Content>
+        <span>inner</span>
+      </HomeCard.Content>,
+    );
+
+    const wrapper = container.querySelector('.home-card-content');
+    expect(wrapper).toBeInTheDocument();
+    expect(wrapper).toHaveTextContent('inner');
+  });
+});

--- a/packages/react/src/modules/homepage/components/HomeCard/HomeCard.stories.tsx
+++ b/packages/react/src/modules/homepage/components/HomeCard/HomeCard.stories.tsx
@@ -1,0 +1,200 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+
+import hillsBackground from '@edifice.io/bootstrap/dist/images/backgrounds/hills.svg';
+import { ButtonBeta, Flex } from '../../../../components';
+import {
+  IconArrowRight,
+  IconClose,
+  IconSettings,
+} from '../../../icons/components';
+import HomeCard, { HomeCardProps } from './HomeCard';
+
+const meta: Meta<typeof HomeCard> = {
+  title: 'Modules/Homepage/HomeCard',
+  component: HomeCard,
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          minHeight: '100vh',
+          padding: '4rem',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          backgroundImage: `url(${hillsBackground})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          backgroundRepeat: 'no-repeat',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Compound component utilisé sur la homepage. Compose un `Header` (titre + bouton optionnel) et un `Content`. Trois variantes : `user`, `primary`, `secondary`.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      options: ['user', 'primary', 'secondary'],
+      control: { type: 'radio' },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof HomeCard>;
+
+const renderCard = (args: HomeCardProps) => (
+  <div style={{ maxWidth: 400 }}>
+    <HomeCard {...args}>
+      <HomeCard.Header
+        title="Mes infos"
+        actionLabel="Voir plus"
+        actionRightIcon={<IconArrowRight />}
+        onActionClick={() => alert('Action clicked')}
+      />
+      <HomeCard.Content>
+        <p>Contenu de la carte. À remplacer par le contenu utile.</p>
+      </HomeCard.Content>
+    </HomeCard>
+  </div>
+);
+
+export const User: Story = {
+  args: { variant: 'user' },
+  render: renderCard,
+  parameters: {
+    docs: {
+      description: { story: 'Variante `user` — padding 16, gap 16.' },
+    },
+  },
+};
+
+export const Primary: Story = {
+  args: { variant: 'primary' },
+  render: renderCard,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Variante `primary` — padding 8/16/16/16, gap 8. Titre en font title.',
+      },
+    },
+  },
+};
+
+export const Secondary: Story = {
+  args: { variant: 'secondary' },
+  render: renderCard,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Variante `secondary` — padding 8/16/16/16, gap 4, fond grey-100, titre en font body bold/small.',
+      },
+    },
+  },
+};
+
+export const WithoutAction: Story = {
+  args: { variant: 'primary' },
+  render: (args: HomeCardProps) => (
+    <div style={{ maxWidth: 400 }}>
+      <HomeCard {...args}>
+        <HomeCard.Header title="Titre simple" />
+        <HomeCard.Content>
+          <p>Pas de bouton dans le header.</p>
+        </HomeCard.Content>
+      </HomeCard>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Le bouton du `Header` n'est rendu que si `actionLabel` ET `onActionClick` sont fournis.",
+      },
+    },
+  },
+};
+
+export const Nested: Story = {
+  args: { variant: 'primary' },
+  render: (args: HomeCardProps) => (
+    <div style={{ maxWidth: 400 }}>
+      <HomeCard {...args}>
+        <HomeCard.Header
+          title="Mes infos"
+          actionLabel="Voir plus"
+          actionRightIcon={<IconArrowRight />}
+          onActionClick={() => alert('Action clicked')}
+        />
+        <HomeCard.Content>
+          <HomeCard variant="secondary">
+            <HomeCard.Header
+              title="Sous-section"
+              actionLabel="Voir"
+              onActionClick={() => alert('Sous-action')}
+            />
+            <HomeCard.Content>
+              <p>Contenu de la sous-carte secondary imbriquée.</p>
+            </HomeCard.Content>
+          </HomeCard>
+        </HomeCard.Content>
+      </HomeCard>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Carte `primary` contenant une carte `secondary` imbriquée dans son `Content` — illustre la composition de variantes.',
+      },
+    },
+  },
+};
+
+export const CustomHeader: Story = {
+  args: { variant: 'primary' },
+  render: (args: HomeCardProps) => (
+    <div style={{ maxWidth: 400 }}>
+      <HomeCard {...args}>
+        <Flex
+          align="center"
+          justify="between"
+          gap="8"
+          className="home-card-header"
+        >
+          <Flex align="center" gap="8">
+            <IconSettings />
+            <h3 className="home-card-header-title">Paramètres du widget</h3>
+          </Flex>
+          <ButtonBeta
+            color="default"
+            variant="ghost"
+            aria-label="Fermer"
+            onClick={() => alert('Fermer')}
+            leftIcon={<IconClose />}
+          />
+        </Flex>
+        <HomeCard.Content>
+          <p>Contenu de la carte. À remplacer par le contenu utile.</p>
+        </HomeCard.Content>
+      </HomeCard>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Le slot `Header` accepte n'importe quel contenu : ici un header custom avec une icône à gauche du titre et un bouton de fermeture à droite, sans utiliser `HomeCard.Header`.",
+      },
+    },
+  },
+};

--- a/packages/react/src/modules/homepage/components/HomeCard/HomeCard.tsx
+++ b/packages/react/src/modules/homepage/components/HomeCard/HomeCard.tsx
@@ -1,0 +1,70 @@
+import { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+import HomeCardContent from './HomeCardContent';
+import HomeCardHeader, { HomeCardHeaderProps } from './HomeCardHeader';
+
+export type HomeCardVariant = 'user' | 'primary' | 'secondary';
+
+export interface HomeCardProps extends ComponentPropsWithoutRef<'div'> {
+  /**
+   * Visual variant of the card.
+   * - `user` (default): padding 16, gap 16
+   * - `primary`: padding 8/16/16/16, gap 8
+   * - `secondary`: padding 8/16/16/16, gap 4, grey background, smaller title, no shadowbox
+   */
+  variant?: HomeCardVariant;
+  /**
+   * Children of the card. When omitted, a default `HomeCardHeader` will be
+   * rendered using the `headerProps` prop (handy for the common case where the
+   * card only needs a header + content slot).
+   */
+  children?: ReactNode;
+  /**
+   * Convenience prop: when provided and `children` is empty, a default
+   * `HomeCard.Header` is rendered with these props.
+   */
+  headerProps?: HomeCardHeaderProps;
+}
+
+/**
+ * HomeCard – Compound component used on the homepage.
+ *
+ * @example
+ * <HomeCard variant="primary">
+ *   <HomeCard.Header title="My title" actionLabel="See all" onActionClick={() => {}} />
+ *   <HomeCard.Content>...</HomeCard.Content>
+ * </HomeCard>
+ */
+const Root = ({
+  variant = 'user',
+  children,
+  headerProps,
+  className,
+  ...rest
+}: HomeCardProps) => {
+  return (
+    <div
+      data-testid="home-card"
+      data-variant={variant}
+      className={clsx('home-card', `home-card--${variant}`, className)}
+      {...rest}
+    >
+      {headerProps && !children ? (
+        <HomeCardHeader {...headerProps} />
+      ) : (
+        children
+      )}
+    </div>
+  );
+};
+
+Root.displayName = 'HomeCard';
+
+const HomeCard = Object.assign(Root, {
+  Header: HomeCardHeader,
+  Content: HomeCardContent,
+});
+
+export default HomeCard;

--- a/packages/react/src/modules/homepage/components/HomeCard/HomeCardContent.tsx
+++ b/packages/react/src/modules/homepage/components/HomeCard/HomeCardContent.tsx
@@ -1,0 +1,21 @@
+import { ComponentPropsWithoutRef } from 'react';
+
+import clsx from 'clsx';
+
+export type HomeCardContentProps = ComponentPropsWithoutRef<'div'>;
+
+const HomeCardContent = ({
+  children,
+  className,
+  ...rest
+}: HomeCardContentProps) => {
+  return (
+    <div className={clsx('home-card-content', className)} {...rest}>
+      {children}
+    </div>
+  );
+};
+
+HomeCardContent.displayName = 'HomeCard.Content';
+
+export default HomeCardContent;

--- a/packages/react/src/modules/homepage/components/HomeCard/HomeCardHeader.tsx
+++ b/packages/react/src/modules/homepage/components/HomeCard/HomeCardHeader.tsx
@@ -1,0 +1,61 @@
+import { ComponentPropsWithoutRef, MouseEventHandler, ReactNode } from 'react';
+
+import clsx from 'clsx';
+
+import { ButtonBeta, Flex } from '../../../../components';
+
+export interface HomeCardHeaderProps extends Omit<
+  ComponentPropsWithoutRef<'div'>,
+  'title'
+> {
+  /** Title displayed on the left side of the header. */
+  title: ReactNode;
+  /** Label of the action button displayed on the right side of the header. */
+  actionLabel?: ReactNode;
+  /** Callback invoked when the action button is clicked. */
+  onActionClick?: MouseEventHandler<HTMLButtonElement>;
+  /** Optional left icon of the action button. */
+  actionLeftIcon?: ReactNode;
+  /** Optional right icon of the action button. */
+  actionRightIcon?: ReactNode;
+}
+
+const HomeCardHeader = ({
+  title,
+  actionLabel,
+  onActionClick,
+  actionLeftIcon,
+  actionRightIcon,
+  className,
+  ...rest
+}: HomeCardHeaderProps) => {
+  const hasAction = Boolean(actionLabel) && Boolean(onActionClick);
+
+  return (
+    <Flex
+      align="center"
+      justify="between"
+      gap="8"
+      className={clsx('home-card-header', className)}
+      {...rest}
+    >
+      <h3 className="home-card-header-title">{title}</h3>
+      {hasAction && (
+        <ButtonBeta
+          color="default"
+          variant="ghost"
+          onClick={onActionClick}
+          leftIcon={actionLeftIcon}
+          rightIcon={actionRightIcon}
+          data-testid="home-card-header-action"
+        >
+          {actionLabel}
+        </ButtonBeta>
+      )}
+    </Flex>
+  );
+};
+
+HomeCardHeader.displayName = 'HomeCard.Header';
+
+export default HomeCardHeader;

--- a/packages/react/src/modules/homepage/components/HomeCard/index.ts
+++ b/packages/react/src/modules/homepage/components/HomeCard/index.ts
@@ -1,0 +1,4 @@
+export { default as HomeCard } from './HomeCard';
+export * from './HomeCard';
+export type { HomeCardHeaderProps } from './HomeCardHeader';
+export type { HomeCardContentProps } from './HomeCardContent';

--- a/packages/react/src/modules/homepage/components/LastInfos/LastInfosList.stories.tsx
+++ b/packages/react/src/modules/homepage/components/LastInfos/LastInfosList.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 
 import { mockLastInfos } from '@edifice.io/config/src/msw/mocks/actualites';
 import { LastInfosProps } from './LastInfos';

--- a/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlash.stories.tsx
+++ b/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlash.stories.tsx
@@ -5,7 +5,7 @@ import {
   mockMessageSuccess,
   mockMessageWarning,
 } from '@edifice.io/config';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import MessageFlash from './MessageFlash';
 
 const meta = {

--- a/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlashList.stories.tsx
+++ b/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlashList.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 
 import { mockMessages } from '@edifice.io/config';
 import MessageFlashList from './MessageFlashList';

--- a/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlashListContainer.stories.tsx
+++ b/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlashListContainer.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 
 import MessageFlashList from './MessageFlashList';
 import MessageFlashListContainer from './MessageFlashListContainer';

--- a/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.stories.tsx
+++ b/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.stories.tsx
@@ -1,5 +1,5 @@
 import { School } from '@edifice.io/client';
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
 import SchoolSpace, { SchoolSpaceProps } from './SchoolSpace';
 
 const meta: Meta<typeof SchoolSpace> = {

--- a/packages/react/src/modules/homepage/components/index.tsx
+++ b/packages/react/src/modules/homepage/components/index.tsx
@@ -1,4 +1,5 @@
 export * from './Header';
+export * from './HomeCard';
 export * from './LastInfos';
 export * from './MessageFlashList';
 export * from './SchoolSpace';


### PR DESCRIPTION
# Description

Introduces a new `HomeCard` compound component, designed for flexible usage across homepage sections. This component provides a structured layout comprising a header with an optional action button and a dedicated content area. It supports three distinct visual variants (`user`, `primary`, `secondary`) to adapt to various design requirements. The component includes comprehensive styling, unit tests, and Storybook documentation.

This feature enables a standardized and reusable building block for constructing different information cards on the homepage.

J'ai aussi corrigé des erreurs typescript dans les stories

## Which Package changed?

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

Relates to ENABLING-821