### PR TITLE
fix(homepage): #IMPULS-5441, refacto widget hooks

### DIFF
--- a/packages/client/src/ts/services/OdeServices.ts
+++ b/packages/client/src/ts/services/OdeServices.ts
@@ -1,28 +1,29 @@
+import { AnalyticsService } from '../analytics/Service';
+import { AudienceService } from '../audience/Service';
+import { IAudienceService } from '../audience/interface';
 import { CacheService } from '../cache/Service';
 import { ConfService } from '../configure/Service';
+import { DataService } from '../data/Service';
+import { IDataService } from '../data/interface';
 import { DirectoryService } from '../directory/Service';
-import { HttpService } from '../transport/Service';
-import { ResourceService } from '../resources/ResourceService';
-import { RightService } from '../rights/Service';
-import { SessionService } from '../session/Service';
-import { ShareService } from '../share/Service';
-import { WorkspaceService } from '../workspace/Service';
-import { IdiomService } from '../idiom/Service';
-import { AnalyticsService } from '../analytics/Service';
-import { IAudienceService } from '../audience/interface';
-import { VideoService } from '../video/Service';
+import { EmbedderService } from '../embedder/Service';
 import { App, ResourceType } from '../globals';
+import { IdiomService } from '../idiom/Service';
+import { INotifyFramework, NotifyFrameworkFactory } from '../notify/interfaces';
+import { ResourceService } from '../resources/ResourceService';
+import { SnipletsService } from '../resources/SnipletsService';
 import {
   IBehaviourService,
   IResourceService,
   IWebResourceService,
 } from '../resources/interface';
