### PR TITLE
fix: use best practice method for building url in base api client

### DIFF
--- a/packages/rest-client-base/src/client/base-api.client.ts
+++ b/packages/rest-client-base/src/client/base-api.client.ts
@@ -236,18 +236,24 @@ export abstract class BaseApiClient {
    * @param queryParams Optional query parameters
    * @returns Complete URL
    * @protected
+   * @throws {URIError} if the baseUrl attribute is not parsable
    */
   protected buildUrl(endpoint: string, queryParams?: URLSearchParams): string {
-    let url = `${this.baseUrl}${endpoint}`;
-    // Ensure URL starts with a slash
-    if (url.startsWith('//')) {
-      url = url.replace(/^\/\//, '/');
+    // Fail explicitely if base url is not correct
+    if(!URL.canParse(this.baseUrl)) {
+      throw new URIError(`{baseUrl: ${this.baseUrl}} is not a parsable URL.`);
     }
-    if (queryParams && queryParams.toString()) {
-      url += `?${queryParams.toString()}`;
+    // Parse base url with MDN-defined rules
+    const url = new URL(this.baseUrl);
+    // Add endpoint path
+    url.pathname = endpoint;
+    // Add query params if they are defined
+    if (queryParams) {
+      queryParams.forEach((value, key, _) => {
+          url.searchParams.set(key, value);
+      });
     }
-
-    return url;
+    return url.toString();
   }
 
   /**


### PR DESCRIPTION
Je me permets de proposer un changement dans la construction d'URL du client de base.
On a eu un problème suite à un oubli de "/" dans les paramètres `endpoint` sur le client d'une application. A mon sens ça ne devrait pas arriver.

Avec les fonctions prévues à cet effet (https://developer.mozilla.org/docs/Web/API/URL), on peut mettre ou ne pas mettre de "/" ça construira une URL valide, à condition que le `baseUrl` soit correct.