### PR TITLE
  fix: ENABLING-840 fix linters, formatters and TypeScript errors

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -10,14 +10,13 @@
     "strict": true,
     "forceConsistentCasingInFileNames": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "baseUrl": ".",
     "paths": {
-      "@images/*": ["node_modules/@edifice.io/bootstrap/dist/images/*"]
+      "@images/*": ["./node_modules/@edifice.io/bootstrap/dist/images/*"]
     }
   },
   "include": ["src", "i18n.ts"],

--- a/apps/docs/tsconfig.node.json
+++ b/apps/docs/tsconfig.node.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "module": "ESNext",
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true
   }
 }

--- a/apps/tiptap-playground/eslint.config.js
+++ b/apps/tiptap-playground/eslint.config.js
@@ -12,6 +12,9 @@ export default tseslint.config(
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     plugins: {
       'react-hooks': reactHooks,

--- a/apps/tiptap-playground/package.json
+++ b/apps/tiptap-playground/package.json
@@ -18,7 +18,8 @@
   "scripts": {
     "build": "pnpm run typecheck && vite build",
     "dev": "vite",
-    "format": "prettier --write .",
+    "format": "prettier --check .",
+    "format:write": "prettier --write .",
     "lint": "eslint",
     "preview": "vite preview",
     "typecheck": "tsc -b --noEmit"

--- a/apps/tiptap-playground/tsconfig.app.json
+++ b/apps/tiptap-playground/tsconfig.app.json
@@ -20,10 +20,9 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
 
-    "baseUrl": ".",
     "paths": {
-      "~/*": ["src/*"],
-      "@images/*": ["node_modules/@edifice.io/bootstrap/dist/images/*"]
+      "~/*": ["./src/*"],
+      "@images/*": ["./node_modules/@edifice.io/bootstrap/dist/images/*"]
     },
     "types": ["node", "vite/client"]
   },

--- a/eff.code-workspace
+++ b/eff.code-workspace
@@ -36,7 +36,6 @@
     "workbench.startupEditor": "none",
     "scss.format.spaceAroundSelectorSeparator": true,
     "scss.format.enable": false,
-    "eslint.format.enable": true,
     "window.commandCenter": false,
   },
   "extensions": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "preinstall": "npx only-allow pnpm",
     "lint": "turbo run lint --filter=./packages/**",
     "pre-commit": "pnpm run lint && pnpm run format && pnpm run test",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "turbo run test --filter=./packages/react",
     "test:client": "turbo run test --filter=./packages/client"
   },

--- a/packages/bootstrap/package.json
+++ b/packages/bootstrap/package.json
@@ -28,9 +28,8 @@
     "clean": "rm -rf dist",
     "compile": "sass --load-path=node_modules/ --style=compressed --quiet-deps --silence-deprecation=import src/index.scss dist/index.css",
     "fix": "stylelint src/**/*.scss --fix",
-    "format": "pnpm format:write && pnpm format:check",
-    "format:check": "npx prettier --check src/**/*.scss",
-    "format:write": "npx prettier --write src/**/*.scss",
+    "format": "prettier --check src/**/*.scss",
+    "format:write": "prettier --write src/**/*.scss",
     "generate-commit-version": "node scripts/version.cjs",
     "lint": "stylelint src/**/*.scss",
     "watch": "sass --watch --load-path=node_modules/ --style=compressed --quiet-deps --silence-deprecation=import src/index.scss dist/index.css"

--- a/packages/client/eslint.config.js
+++ b/packages/client/eslint.config.js
@@ -10,6 +10,9 @@ export default tseslint.config(
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       '@typescript-eslint/no-unused-expressions': 'off',

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -37,9 +37,8 @@
     "build": "vite build",
     "docs": "npx rimraf ./docs/ && npx typedoc src/ts/index.ts --excludePrivate --disableSources --plugin typedoc-plugin-markdown",
     "fix": "eslint --fix --report-unused-disable-directives --max-warnings 0",
-    "format": "pnpm run format:write && pnpm run format:check",
-    "format:check": "npx prettier --check \"src/ts/**/*.ts\"",
-    "format:write": "npx prettier --write \"src/ts/**/*.ts\"",
+    "format": "prettier --check \"src/ts/**/*.ts\"",
+    "format:write": "prettier --write \"src/ts/**/*.ts\"",
     "lint": "eslint",
     "test": "vitest"
   },

--- a/packages/client/src/ts/directory/Service.ts
+++ b/packages/client/src/ts/directory/Service.ts
@@ -38,6 +38,7 @@ export class DirectoryService {
       return {
         id,
         displayName: name,
+        notVisibleCount: 0,
         members: [], // this api does not return members
       };
     });
@@ -96,13 +97,14 @@ export class DirectoryService {
     });
     const bookmarkDetailPromises = bookmarks.map(async (bookmark) => {
       if (typeof bookmark === 'string') {
-        const { displayName, groups, id, users } =
+        const { displayName, groups, id, notVisibleCount, users } =
           await this.getBookMarkById(bookmark);
         const usersId = users.map((user) => user.id);
         const groupId = groups.map((user) => user.id);
         const tmp: BookmarkWithMembers = {
           displayName,
           id,
+          notVisibleCount,
           members: [...groupId, ...usersId],
         };
         return tmp;
@@ -132,6 +134,7 @@ export class DirectoryService {
     return {
       id,
       displayName: name,
+      notVisibleCount: 0,
       members: data.members,
     };
   }

--- a/packages/client/src/ts/resources/behaviours/AppointmentsBehaviour.ts
+++ b/packages/client/src/ts/resources/behaviours/AppointmentsBehaviour.ts
@@ -3,8 +3,8 @@ import { AbstractBehaviourService } from './AbstractBehaviourService';
 type GridData = {
   id: number;
   name: string;
-  ownerId: string;  
-  ownerName: string;  
+  ownerId: string;
+  ownerName: string;
   updatingDate: string;
   color: string;
 };
@@ -14,18 +14,18 @@ const hexToDataUrl = (hex: string, width: number = 1, height: number = 1) => {
   canvas.width = width;
   canvas.height = height;
   const ctx = canvas.getContext('2d');
-  if (!ctx) return "";
+  if (!ctx) return '';
   ctx.fillStyle = hex;
   ctx.fillRect(0, 0, width, height);
   return canvas.toDataURL('image/png');
-}
+};
 
 export class AppointmentsBehaviour extends AbstractBehaviourService {
   APP = 'appointments';
   RESOURCE = 'appointments';
 
   async loadResources() {
-    const data = await this.httpGet<GridData[]>('/appointments/grids/linker',);
+    const data = await this.httpGet<GridData[]>('/appointments/grids/linker');
     return data.map((grid) => {
       return this.dataToResource({
         _id: grid.id.toString(),

--- a/packages/client/tsconfig.json
+++ b/packages/client/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ESNext",
     "useDefineForClassFields": true,
     "lib": ["ESNext", "dom"],
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "strict": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/packages/extensions/eslint.config.js
+++ b/packages/extensions/eslint.config.js
@@ -10,6 +10,9 @@ export default tseslint.config(
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       '@typescript-eslint/no-unused-expressions': 'off',

--- a/packages/extensions/package.json
+++ b/packages/extensions/package.json
@@ -124,9 +124,8 @@
   "scripts": {
     "build": "vite build",
     "fix": "eslint --fix --report-unused-disable-directives --max-warnings 0",
-    "format": "pnpm run format:write && pnpm run format:check",
-    "format:check": "npx prettier --check \"src/**/*.ts\"",
-    "format:write": "npx prettier --write \"src/**/*.ts\"",
+    "format": "prettier --check \"src/**/*.ts\"",
+    "format:write": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint"
   },
   "dependencies": {

--- a/packages/extensions/src/attachment/attachment-transformer.ts
+++ b/packages/extensions/src/attachment/attachment-transformer.ts
@@ -7,7 +7,8 @@ export interface AttachmentOptions {
 declare module '@tiptap/core' {
   interface Commands<ReturnType> {
     attachment: {
-      setAttachment: (attachment) => ReturnType;
+      setAttachment: (attachment: any) => ReturnType;
+      unsetAttachment: (documentId: string) => ReturnType;
     };
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -77,9 +77,8 @@
     "build:icons": "svgr src/modules/icons/assets --config-file ./svgr.config.cjs",
     "build:analyze": "vite build --mode analyze",
     "fix": "eslint --fix --report-unused-disable-directives --max-warnings 0",
-    "format": "pnpm run format:write && pnpm run format:check",
-    "format:check": "npx prettier --check \"src/**/*.{ts,tsx}\"",
-    "format:write": "npx prettier --write \"src/**/*.{ts,tsx}\"",
+    "format": "prettier --check \"src/**/*.{ts,tsx}\"",
+    "format:write": "prettier --write \"src/**/*.{ts,tsx}\"",
     "lint": "eslint",
     "test": "vitest",
     "test:watch": "vitest --watch"

--- a/packages/react/src/components/AddAttachments/AddAttachments.stories.tsx
+++ b/packages/react/src/components/AddAttachments/AddAttachments.stories.tsx
@@ -24,6 +24,7 @@ const mockAttachments: Attachment[] = [
     filename: 'document.pdf',
     name: 'Document PDF',
     size: 102400,
+    file: new File([], 'document.pdf'),
   },
   {
     id: 'attachment-2',
@@ -33,6 +34,7 @@ const mockAttachments: Attachment[] = [
     filename: 'image.png',
     name: 'Image PNG',
     size: 51200,
+    file: new File([], 'image.png'),
   },
   {
     id: 'attachment-3',
@@ -43,6 +45,7 @@ const mockAttachments: Attachment[] = [
     filename: 'spreadsheet.xlsx',
     name: 'Feuille de calcul',
     size: 204800,
+    file: new File([], 'spreadsheet.xlsx'),
   },
 ];
 

--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -28,12 +28,12 @@ const meta: Meta<typeof Alert> = {
     },
     onClose: {
       control: {
-        type: null,
+        type: undefined,
       },
     },
     onVisibilityChange: {
       control: {
-        type: null,
+        type: undefined,
       },
     },
   },

--- a/packages/react/src/components/Avatar/Avatar.stories.tsx
+++ b/packages/react/src/components/Avatar/Avatar.stories.tsx
@@ -47,7 +47,7 @@ export const Base: Story = {
 };
 
 export const AvatarSizes: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <div className="d-flex align-items-center gap-8">
         <Avatar size="xs" alt="alternative text" />
@@ -69,7 +69,7 @@ export const AvatarSizes: Story = {
 };
 
 export const AvatarShapes: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <div className="d-flex align-items-center gap-8">
         <Avatar
@@ -105,7 +105,7 @@ export const AvatarShapes: Story = {
 };
 
 export const AvatarFallback: Story = {
-  render: (args) => (
+  render: () => (
     <Avatar src={noAvatar} size="md" variant="square" alt="alternative text" />
   ),
 
@@ -120,7 +120,7 @@ export const AvatarFallback: Story = {
 };
 
 export const AvatarCustomFallback: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Avatar
         size="md"

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -150,7 +150,7 @@ export const BadgeContent: Story = {
     variant: { type: 'content', level: 'success', background: true },
   },
 
-  render: (args: BadgeProps) => {
+  render: (args) => {
     return <Badge {...args}>Visible</Badge>;
   },
 
@@ -169,7 +169,7 @@ export const BadgeProfile: Story = {
     variant: { type: 'user', profile: 'Student', background: true },
   },
 
-  render: (args: BadgeProps) => {
+  render: (args) => {
     return <Badge {...args}>Profil</Badge>;
   },
 
@@ -188,7 +188,7 @@ export const BadgeChip: Story = {
     variant: { type: 'chip' },
   },
 
-  render: (args: BadgeProps) => {
+  render: (args) => {
     return (
       <Badge {...args}>
         <IconHourglass width="20" height="20" className="me-8" />
@@ -212,7 +212,7 @@ export const BadgeLink: Story = {
     variant: { type: 'link' },
   },
 
-  render: (args: BadgeProps) => {
+  render: (args) => {
     return (
       <Badge {...args}>
         <a href="/">An history of time</a>
@@ -235,7 +235,7 @@ export const BadgeNotification: Story = {
     variant: { type: 'notification', level: 'danger' },
   },
 
-  render: (args: BadgeProps) => {
+  render: (args) => {
     return <Badge {...args}>9</Badge>;
   },
 
@@ -273,7 +273,7 @@ export const BadgeBetaCommunities: Story = {
       },
     },
   },
-  render: (args: BadgeProps) => {
+  render: (args) => {
     return <Badge {...args} />;
   },
 };
@@ -302,7 +302,7 @@ export const BadgeBetaBlog: Story = {
       },
     },
   },
-  render: (args: BadgeProps) => {
+  render: (args) => {
     return <Badge {...args} />;
   },
 };

--- a/packages/react/src/components/Button/stories/Button.stories.tsx
+++ b/packages/react/src/components/Button/stories/Button.stories.tsx
@@ -183,7 +183,7 @@ export const LoadingButtonWithCustomIcon: Story = {
 };
 
 export const ButtonGroupWithSecondaryAction: Story = {
-  render: (args: ButtonProps) => {
+  render: (args) => {
     return (
       <div className="d-flex align-items-center gap-8">
         <Button {...args} color="secondary" variant="outline">
@@ -207,7 +207,7 @@ export const ButtonGroupWithSecondaryAction: Story = {
 };
 
 export const ButtonGroupWithIconButton: Story = {
-  render: (args: ButtonProps) => {
+  render: (args) => {
     return (
       <div className="d-flex align-items-center gap-8">
         <Button {...args} color="primary" variant="filled">
@@ -235,7 +235,7 @@ export const ButtonGroupWithIconButton: Story = {
 };
 
 export const ButtonGroupWithThirdAction: Story = {
-  render: (args: ButtonProps) => {
+  render: (args) => {
     return (
       <div className="d-flex align-items-center gap-8">
         <Button

--- a/packages/react/src/components/Button/stories/SearchButton.stories.tsx
+++ b/packages/react/src/components/Button/stories/SearchButton.stories.tsx
@@ -1,10 +1,12 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 
 import { IconSearch, IconUserSearch } from '../../../modules/icons/components';
-import SearchButton from '../SearchButton';
+import SearchButton, { SearchButtonProps } from '../SearchButton';
+
+type SearchButtonStoryArgs = SearchButtonProps & { 'aria-label': string };
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
-const meta: Meta<typeof SearchButton> = {
+const meta: Meta<SearchButtonStoryArgs> = {
   title: 'Components/Buttons/SearchButton',
   component: SearchButton,
   args: {
@@ -25,7 +27,7 @@ const meta: Meta<typeof SearchButton> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof SearchButton>;
+type Story = StoryObj<SearchButtonStoryArgs>;
 
 export const Base: Story = {};
 

--- a/packages/react/src/components/Card/CardContext.tsx
+++ b/packages/react/src/components/Card/CardContext.tsx
@@ -4,8 +4,10 @@ import { IWebApp } from '@edifice.io/client';
 
 import { CardProps } from './Card';
 
-export interface CardContextProps
-  extends Omit<CardProps, 'children' | 'className'> {
+export interface CardContextProps extends Omit<
+  CardProps,
+  'children' | 'className'
+> {
   app?: IWebApp | undefined;
   appCode: string | undefined;
   isSelectable?: boolean;

--- a/packages/react/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.stories.tsx
@@ -48,7 +48,7 @@ export const Base: Story = {
 };
 
 export const Disabled: Story = {
-  render: (args) => {
+  render: () => {
     const [isChecked, setIsChecked] = useState(true);
 
     return (
@@ -65,7 +65,7 @@ export const Disabled: Story = {
 };
 
 export const Indeterminate: Story = {
-  render: (args) => {
+  render: () => {
     const [isChecked, setIsChecked] = useState(false);
     const [isIndeterminate, setIsIndeterminate] = useState(true);
 

--- a/packages/react/src/components/Checkbox/Checkbox.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.tsx
@@ -9,8 +9,7 @@ import {
 
 import clsx from 'clsx';
 
-export interface CheckboxProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
   /**
    * Add a label
    */

--- a/packages/react/src/components/ColorPicker/stories/ColorPicker.stories.tsx
+++ b/packages/react/src/components/ColorPicker/stories/ColorPicker.stories.tsx
@@ -1,8 +1,8 @@
-import { Meta, StoryObj } from '@storybook/react-vite';
+import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 
 import { useState } from 'react';
 import { ColorPaletteItem, DefaultPalette } from '../ColorPalette';
-import ColorPicker, { ColorPickerProps } from '../ColorPicker';
+import ColorPicker from '../ColorPicker';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<typeof ColorPicker> = {
@@ -21,7 +21,7 @@ const meta: Meta<typeof ColorPicker> = {
 export default meta;
 type Story = StoryObj<typeof ColorPicker>;
 
-const Template = (args: ColorPickerProps) => {
+const Template: StoryFn<typeof ColorPicker> = (args) => {
   const [currentColor, setCurrentColor] = useState<string>('#4A4A4A');
   const handleOnChange = (color: ColorPaletteItem) =>
     setCurrentColor(color.value);
@@ -35,16 +35,22 @@ export const Base: Story = {
 };
 
 export const Reset: Story = {
-  render: (args: ColorPickerProps) => {
-    const newArgs = {
-      ...args,
-      palettes: [
-        {
-          ...DefaultPalette,
-          reset: { value: 'transparent', description: 'None', isReset: true },
-        },
-      ],
-    };
-    return Template(newArgs);
+  render: (args) => {
+    const [currentColor, setCurrentColor] = useState<string>('#4A4A4A');
+    const handleOnChange = (color: ColorPaletteItem) =>
+      setCurrentColor(color.value);
+    return (
+      <ColorPicker
+        {...args}
+        model={currentColor}
+        onSuccess={handleOnChange}
+        palettes={[
+          {
+            ...DefaultPalette,
+            reset: { value: 'transparent', description: 'None', isReset: true },
+          },
+        ]}
+      />
+    );
   },
 };

--- a/packages/react/src/components/Combobox/Combobox.tsx
+++ b/packages/react/src/components/Combobox/Combobox.tsx
@@ -16,8 +16,7 @@ import { Dropdown } from '../Dropdown';
 import { Loading } from '../Loading';
 import ComboboxTrigger from './ComboboxTrigger';
 
-export interface ComboboxProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface ComboboxProps extends React.InputHTMLAttributes<HTMLInputElement> {
   onSearchInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
   options: OptionListItemType[];
   value: string;

--- a/packages/react/src/components/Combobox/ComboboxTrigger.tsx
+++ b/packages/react/src/components/Combobox/ComboboxTrigger.tsx
@@ -11,8 +11,7 @@ import { useDropdownContext } from '../Dropdown/DropdownContext';
 import { FormControl } from '../Form';
 import Input from '../Input/Input';
 
-export interface ComboboxTriggerProps
-  extends React.ComponentPropsWithRef<'input'> {
+export interface ComboboxTriggerProps extends React.ComponentPropsWithRef<'input'> {
   handleSearchInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
   handleSearchInputKeyUp: (event: KeyboardEvent<HTMLInputElement>) => void;
   value: string;

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -22,12 +22,11 @@ dayjs.extend(localeData);
  * Ant Design implementation is hidden and no Ant Design-specific props are exposed.
  * Standard HTML div attributes are supported (passed through to the underlying DOM element).
  */
-export interface DatePickerProps
-  extends Omit<
-    React.HTMLAttributes<HTMLElement>,
-    // Excluded because they are redefined below with different signatures:
-    'onChange' | 'value' | 'defaultValue' // defaultValue is excluded by design choice to simplify the API (only controlled mode with value prop is supported)
-  > {
+export interface DatePickerProps extends Omit<
+  React.HTMLAttributes<HTMLElement>,
+  // Excluded because they are redefined below with different signatures:
+  'onChange' | 'value' | 'defaultValue' // defaultValue is excluded by design choice to simplify the API (only controlled mode with value prop is supported)
+> {
   /**
    * Selected date values
    * @default today's date is setted by ant design if no value is provided

--- a/packages/react/src/components/Dropdown/stories/Dropdown.CheckboxItem.stories.tsx
+++ b/packages/react/src/components/Dropdown/stories/Dropdown.CheckboxItem.stories.tsx
@@ -8,9 +8,6 @@ const meta: Meta<typeof Dropdown> = {
   title: 'Components/Dropdown/Dropdown Checkbox Item',
   component: Dropdown,
   decorators: [(Story) => <div style={{ height: '25em' }}>{Story()}</div>],
-  args: {
-    badgeContent: 0,
-  },
   parameters: {
     docs: {
       description: {
@@ -25,7 +22,7 @@ export default meta;
 type Story = StoryObj<typeof Dropdown>;
 
 export const CheckboxGroup: Story = {
-  render: (args) => {
+  render: () => {
     const [selectedCheckboxes, setSelectedCheckboxes] = useState<
       (string | number)[]
     >([]);
@@ -60,7 +57,7 @@ export const CheckboxGroup: Story = {
         <Dropdown.Trigger
           label="Dropdown"
           icon={<IconFilter />}
-          badgeContent={count || args.badgeContent}
+          badgeContent={count}
         />
         <Dropdown.Menu>
           {checkboxOptions.map((option, index) => (
@@ -80,7 +77,7 @@ export const CheckboxGroup: Story = {
 };
 
 export const BadgeContent: Story = {
-  render: (args) => {
+  render: () => {
     const [selectedCheckboxes, setSelectedCheckboxes] = useState<
       (string | number)[]
     >([1, 2]);

--- a/packages/react/src/components/Dropdown/stories/Dropdown.Item.stories.tsx
+++ b/packages/react/src/components/Dropdown/stories/Dropdown.Item.stories.tsx
@@ -27,7 +27,7 @@ export default meta;
 type Story = StoryObj<typeof Dropdown>;
 
 export const Base: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Dropdown>
         <Dropdown.Trigger label="Action menu" />
@@ -56,7 +56,7 @@ export const Base: Story = {
 };
 
 export const WithTypeAction: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Dropdown>
         <Dropdown.Trigger label="Action menu" />
@@ -90,7 +90,7 @@ export const WithTypeAction: Story = {
 };
 
 export const WithTypeSelect: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Dropdown>
         <Dropdown.Trigger label="Select menu" />
@@ -124,7 +124,7 @@ export const WithTypeSelect: Story = {
 };
 
 export const WithAdditionalClassName: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Dropdown>
         <Dropdown.Trigger label="Styled menu" />

--- a/packages/react/src/components/Dropdown/stories/Dropdown.RadioItem.stories.tsx
+++ b/packages/react/src/components/Dropdown/stories/Dropdown.RadioItem.stories.tsx
@@ -8,10 +8,6 @@ const meta: Meta<typeof Dropdown> = {
   title: 'Components/Dropdown/Dropdown Radio Item',
   component: Dropdown,
   decorators: [(Story) => <div style={{ height: '25em' }}>{Story()}</div>],
-  args: {
-    label: 'Dropdown',
-    icon: <IconFilter />,
-  },
   parameters: {
     docs: {
       description: {
@@ -34,7 +30,7 @@ export const WithSearch: Story = {
       },
     },
   },
-  render: (args) => {
+  render: () => {
     const [value, setValue] = useState<string>('');
 
     const radioOptions = [
@@ -47,7 +43,7 @@ export const WithSearch: Story = {
 
     return (
       <Dropdown>
-        <Dropdown.Trigger label={args.label} icon={args.icon} />
+        <Dropdown.Trigger label="Dropdown" icon={<IconFilter />} />
         <Dropdown.Menu>
           <Dropdown.SearchInput placeholder="Rechercher..." />
           {radioOptions.map((option) => (
@@ -68,7 +64,7 @@ export const WithSearch: Story = {
 };
 
 export const RadioGroup: Story = {
-  render: (args) => {
+  render: () => {
     const [value, setValue] = useState<string>('');
 
     const handleOnChangeRadio = (value: string) => {
@@ -92,7 +88,7 @@ export const RadioGroup: Story = {
 
     return (
       <Dropdown>
-        <Dropdown.Trigger label={args.label} icon={args.icon} />
+        <Dropdown.Trigger label="Dropdown" icon={<IconFilter />} />
         <Dropdown.Menu>
           {radioOptions.map((option, index) => (
             <Dropdown.RadioItem

--- a/packages/react/src/components/Dropdown/stories/Dropdown.SearchInput.stories.tsx
+++ b/packages/react/src/components/Dropdown/stories/Dropdown.SearchInput.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 
 import Dropdown from '../Dropdown';
 

--- a/packages/react/src/components/Dropdown/stories/Dropdown.stories.tsx
+++ b/packages/react/src/components/Dropdown/stories/Dropdown.stories.tsx
@@ -54,7 +54,7 @@ export const Base: Story = {
 };
 
 export const Hover: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Dropdown isTriggerHovered={true}>
         <Dropdown.Trigger label="Dropdown" />
@@ -74,7 +74,7 @@ export const Hover: Story = {
 };
 
 export const MenuGroup: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Dropdown>
         <Dropdown.Trigger label="Dropdown" />
@@ -109,7 +109,7 @@ export const MenuGroup: Story = {
 };
 
 export const ActionMenu: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Dropdown>
         <Dropdown.Trigger label="Action menu" />
@@ -145,7 +145,7 @@ export const ActionMenu: Story = {
 };
 
 export const CheckboxGroup: Story = {
-  render: (args) => {
+  render: () => {
     const [selectedCheckboxes, setSelectedCheckboxes] = useState<
       (string | number)[]
     >([]);
@@ -200,7 +200,7 @@ export const CheckboxGroup: Story = {
 };
 
 export const RadioGroup: Story = {
-  render: (args) => {
+  render: () => {
     const [value, setValue] = useState<string>('');
 
     const handleOnChangeRadio = (value: string) => {
@@ -243,7 +243,7 @@ export const RadioGroup: Story = {
 };
 
 export const Stack: Story = {
-  render: (args) => {
+  render: () => {
     const [value, setValue] = useState<string>('');
     const [selectedCheckboxes, setSelectedCheckboxes] = useState<
       (string | number)[]
@@ -335,7 +335,7 @@ export const Stack: Story = {
 };
 
 export const CustomTrigger: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Dropdown>
         {(
@@ -398,7 +398,7 @@ export const CustomTrigger: Story = {
 };
 
 export const CustomMenu: Story = {
-  render: (args) => {
+  render: () => {
     const [currentColor, setCurrentColor] = useState<string>('#4A4A4A');
     const handleOnChange = (color: string) => setCurrentColor(color);
     return (

--- a/packages/react/src/components/Form/FormControl.stories.tsx
+++ b/packages/react/src/components/Form/FormControl.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 
 import { IconMail } from '../../modules/icons/components';
-import { FormControl, FormControlProps, FormText } from './index';
+import { FormControl, FormText } from './index';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<typeof FormControl> = {
@@ -34,7 +34,7 @@ export default meta;
 type Story = StoryObj<typeof FormControl>;
 
 export const Base: Story = {
-  render: (args: FormControlProps) => {
+  render: (args) => {
     return (
       <FormControl {...args}>
         <FormControl.Label>Email</FormControl.Label>
@@ -49,7 +49,7 @@ export const Base: Story = {
 };
 
 export const WithLabel: Story = {
-  render: (args: FormControlProps) => {
+  render: () => {
     return (
       <FormControl id="email-X23">
         <FormControl.Label>Email</FormControl.Label>
@@ -64,7 +64,7 @@ export const WithLabel: Story = {
 };
 
 export const WithLabelAndIcon: Story = {
-  render: (args: FormControlProps) => {
+  render: () => {
     return (
       <FormControl id="email-7">
         <FormControl.Label leftIcon={<IconMail />}>Email</FormControl.Label>
@@ -79,7 +79,7 @@ export const WithLabelAndIcon: Story = {
 };
 
 export const WithInformativeMessage: Story = {
-  render: (args: FormControlProps) => {
+  render: () => {
     return (
       <FormControl id="email" style={{ marginTop: '3px' }}>
         <FormControl.Label leftIcon={<IconMail />}>Email</FormControl.Label>
@@ -95,7 +95,7 @@ export const WithInformativeMessage: Story = {
 };
 
 export const OptionalField: Story = {
-  render: (args: FormControlProps) => {
+  render: () => {
     return (
       <FormControl id="email-0" isOptional>
         <FormControl.Label leftIcon={<IconMail />}>Email</FormControl.Label>
@@ -110,7 +110,7 @@ export const OptionalField: Story = {
 };
 
 export const OptionalFieldCustomText: Story = {
-  render: (args: FormControlProps) => {
+  render: () => {
     return (
       <FormControl id="email-1" isOptional>
         <FormControl.Label leftIcon={<IconMail />} optionalText="Not mandatory">
@@ -127,7 +127,7 @@ export const OptionalFieldCustomText: Story = {
 };
 
 export const RequiredField: Story = {
-  render: (args: FormControlProps) => {
+  render: () => {
     return (
       <FormControl id="email-2" isRequired>
         <FormControl.Label leftIcon={<IconMail />}>Email</FormControl.Label>
@@ -142,7 +142,7 @@ export const RequiredField: Story = {
 };
 
 export const RequiredFieldCustomText: Story = {
-  render: (args: FormControlProps) => {
+  render: () => {
     return (
       <FormControl id="email-3" isRequired>
         <FormControl.Label leftIcon={<IconMail />} requiredText="- Mandatory">
@@ -159,19 +159,15 @@ export const RequiredFieldCustomText: Story = {
 };
 
 export const ReadOnlyStatus: Story = {
-  render: (args: FormControlProps) => {
+  render: () => {
     return (
       <FormControl id="example-5" isReadOnly>
         <FormControl.Input
           type="text"
           size="md"
-          placeholder={args.placeholder}
+          placeholder="This input is readonly and can't be modified."
         />
       </FormControl>
     );
-  },
-
-  args: {
-    placeholder: "This input is readonly and can't be modified.",
   },
 };

--- a/packages/react/src/components/Grid/stories/Grid.stories.tsx
+++ b/packages/react/src/components/Grid/stories/Grid.stories.tsx
@@ -10,7 +10,7 @@ export default meta;
 type Story = StoryObj<typeof Grid>;
 
 export const Base: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Grid>
         <Grid.Col
@@ -139,7 +139,7 @@ export const Base: Story = {
 };
 
 export const Responsive: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Grid>
         <Grid.Col

--- a/packages/react/src/components/Grid/stories/GridCol.stories.tsx
+++ b/packages/react/src/components/Grid/stories/GridCol.stories.tsx
@@ -10,7 +10,7 @@ export default meta;
 type Story = StoryObj<typeof Grid.Col>;
 
 export const Base: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Grid>
         <Grid.Col
@@ -139,7 +139,7 @@ export const Base: Story = {
 };
 
 export const Responsive: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <Grid>
         <Grid.Col

--- a/packages/react/src/components/Image/Image.stories.tsx
+++ b/packages/react/src/components/Image/Image.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<typeof Image>;
 export const Base: Story = {};
 
 export const Ratio: Story = {
-  render: (args: ImageProps) => {
+  render: (args) => {
     return (
       <div className="d-flex align-items-center">
         <div style={{ width: '60%' }}>

--- a/packages/react/src/components/Input/Input.tsx
+++ b/packages/react/src/components/Input/Input.tsx
@@ -13,8 +13,10 @@ export type OmitInputProps =
   | 'id'
   | 'readOnly';
 
-export interface InputProps
-  extends Omit<React.ComponentPropsWithRef<'input'>, OmitInputProps> {
+export interface InputProps extends Omit<
+  React.ComponentPropsWithRef<'input'>,
+  OmitInputProps
+> {
   /**
    * Control size of input
    */

--- a/packages/react/src/components/Input/stories/Input.stories.tsx
+++ b/packages/react/src/components/Input/stories/Input.stories.tsx
@@ -1,10 +1,10 @@
-import { Meta, StoryObj } from '@storybook/react-vite';
+import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import { Ref, useEffect, useRef } from 'react';
 import { Button } from '../../Button';
 
 import { FormControl, FormText } from '../../Form/index';
 import { Label } from '../../Label';
-import Input, { InputProps } from '../Input';
+import Input from '../Input';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta: Meta<typeof Input> = {
@@ -62,7 +62,7 @@ const meta: Meta<typeof Input> = {
 export default meta;
 type Story = StoryObj<typeof Input>;
 
-const Template = (args: InputProps) => {
+const Template: StoryFn<typeof Input> = (args) => {
   return (
     <FormControl id="example">
       <Input {...args} />

--- a/packages/react/src/components/Input/stories/InputGroup.stories.tsx
+++ b/packages/react/src/components/Input/stories/InputGroup.stories.tsx
@@ -74,7 +74,7 @@ export const BorderlessDisabledInputGroup: Story = {
 };
 
 export const MultiInputGroup: Story = {
-  render: (args) => {
+  render: () => {
     const [username, setUsername] = useState<string>('');
     const [server, setServer] = useState<string>('');
     const serverUrl = useMemo(
@@ -114,7 +114,7 @@ export const MultiInputGroup: Story = {
 };
 
 export const CheckboxRadio: Story = {
-  render: (args) => {
+  render: () => {
     const [value, setValue] = useState<string>('CM1');
     const [isChecked, setIsChecked] = useState(false);
     const [isIndeterminate, setIsIndeterminate] = useState(true);

--- a/packages/react/src/components/Label/Label.stories.tsx
+++ b/packages/react/src/components/Label/Label.stories.tsx
@@ -34,7 +34,7 @@ export const Base: Story = {
 };
 
 export const OptionalField: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <FormControl id="email-0" isOptional>
         <Label>Email</Label>
@@ -53,7 +53,7 @@ export const OptionalField: Story = {
 };
 
 export const OptionalFieldCustomText: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <FormControl id="email-1" isOptional>
         <Label leftIcon={<IconMail />} optionalText="Not mandatory">
@@ -74,7 +74,7 @@ export const OptionalFieldCustomText: Story = {
 };
 
 export const RequiredField: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <FormControl id="email-2" isRequired>
         <Label leftIcon={<IconMail />}>Email</Label>
@@ -84,7 +84,7 @@ export const RequiredField: Story = {
 };
 
 export const RequiredFieldCustomText: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <FormControl id="email-3" isRequired>
         <Label leftIcon={<IconMail />} requiredText="- Mandatory">

--- a/packages/react/src/components/Label/Label.tsx
+++ b/packages/react/src/components/Label/Label.tsx
@@ -7,8 +7,10 @@ import { useFormControl } from '../Form/FormContext';
 
 export type OmitLabelProps = 'htmlFor';
 
-export interface LabelProps
-  extends Omit<React.ComponentPropsWithRef<'label'>, OmitLabelProps> {
+export interface LabelProps extends Omit<
+  React.ComponentPropsWithRef<'label'>,
+  OmitLabelProps
+> {
   /**
    * Display Icon to the left
    */

--- a/packages/react/src/components/Layout/components/Header.tsx
+++ b/packages/react/src/components/Layout/components/Header.tsx
@@ -155,9 +155,7 @@ const Header = ({ is1d = false, src = '' }: HeaderProps): JSX.Element => {
                       link="/communities"
                       translate={t('navbar.community')}
                     >
-                      <IconCommunities
-                        className="icon communities text-purple-500"
-                      />
+                      <IconCommunities className="icon communities text-purple-500" />
                     </NavLink>
                   </NavItem>
                 )}

--- a/packages/react/src/components/List/List.stories.tsx
+++ b/packages/react/src/components/List/List.stories.tsx
@@ -96,7 +96,7 @@ const data: Data[] = [
 ];
 
 export const Base: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <List
         data={data}
@@ -118,7 +118,7 @@ export const Base: Story = {
 };
 
 export const ListWithToolbar: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <List
         data={data}
@@ -141,7 +141,7 @@ export const ListWithToolbar: Story = {
 };
 
 export const ListWithCheckboxes: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <>
         <List
@@ -167,7 +167,7 @@ export const ListWithCheckboxes: Story = {
 };
 
 export const ListWithCheckboxesAndToolbar: Story = {
-  render: (args) => {
+  render: () => {
     return (
       <>
         <List
@@ -193,7 +193,7 @@ export const ListWithCheckboxesAndToolbar: Story = {
 };
 
 export const ListWithOnSelectedItems: Story = {
-  render: (args) => {
+  render: () => {
     const [selectedItems, setSelectedItems] = useState<string[]>([]);
     return (
       <>

--- a/packages/react/src/components/LoadingScreen/LoadingScreen.stories.tsx
+++ b/packages/react/src/components/LoadingScreen/LoadingScreen.stories.tsx
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof LoadingScreen>;
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
 
 export const Base: Story = {
-  render: (args) => <LoadingScreen />,
+  render: () => <LoadingScreen />,
 };
 
 export const Position: Story = {

--- a/packages/react/src/components/Pagination/Pagination.stories.tsx
+++ b/packages/react/src/components/Pagination/Pagination.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { Pagination } from './Pagination';
 

--- a/packages/react/src/components/Radio/Radio.stories.tsx
+++ b/packages/react/src/components/Radio/Radio.stories.tsx
@@ -30,7 +30,7 @@ export default meta;
 type Story = StoryObj<typeof Radio>;
 
 export const Base: Story = {
-  render: (args: RadioProps) => {
+  render: () => {
     const [value, setValue] = useState<string>('CP');
 
     const handleChange = ({
@@ -75,7 +75,7 @@ export const Base: Story = {
 };
 
 export const RadioWithIcons: Story = {
-  render: (args) => {
+  render: () => {
     const [value, setValue] = useState<string>('list');
 
     const options = [

--- a/packages/react/src/components/Radio/Radio.tsx
+++ b/packages/react/src/components/Radio/Radio.tsx
@@ -2,8 +2,7 @@ import { ChangeEvent, forwardRef, ReactNode, Ref, useId } from 'react';
 
 import clsx from 'clsx';
 
-export interface RadioProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+export interface RadioProps extends React.InputHTMLAttributes<HTMLInputElement> {
   /**
    * State controlling activated radio group
    */

--- a/packages/react/src/components/RadioCard/RadioCard.stories.tsx
+++ b/packages/react/src/components/RadioCard/RadioCard.stories.tsx
@@ -31,7 +31,7 @@ export default meta;
 type Story = StoryObj<typeof RadioCard>;
 
 export const Base: Story = {
-  render: (args: RadioCardProps) => {
+  render: () => {
     const [selectedValue, setSelectedValue] = useState<string>('CP');
 
     const handleChange = ({

--- a/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
+++ b/packages/react/src/components/SegmentedControl/SegmentedControl.tsx
@@ -28,14 +28,13 @@ export interface SegmentedOption {
  * Ant Design implementation is hidden and no Ant Design-specific props are exposed.
  * Standard HTML div attributes are supported (passed through to the underlying DOM element).
  */
-export interface SegmentedControlProps
-  extends Omit<
-    React.HTMLAttributes<HTMLDivElement>,
-    // Excluded because they are redefined below with different signatures:
-    // - onChange: takes (value: string) instead of React.ChangeEvent
-    // - defaultValue: excluded by design choice to simplify the API (only controlled mode with value prop is supported)
-    'onChange' | 'defaultValue'
-  > {
+export interface SegmentedControlProps extends Omit<
+  React.HTMLAttributes<HTMLDivElement>,
+  // Excluded because they are redefined below with different signatures:
+  // - onChange: takes (value: string) instead of React.ChangeEvent
+  // - defaultValue: excluded by design choice to simplify the API (only controlled mode with value prop is supported)
+  'onChange' | 'defaultValue'
+> {
   /**
    * Segmented control options
    */

--- a/packages/react/src/components/Select/Select.stories.tsx
+++ b/packages/react/src/components/Select/Select.stories.tsx
@@ -62,7 +62,7 @@ const subjectAreaOptions: OptionsType[] = [
 ];
 
 export const Base: Story = {
-  render: (args) => {
+  render: () => {
     const onChange = (option: OptionsType | string) => {
       console.log(option);
     };
@@ -78,7 +78,7 @@ export const Base: Story = {
 };
 
 export const WithIcon: Story = {
-  render: (args) => {
+  render: () => {
     const onChange = (option: OptionsType | string) => {
       console.log(option);
     };
@@ -95,7 +95,7 @@ export const WithIcon: Story = {
 };
 
 export const DefaultValue: Story = {
-  render: (args) => {
+  render: () => {
     const onChange = (option: OptionsType | string) => {
       console.log(option);
     };
@@ -112,7 +112,7 @@ export const DefaultValue: Story = {
 };
 
 export const Disabled: Story = {
-  render: (args) => {
+  render: () => {
     const onChange = (option: OptionsType | string) => {
       console.log(option);
     };
@@ -129,7 +129,7 @@ export const Disabled: Story = {
 };
 
 export const Variant: Story = {
-  render: (args) => {
+  render: () => {
     const onChange = (option: OptionsType | string) => {
       console.log(option);
     };
@@ -146,7 +146,7 @@ export const Variant: Story = {
 };
 
 export const SelectSizes: Story = {
-  render: (args) => {
+  render: () => {
     const onChange = (option: OptionsType | string) => {
       console.log(option);
     };

--- a/packages/react/src/components/Select/Select.tsx
+++ b/packages/react/src/components/Select/Select.tsx
@@ -22,7 +22,8 @@ export interface OptionsType {
 }
 
 export interface SelectProps
-  extends Omit<DropdownProps, 'children'>,
+  extends
+    Omit<DropdownProps, 'children'>,
     Omit<DropdownTriggerProps, 'badgeContent' | 'defaultValue'> {
   /**
    * Controlled value

--- a/packages/react/src/components/Switch/Switch.tsx
+++ b/packages/react/src/components/Switch/Switch.tsx
@@ -1,8 +1,10 @@
 import { forwardRef, InputHTMLAttributes } from 'react';
 import clsx from 'clsx';
 
-export interface SwitchProps
-  extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+export interface SwitchProps extends Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'size'
+> {
   /**
    * The label of the switch
    */

--- a/packages/react/src/components/TextArea/TextArea.stories.tsx
+++ b/packages/react/src/components/TextArea/TextArea.stories.tsx
@@ -1,10 +1,10 @@
-import { StoryObj } from '@storybook/react-vite';
+import { StoryFn, StoryObj } from '@storybook/react-vite';
 
 import { Ref, useEffect, useRef } from 'react';
 import { Button } from '../Button';
 import FormControl from '../Form/FormControl';
 import FormText from '../Form/FormText';
-import TextArea, { TextAreaProps } from './TextArea';
+import TextArea from './TextArea';
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
 const meta = {
@@ -34,7 +34,7 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof TextArea>;
 
-const Template = (args: TextAreaProps) => {
+const Template: StoryFn<typeof TextArea> = (args) => {
   return (
     <FormControl id="example">
       <TextArea {...args} />

--- a/packages/react/src/components/TextArea/TextArea.tsx
+++ b/packages/react/src/components/TextArea/TextArea.tsx
@@ -13,8 +13,10 @@ export type OmitTextAreaProps =
   | 'id'
   | 'readOnly';
 
-export interface TextAreaProps
-  extends Omit<React.ComponentPropsWithRef<'textarea'>, OmitTextAreaProps> {
+export interface TextAreaProps extends Omit<
+  React.ComponentPropsWithRef<'textarea'>,
+  OmitTextAreaProps
+> {
   /**
    * Control size of TextArea
    */

--- a/packages/react/src/components/Toolbar/Toolbar.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.tsx
@@ -35,16 +35,14 @@ export interface ToolbarTooltipProps {
 }
 
 export interface ToolbarButtonItem
-  extends ToolbarCommonItem,
-    ToolbarTooltipProps {
+  extends ToolbarCommonItem, ToolbarTooltipProps {
   type: 'button';
   name: string;
   props: ButtonProps;
 }
 
 export interface ToolbarIconButtonItem
-  extends ToolbarCommonItem,
-    ToolbarTooltipProps {
+  extends ToolbarCommonItem, ToolbarTooltipProps {
   type: 'icon';
   name: string;
   props: IconButtonProps;
@@ -57,8 +55,7 @@ export interface ToolbarDropdownItem extends ToolbarCommonItem {
 }
 
 export interface ToolbarPrimaryItem
-  extends ToolbarCommonItem,
-    ToolbarTooltipProps {
+  extends ToolbarCommonItem, ToolbarTooltipProps {
   type: 'primary';
   props: ButtonProps;
 }

--- a/packages/react/src/components/Tree/types/index.ts
+++ b/packages/react/src/components/Tree/types/index.ts
@@ -104,8 +104,7 @@ export interface SharedTreeProps {
 }
 
 export interface TreeNodeProps
-  extends ComponentPropsWithRef<'li'>,
-    SharedTreeProps {
+  extends ComponentPropsWithRef<'li'>, SharedTreeProps {
   /**
    * Node data
    */

--- a/packages/react/src/components/TreeView/TreeView.stories.tsx
+++ b/packages/react/src/components/TreeView/TreeView.stories.tsx
@@ -1,4 +1,4 @@
-import { Meta, StoryObj } from '@storybook/react-vite';
+import { Meta, StoryFn, StoryObj } from '@storybook/react-vite';
 import { useRef, useState } from 'react';
 import { Button } from '../Button';
 import TreeView, { TreeViewHandlers } from './TreeView';
@@ -93,7 +93,7 @@ export default meta;
 type Story = StoryObj<typeof TreeView>;
 
 // More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template = (args) => {
+const Template: StoryFn<typeof TreeView> = (args) => {
   return <TreeView {...args} />;
 };
 

--- a/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.stories.tsx
@@ -1,7 +1,7 @@
-import { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import type { ComponentRef } from 'react';
 import { useEffect, useRef } from 'react';
+import { fn } from 'storybook/test';
 import { UserRightsList } from './UserRightsList';
 import type { BookmarkInput, ResourceRights, SharingItem } from './types/types';
 

--- a/packages/react/src/components/UserRightsList/helpers/rightsHelpers.tsx
+++ b/packages/react/src/components/UserRightsList/helpers/rightsHelpers.tsx
@@ -48,7 +48,7 @@ export const createRightsHelpers = (resourceRights: ResourceRights) => {
     rightName: ResourceRightName,
     add: boolean,
   ): SharingItem => {
-    const { requires, excludes } = resourceRights[rightName];
+    const { requires, excludes } = resourceRights[rightName]!;
 
     let newPermission: string[];
 

--- a/packages/react/src/components/UserSearch/UserSearch.stories.tsx
+++ b/packages/react/src/components/UserSearch/UserSearch.stories.tsx
@@ -1,7 +1,8 @@
-import { Meta, StoryObj } from '@storybook/react';
-import { fn } from 'storybook/test';
+import { Meta, StoryObj } from '@storybook/react-vite';
 import { useRef, useState } from 'react';
-import { UserSearch, type UserSearchRef } from './UserSearch';
+import { fn } from 'storybook/test';
+import { UserSearch } from './UserSearch';
+import type { UserSearchRef } from './types/types';
 import type { Visible } from './types/visible';
 import { VisibleType } from './types/visible';
 

--- a/packages/react/src/hooks/useCheckable/useCheckable.stories.tsx
+++ b/packages/react/src/hooks/useCheckable/useCheckable.stories.tsx
@@ -26,7 +26,7 @@ const data: Data[] = [
 ];
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const {
       selectedItems,
       allItemsSelected,

--- a/packages/react/src/hooks/useClickOutside/useClickOutside.stories.tsx
+++ b/packages/react/src/hooks/useClickOutside/useClickOutside.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 type Story = StoryObj<typeof useClickOutside>;
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const [isOpen, setOpen] = useState<boolean>(true);
 
     const ref = useClickOutside(() => setOpen(false));

--- a/packages/react/src/hooks/useDropzone/useDropzone.stories.tsx
+++ b/packages/react/src/hooks/useDropzone/useDropzone.stories.tsx
@@ -11,7 +11,7 @@ export default meta;
 type Story = StoryObj<typeof useDropzone>;
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const {
       inputRef,
       files,

--- a/packages/react/src/hooks/useHover/useHover.stories.tsx
+++ b/packages/react/src/hooks/useHover/useHover.stories.tsx
@@ -10,7 +10,7 @@ export default meta;
 type Story = StoryObj<typeof useHover>;
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const [ref, isHovered] = useHover<HTMLButtonElement>();
     return (
       <>

--- a/packages/react/src/hooks/useImage/useImage.stories.tsx
+++ b/packages/react/src/hooks/useImage/useImage.stories.tsx
@@ -10,7 +10,7 @@ export default meta;
 type Story = StoryObj<typeof useImage>;
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const src = '';
     const alt = 'alternative text';
     const placeholder = imagePlaceholder;

--- a/packages/react/src/hooks/useKeyPress/useKeyPress.stories.tsx
+++ b/packages/react/src/hooks/useKeyPress/useKeyPress.stories.tsx
@@ -12,7 +12,7 @@ export default meta;
 type Story = StoryObj<typeof useKeyPress>;
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const [isVisible, setIsVisible] = useState<boolean>(true);
     useKeyPress(() => {
       setIsVisible(false);

--- a/packages/react/src/hooks/useScrollToTop/useScrollToTop.stories.tsx
+++ b/packages/react/src/hooks/useScrollToTop/useScrollToTop.stories.tsx
@@ -10,7 +10,7 @@ export default meta;
 type Story = StoryObj<typeof useScrollToTop>;
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const scrollTotop = useScrollToTop();
     return (
       <>

--- a/packages/react/src/hooks/useTitle/useTitle.stories.tsx
+++ b/packages/react/src/hooks/useTitle/useTitle.stories.tsx
@@ -10,7 +10,7 @@ export default meta;
 type Story = StoryObj<typeof useTitle>;
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const title = useTitle();
 
     return (

--- a/packages/react/src/hooks/useToast/useToast.stories.tsx
+++ b/packages/react/src/hooks/useToast/useToast.stories.tsx
@@ -11,7 +11,7 @@ export default meta;
 type Story = StoryObj<typeof useToast>;
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const toast = useToast();
 
     const infoNotify = () => toast.info('This is an info message!');

--- a/packages/react/src/hooks/useToggle/useToggle.stories.tsx
+++ b/packages/react/src/hooks/useToggle/useToggle.stories.tsx
@@ -3,15 +3,15 @@ import Heading from '../../components/Heading/Heading';
 import useToggle from './useToggle';
 import { Meta, StoryObj } from '@storybook/react-vite';
 
-const meta: Meta<typeof useToggle> = {
+const meta: Meta = {
   title: 'Hooks/useToggle',
 };
 
 export default meta;
-type Story = StoryObj<typeof useToggle>;
+type Story = StoryObj;
 
 export const Example: Story = {
-  render: (args) => {
+  render: () => {
     const [state, toggle] = useToggle(false);
 
     return (

--- a/packages/react/src/hooks/useTrapFocus/useTrapFocus.stories.tsx
+++ b/packages/react/src/hooks/useTrapFocus/useTrapFocus.stories.tsx
@@ -14,7 +14,7 @@ export default meta;
 type Story = StoryObj<typeof useTrapFocus>;
 
 export const Base: Story = {
-  render: (args) => {
+  render: () => {
     const ref = useTrapFocus();
 
     return (

--- a/packages/react/src/modules/audience/ViewsCounter.tsx
+++ b/packages/react/src/modules/audience/ViewsCounter.tsx
@@ -4,8 +4,7 @@ import { forwardRef, Ref } from 'react';
 import { Button } from '../../components';
 import { IconSee } from '../icons/components';
 
-export interface ViewsCounterProps
-  extends React.ComponentPropsWithRef<'button'> {
+export interface ViewsCounterProps extends React.ComponentPropsWithRef<'button'> {
   /** The number of views to display. */
   viewsCounter: number;
 }

--- a/packages/react/src/modules/audience/stories/ViewsCounter.stories.tsx
+++ b/packages/react/src/modules/audience/stories/ViewsCounter.stories.tsx
@@ -27,7 +27,7 @@ export default meta;
 type Story = StoryObj<typeof ViewsCounter>;
 
 export const Base: Story = {
-  render: (props: ViewsCounterProps) => {
+  render: (props) => {
     return <ViewsCounter {...props} />;
   },
 };

--- a/packages/react/src/modules/multimedia/LinkerCard/LinkerCard._.tsx
+++ b/packages/react/src/modules/multimedia/LinkerCard/LinkerCard._.tsx
@@ -14,9 +14,10 @@ const baseResource = {
   createdAt: null as unknown as string,
   modifierId: null as unknown as string,
   modifierName: null as unknown as string,
-  rights: [],
+  rights: [] as string[],
   trashed: false,
   updatedAt: null as unknown as string,
+  path: '',
 };
 
 const meta: Meta<typeof LinkerCard> = {

--- a/packages/react/src/modules/widgets/BookmarkedApps/BookmarkedApps.stories.tsx
+++ b/packages/react/src/modules/widgets/BookmarkedApps/BookmarkedApps.stories.tsx
@@ -77,7 +77,7 @@ const bookmarkedApps = [
 ];
 
 export const Base: Story = {
-  render: (args) => (
+  render: () => (
     <Widget>
       <Widget.Body>
         <BookmarkedApps data={bookmarkedApps} />
@@ -87,7 +87,7 @@ export const Base: Story = {
 };
 
 export const Empty: Story = {
-  render: (args) => (
+  render: () => (
     <Widget>
       <Widget.Header>Mes applis</Widget.Header>
       <Widget.Body>
@@ -99,7 +99,7 @@ export const Empty: Story = {
 };
 
 export const Complete: Story = {
-  render: (args) => (
+  render: () => (
     <Widget>
       <Widget.Header>Mes applis</Widget.Header>
       <Widget.Body>

--- a/packages/react/tsconfig.lib.json
+++ b/packages/react/tsconfig.lib.json
@@ -27,9 +27,9 @@
       "vitest/importMeta",
       "vitest"
     ],
-    "baseUrl": ".",
     "paths": {
-      "~/setup": ["vitest.setup.ts"]
+      "~/setup": ["./vitest.setup.ts"],
+      "src/*": ["./src/*"]
     }
   },
   "include": ["src"]

--- a/packages/rest-client-base/eslint.config.js
+++ b/packages/rest-client-base/eslint.config.js
@@ -10,6 +10,9 @@ export default tseslint.config(
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       '@typescript-eslint/no-unused-expressions': 'off',

--- a/packages/rest-client-base/package.json
+++ b/packages/rest-client-base/package.json
@@ -35,7 +35,8 @@
   ],
   "scripts": {
     "clean": "rm -rf dist node_modules",
-    "format": "prettier --write src",
+    "format": "prettier --check src",
+    "format:write": "prettier --write src",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "build": "pnpm run build:node && pnpm run build:browser && pnpm run build:react-native",

--- a/packages/rest-client-base/tsconfig.base.json
+++ b/packages/rest-client-base/tsconfig.base.json
@@ -9,7 +9,6 @@
     "target": "esnext",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,

--- a/packages/rest-client-base/tsconfig.browser.json
+++ b/packages/rest-client-base/tsconfig.browser.json
@@ -2,11 +2,10 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "ESNext",
-    "moduleResolution": "node",
-    "baseUrl": "./src",
+    "moduleResolution": "bundler",
     "paths": {
       "@decorators/custom-type.decorator": [
-        "decorators/custom-type.decorator.browser"
+        "./src/decorators/custom-type.decorator.browser"
       ]
     }
   }

--- a/packages/rest-client-base/tsconfig.json
+++ b/packages/rest-client-base/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./src",
     "paths": {
-      "@decorators/*": ["decorators/*.node"]
+      "@decorators/*": ["./src/decorators/*.node"]
     }
   }
 }

--- a/packages/rest-client-base/tsconfig.node.json
+++ b/packages/rest-client-base/tsconfig.node.json
@@ -1,10 +1,9 @@
 {
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": "./src",
     "paths": {
       "@decorators/custom-type.decorator": [
-        "decorators/custom-type.decorator.node"
+        "./src/decorators/custom-type.decorator.node"
       ]
     }
   }

--- a/packages/utilities/eslint.config.js
+++ b/packages/utilities/eslint.config.js
@@ -10,6 +10,9 @@ export default tseslint.config(
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
     rules: {
       '@typescript-eslint/no-unused-expressions': 'off',

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -36,9 +36,8 @@
   "scripts": {
     "build": "vite build",
     "fix": "eslint --fix --report-unused-disable-directives --max-warnings 0",
-    "format": "pnpm run format:write && pnpm run format:check",
-    "format:check": "npx prettier --check \"src/**/*.ts\"",
-    "format:write": "npx prettier --write \"src/**/*.ts\"",
+    "format": "prettier --check \"src/**/*.ts\"",
+    "format:write": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint"
   },
   "devDependencies": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://turbo.build/schema.json",
+  "$schema": "node_modules/turbo/schema.json",
   "tasks": {
     "build": {
       "dependsOn": [


### PR DESCRIPTION
  ## Ticket

  [ENABLING-840](https://edifice-community.atlassian.net/browse/ENABLING-840)

  ## Summary

  - **Pre-commit hook** : remplace `format:write` (réécriture de tous les fichiers) par `prettier --check` uniquement — supprime les diffs fantômes de
  formatage au commit
  - **Husky v9** : corrige `prepare: "husky install"` → `"husky"` (deprecated)
  - **Format scripts** : remplace `npx prettier` par `prettier` dans tous les packages, supprime le double `format:write + format:check` redondant
  - **ESLint** : ajoute `tsconfigRootDir` dans les configs de 5 packages pour lever l'ambiguïté sur les tsconfigs
  - **TypeScript** : migration `moduleResolution: "Node"` → `"bundler"` (4 tsconfigs), suppression de `baseUrl` deprecated (7 tsconfigs), ajout des
  `paths` correspondants
  - **Erreurs TS** : correction des erreurs TypeScript dans `client`, `extensions` et `react` (code de prod + stories)
  - **Stories Storybook 10** : correction des types `Meta`/`StoryObj`/`StoryFn`, imports `@storybook/react-vite`, args typés correctement
  - **Workspace** : suppression de `eslint.format.enable` (ESLint ne doit pas agir comme formateur)
  - **Turbo** : schema local `node_modules/turbo/schema.json` pour éviter l'avertissement URL non fiable dans VS Code

  ## Test plan

  - [ ] `pnpm run lint` → 0 erreur (15 warnings préexistants `react-hooks/exhaustive-deps`)
  - [ ] `pnpm run format` → tous les fichiers conformes Prettier
  - [ ] `pnpm build` → 6/6 tâches réussies, 0 erreur TypeScript

[ENABLING-840]: https://edifice-community.atlassian.net/browse/ENABLING-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