-import { EmbedderService } from '../embedder/Service';
-import { INotifyFramework, NotifyFrameworkFactory } from '../notify/interfaces';
-import { SnipletsService } from '../resources/SnipletsService';
-import { DataService } from '../data/Service';
-import { IDataService } from '../data/interface';
-import { AudienceService } from '../audience/Service';
+import { RightService } from '../rights/Service';
+import { SessionService } from '../session/Service';
+import { ShareService } from '../share/Service';
+import { HttpService } from '../transport/Service';
+import { VideoService } from '../video/Service';
+import { WidgetService } from '../widget/Service';
+import { WorkspaceService } from '../workspace/Service';
 
 export interface IOdeServices {
   analytics(): AnalyticsService;
@@ -43,6 +44,7 @@ export interface IOdeServices {
   session(): SessionService;
   share(): ShareService;
   video(): VideoService;
+  widget(): WidgetService;
   workspace(): WorkspaceService;
   embedder(): EmbedderService;
 }
@@ -60,6 +62,7 @@ export class OdeServices implements IOdeServices {
   private _session: SessionService;
   private _share: ShareService;
   private _video: VideoService;
+  private _widget: WidgetService;
   private _workspace: WorkspaceService;
   private _embedder: EmbedderService;
 
@@ -76,6 +79,7 @@ export class OdeServices implements IOdeServices {
     this._session = new SessionService(this);
     this._share = new ShareService(this);
     this._video = new VideoService(this);
+    this._widget = new WidgetService(this);
     this._workspace = new WorkspaceService(this);
     this._embedder = new EmbedderService(this);
   }
@@ -149,6 +153,10 @@ export class OdeServices implements IOdeServices {
 
   video() {
     return this._video;
+  }
+
+  widget() {
+    return this._widget;
   }
 
   workspace() {

--- a/packages/client/src/ts/services/index.ts
+++ b/packages/client/src/ts/services/index.ts
@@ -1,8 +1,8 @@
 // TODO should be loaded from React app in future
-import '../resources/services/ScrapbookResourceService';
-import '../resources/services/HomeworksResourceService';
-import '../resources/services/TimelineGeneratorResourceService';
 import '../resources/services/CollaborativeEditorResourceService';
+import '../resources/services/HomeworksResourceService';
+import '../resources/services/ScrapbookResourceService';
+import '../resources/services/TimelineGeneratorResourceService';
 
 import { IOdeServices, OdeServices } from './OdeServices';
 
@@ -15,4 +15,5 @@ export * from '../resources/ResourceService';
 export * from '../resources/SnipletsService'; // FIXME to be removed when dropping behaviours
 export * from '../rights/interface';
 export * from '../share/interface';
+export type { IWidgetPreferences } from '../widget/Service';
 export * from '../workspace/interface';

--- a/packages/client/src/ts/widget/Service.ts
+++ b/packages/client/src/ts/widget/Service.ts
@@ -17,7 +17,8 @@ export class WidgetService {
       const user = await this.session.getUser();
       return user?.widgets;
     } catch (e) {
-      return undefined;
+      console.error('[WidgetService] getSystemWidgets failed', e);
+      throw e;
     }
   }
 

--- a/packages/client/src/ts/widget/Service.ts
+++ b/packages/client/src/ts/widget/Service.ts
@@ -1,0 +1,34 @@
+import { IOdeServices } from '../services/OdeServices';
+import { WidgetUserPref } from './interfaces';
+
+export interface IWidgetPreferences {
+  [widgetName: string]: WidgetUserPref;
+}
+
+export class WidgetService {
+  constructor(private context: IOdeServices) {}
+
+  private get session() {
+    return this.context.session();
+  }
+
+  public async getSystemWidgets() {
+    try {
+      const user = await this.session.getUser();
+      return user?.widgets;
+    } catch (e) {
+      return undefined;
+    }
+  }
+
+  public async getPreferences() {
+    const prefs = await this.context
+      .conf()
+      .getPreference<IWidgetPreferences>('widgets');
+    return prefs;
+  }
+
+  public async setPreferences(prefs: IWidgetPreferences) {
+    await this.context.conf().savePreference('widgets', prefs);
+  }
+}

--- a/packages/react/src/modules/homepage/components/SchoolSpace/useUserSchools.ts
+++ b/packages/react/src/modules/homepage/components/SchoolSpace/useUserSchools.ts
@@ -1,12 +1,11 @@
-import { School, WIDGET_NAME, WidgetUserPref } from '@edifice.io/client';
+import { School, WIDGET_NAME } from '@edifice.io/client';
 import { useEffect, useState } from 'react';
 import { useSession } from 'src/hooks/useSession';
-import useWidgetPreferences from '../../hooks/useWidgetPreferences';
+import useWidget from '../../hooks/useWidget';
 
 export function useUserSchools() {
   const { data: session } = useSession();
-  const { lookup, saveUserPreferences } = useWidgetPreferences();
-  const [userPreferences, setUserPreferences] = useState<WidgetUserPref>();
+  const { preference, savePreference } = useWidget(WIDGET_NAME.SCHOOL);
   const [selectedSchool, setSelectedSchool] = useState<School>();
   const [schools, setSchools] = useState(session?.userDescription?.schools);
 
@@ -17,37 +16,31 @@ export function useUserSchools() {
     setSelectedSchool(newSchools?.[0]);
   }, [session?.userDescription?.schools]);
 
-  // Memoize user's preferences for this widget, depending on the 'lookup' function availability.
-  useEffect(() => {
-    const userPref = lookup?.(WIDGET_NAME.SCHOOL)?.userPref;
-    setUserPreferences(userPref);
-  }, [lookup]);
-
   // Select the user's prefered school
   useEffect(() => {
     if (Array.isArray(schools)) {
       if (schools.length === 1) {
         setSelectedSchool(schools[0]);
-      } else if (userPreferences?.schoolId) {
+      } else if (preference?.schoolId) {
         const index = schools.findIndex(
-          (school) => school.id === userPreferences?.schoolId,
+          (school) => school.id === preference?.schoolId,
         );
         setSelectedSchool(
           index < 0 || index >= schools.length ? schools[0] : schools[index],
         );
       }
     }
-  }, [userPreferences, schools]);
+  }, [preference, schools]);
 
   return {
     schools: schools ?? [],
     selectedSchool,
     handleSelectedSchoolChange: (school: School) => {
       setSelectedSchool(school);
-      if (userPreferences) {
+      if (preference) {
         // Update user's preferences and save them
-        userPreferences.schoolId = school.id;
-        saveUserPreferences();
+        preference.schoolId = school.id;
+        savePreference(preference);
       }
     },
   };

--- a/packages/react/src/modules/homepage/components/SchoolSpace/useUserSchools.ts
+++ b/packages/react/src/modules/homepage/components/SchoolSpace/useUserSchools.ts
@@ -39,8 +39,7 @@ export function useUserSchools() {
       setSelectedSchool(school);
       if (preference) {
         // Update user's preferences and save them
-        preference.schoolId = school.id;
-        savePreference(preference);
+        savePreference({ ...preference, schoolId: school.id });
       }
     },
   };

--- a/packages/react/src/modules/homepage/hooks/useWidget.ts
+++ b/packages/react/src/modules/homepage/hooks/useWidget.ts
@@ -4,7 +4,7 @@ import {
   WidgetPosition,
   WidgetUserPref,
 } from '@edifice.io/client';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useWidgetPreferences } from './useWidgetPreferences';
 
 // Default index and position values for widgets.
@@ -34,7 +34,10 @@ const DEFAULT_VALUES = new Map<
 export default function useWidget(widgetName: WidgetName) {
   const { widgets, preferences, savePreferences } = useWidgetPreferences();
 
-  const [widget] = useState(() => widgets?.find((w) => w.name === widgetName));
+  const widget = useMemo(
+    () => widgets?.find((w) => w.name === widgetName),
+    [widgets, widgetName],
+  );
   const [preference, setPreference] = useState<WidgetUserPref>();
 
   const savePreference = useCallback(
@@ -44,14 +47,8 @@ export default function useWidget(widgetName: WidgetName) {
         return savePreferences(preferences);
       }
     },
-    [preferences, savePreferences],
+    [preferences, savePreferences, widgetName],
   );
-
-  // useEffect( () => {
-  //   if( !widget ) {
-  //     setWidget( widgets?.find((w) => w.name === widgetName) );
-  //   }
-  // }, [widgets])
 
   useEffect(() => {
     const defaultValue = DEFAULT_VALUES.get(widgetName);
@@ -65,7 +62,7 @@ export default function useWidget(widgetName: WidgetName) {
       pref.index = defaultValue?.index ?? 0;
     }
     setPreference(pref);
-  }, [preferences]);
+  }, [preferences, widget, widgetName]);
 
   return {
     widget,

--- a/packages/react/src/modules/homepage/hooks/useWidget.ts
+++ b/packages/react/src/modules/homepage/hooks/useWidget.ts
@@ -1,0 +1,75 @@
+import {
+  WIDGET_POSITION,
+  WidgetName,
+  WidgetPosition,
+  WidgetUserPref,
+} from '@edifice.io/client';
+import { useCallback, useEffect, useState } from 'react';
+import { useWidgetPreferences } from './useWidgetPreferences';
+
+// Default index and position values for widgets.
+const DEFAULT_VALUES = new Map<
+  WidgetName,
+  { index: number; position: WidgetPosition }
+>()
+  .set('school-widget', { index: 0, position: WIDGET_POSITION.LEFT })
+  .set('my-apps', { index: 10, position: WIDGET_POSITION.RIGHT })
+  .set('record-me', { index: 15, position: WIDGET_POSITION.RIGHT })
+  .set('last-infos-widget', { index: 20, position: WIDGET_POSITION.LEFT }) // Actualités
+  .set('qwant', { index: 30, position: WIDGET_POSITION.RIGHT })
+  .set('qwant-junior', { index: 30, position: WIDGET_POSITION.LEFT })
+  .set('universalis-widget', { index: 35, position: WIDGET_POSITION.RIGHT })
+  .set('agenda-widget', { index: 40, position: WIDGET_POSITION.LEFT }) // Agenda
+  .set('bookmark-widget', { index: 50, position: WIDGET_POSITION.RIGHT })
+  .set('carnet-de-bord', { index: 60, position: WIDGET_POSITION.LEFT })
+  .set('maxicours-widget', { index: 70, position: WIDGET_POSITION.RIGHT })
+  .set('cursus-widget', { index: 80, position: WIDGET_POSITION.LEFT }) // Dictaphone
+  .set('briefme-widget', { index: 90, position: WIDGET_POSITION.LEFT })
+  .set('rss-widget', { index: 100, position: WIDGET_POSITION.LEFT })
+  .set('mood', { index: 110, position: WIDGET_POSITION.LEFT })
+  .set('birthday', { index: 120, position: WIDGET_POSITION.LEFT })
+  .set('calendar-widget', { index: 130, position: WIDGET_POSITION.RIGHT }) // Calendrier
+  .set('notes', { index: 140, position: WIDGET_POSITION.RIGHT });
+
+export default function useWidget(widgetName: WidgetName) {
+  const { widgets, preferences, savePreferences } = useWidgetPreferences();
+
+  const [widget] = useState(() => widgets?.find((w) => w.name === widgetName));
+  const [preference, setPreference] = useState<WidgetUserPref>();
+
+  const savePreference = useCallback(
+    (pref: WidgetUserPref) => {
+      if (preferences) {
+        preferences[widgetName] = pref;
+        return savePreferences(preferences);
+      }
+    },
+    [preferences, savePreferences],
+  );
+
+  // useEffect( () => {
+  //   if( !widget ) {
+  //     setWidget( widgets?.find((w) => w.name === widgetName) );
+  //   }
+  // }, [widgets])
+
+  useEffect(() => {
+    const defaultValue = DEFAULT_VALUES.get(widgetName);
+    const pref = preferences?.[widgetName] ?? {
+      index: defaultValue?.index ?? 999,
+      show: true,
+      position: defaultValue?.position,
+    };
+    if (widget?.mandatory) {
+      pref.show = true;
+      pref.index = defaultValue?.index ?? 0;
+    }
+    setPreference(pref);
+  }, [preferences]);
+
+  return {
+    widget,
+    preference,
+    savePreference,
+  };
+}

--- a/packages/react/src/modules/homepage/hooks/useWidgetPreferences.ts
+++ b/packages/react/src/modules/homepage/hooks/useWidgetPreferences.ts
@@ -1,22 +1,47 @@
-import { IWidgetFramework, WidgetFrameworkFactory } from '@edifice.io/client';
-import { useMutation } from '@tanstack/react-query';
-import { useEffect, useState } from 'react';
+import { IWidgetPreferences, odeServices } from '@edifice.io/client';
+import {
+  queryOptions,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
-export default function useWidgetPreferences() {
-  const [svc, setSvc] = useState<IWidgetFramework>();
+const WIDGETS_QUERY_KEY = ['widgets', 'system'];
+const PREFERENCES_QUERY_KEY = ['widgets', 'preferences'];
 
-  const saveMutation = useMutation({
-    mutationFn: svc?.saveUserPrefs,
+export function useWidgetPreferences() {
+  const queryClient = useQueryClient();
+
+  const { data: widgets } = useQuery(
+    queryOptions({
+      queryKey: WIDGETS_QUERY_KEY,
+      queryFn: () => odeServices.widget().getSystemWidgets(),
+    }),
+  );
+
+  const { data: preferences } = useQuery(
+    queryOptions({
+      queryKey: PREFERENCES_QUERY_KEY,
+      queryFn: () => odeServices.widget().getPreferences(),
+    }),
+  );
+
+  const preferencesMutation = useMutation({
+    mutationFn: (prefs: IWidgetPreferences) =>
+      odeServices.widget().setPreferences(prefs),
+    onMutate: async (prefs) => {
+      // Optimistic update
+      queryClient.setQueryData(PREFERENCES_QUERY_KEY, () => prefs);
+    },
+    onError() {
+      queryClient.invalidateQueries({ queryKey: PREFERENCES_QUERY_KEY });
+    },
   });
 
-  useEffect(() => {
-    const widgetService = WidgetFrameworkFactory.instance();
-    widgetService.initialize(null, null).then(() => setSvc(widgetService));
-  }, []);
-
   return {
-    list: svc?.list,
-    lookup: svc?.lookup,
-    saveUserPreferences: saveMutation.mutateAsync,
+    widgets,
+    preferences,
+    savePreferences: (prefs: IWidgetPreferences) =>
+      preferencesMutation.mutateAsync(prefs),
   };
 }


### PR DESCRIPTION
# Description

Refacto des préferences pour les widgets : 
- création d'un service `widget` dans odeServices,
- refonte du hook `useWidgetPreferences`
- ajout du hook `useWidget` qui permet d'extraire les préférences et le paramètrage de la plateforme pour 1 widget donné.

`useWidgetPreferences` gère toutes les préférences de TOUS les widgets, car l'API backend fonctionne comme cela.
Auparavant, , il s'occupait d'initialiser le service tiré de l'ancien Framework, mais cela ne peut plus fonctionner avec la couche `odeServices` pensée pour React (le bug de sélection d'établissement non-mémorisé venait de là).

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [X] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
