### PR TITLE
  fix(react): #IMPULS-5456 notification fixes, useOverlay reset and tests

### DIFF
--- a/packages/bootstrap/src/components/homepage/_favorites.scss
+++ b/packages/bootstrap/src/components/homepage/_favorites.scss
@@ -6,6 +6,11 @@
     border-radius: var(--primitive-border-radius-xl);
     border: 1px solid var(--primitive-grey-200);
     padding: var(--primitive-spacer-12);
+
+    > div {
+      max-height: 8.8rem;
+      overflow: hidden;
+    }
   }
 
   &-empty {

--- a/packages/bootstrap/src/components/homepage/_notification-list.scss
+++ b/packages/bootstrap/src/components/homepage/_notification-list.scss
@@ -1,4 +1,7 @@
 .notification-list {
+  h4 {
+    font-family: var(--font-family-title);
+  }
   ul {
     list-style: none;
     padding: 0;

--- a/packages/bootstrap/src/components/homepage/_notification.scss
+++ b/packages/bootstrap/src/components/homepage/_notification.scss
@@ -10,7 +10,7 @@
   }
 
   &-message {
-    color: var(--primitive-grey-800);
+    color: var(--primitive-text-color-default);
     font-size: var(--primitive-font-size-small);
     line-height: var(--primitive-font-lineheight-xs);
     overflow-wrap: anywhere;
@@ -32,18 +32,18 @@
   &-resource-icon {
     display: flex;
     align-items: center;
-    padding: var(--primitive-spacer-4);
+    padding: var(--primitive-spacer-2);
     border-radius: var(--primitive-border-radius-pill);
     flex-shrink: 0;
 
     // TODO: remove this override when the app icon component supports size 16x16
     .app-icon {
-      width: 1.6rem !important;
-      height: 1.6rem !important;
+      width: 2rem !important;
+      height: 2rem !important;
 
       svg {
-        width: 1.6rem;
-        height: 1.6rem;
+        width: 2rem;
+        height: 2rem;
       }
     }
   }

--- a/packages/bootstrap/src/themes/configs/_breakpoints.scss
+++ b/packages/bootstrap/src/themes/configs/_breakpoints.scss
@@ -1,13 +1,14 @@
 // stylelint-disable at-rule-empty-line-before
 @use 'sass:map';
 
+// have to be consistent with the breakpoints defined in useBreakpoint.ts, otherwise media queries won't work as expected
 $breakpoints: (
-  'mobile': 360px,
-  'mobile-large': 390px,
-  'tablet': 720px,
-  'desktop-small': 960px,
-  'desktop': 1264px,
-  'desktop-large': 1320px,
+  'mobile': 375px,
+  'mobile-large': 430px,
+  'tablet': 768px,
+  'desktop-small': 1024px,
+  'desktop': 1280px,
+  'desktop-large': 1400px,
 );
 
 @mixin respond-from($breakpoint) {

--- a/packages/react/src/components/Flex/Flex.tsx
+++ b/packages/react/src/components/Flex/Flex.tsx
@@ -34,7 +34,11 @@ const Flex = forwardRef<HTMLElement, FlexProps>(
       fill && 'flex-fill',
       align && `align-items-${align}`,
       justify && `justify-content-${justify}`,
-      gap && `gap-${gap}`,
+      gap &&
+        (([rowGap, colGap]) =>
+          colGap !== undefined
+            ? [`row-gap-${rowGap}`, `column-gap-${colGap}`]
+            : `gap-${rowGap}`)(gap.split(' ')),
       wrap && `flex-${wrap === 'reverse' ? 'wrap-reverse' : wrap}`,
       className,
     );

--- a/packages/react/src/components/Flex/Flex.tsx
+++ b/packages/react/src/components/Flex/Flex.tsx
@@ -28,17 +28,23 @@ const Flex = forwardRef<HTMLElement, FlexProps>(
     },
     ref,
   ) => {
+    const gapClasses = (() => {
+      if (!gap) return undefined;
+      const [rowGap, colGap] = gap.trim().split(/\s+/);
+      console.log('colGap:', colGap);
+      console.log('rowGap:', rowGap);
+      return colGap !== undefined
+        ? [`row-gap-${rowGap}`, `column-gap-${colGap}`]
+        : `gap-${rowGap}`;
+    })();
+
     const classes = clsx(
       'd-flex',
       direction && `flex-${direction}`,
       fill && 'flex-fill',
       align && `align-items-${align}`,
       justify && `justify-content-${justify}`,
-      gap &&
-        (([rowGap, colGap]) =>
-          colGap !== undefined
-            ? [`row-gap-${rowGap}`, `column-gap-${colGap}`]
-            : `gap-${rowGap}`)(gap.split(' ')),
+      gapClasses,
       wrap && `flex-${wrap === 'reverse' ? 'wrap-reverse' : wrap}`,
       className,
     );

--- a/packages/react/src/components/PageLayout/PageLayout.stories.tsx
+++ b/packages/react/src/components/PageLayout/PageLayout.stories.tsx
@@ -316,7 +316,7 @@ export const FullpageDynamicRightSidebar: Story = {
 
 export const OverlayWithoutBackdrop: Story = {
   render: (args) => {
-    const { toggleOverlay, closeOverlay } = useOverlay();
+    const { updateOverlayOpen } = useOverlay();
     return (
       <PageLayout {...args}>
         <PageLayout.Header />
@@ -326,17 +326,19 @@ export const OverlayWithoutBackdrop: Story = {
         </PageLayout.SidebarLeft>
         <PageLayout.Content style={colStyle('content')}>
           <div style={innerStyle('content')}>
-            <Button onClick={toggleOverlay}>Ouvrir le panneau</Button>
+            <Button onClick={() => updateOverlayOpen(true)}>
+              Ouvrir le panneau
+            </Button>
           </div>
         </PageLayout.Content>
         <PageLayout.SidebarRight style={colStyle('sidebarRight')}>
           <div style={innerStyle('sidebarRight')}>Sidebar Right</div>
         </PageLayout.SidebarRight>
-        <PageLayout.Overlay onClose={() => console.log('Overlay closed')}>
+        <PageLayout.Overlay onClose={() => updateOverlayOpen(false)}>
           <div style={{ padding: '24px' }}>
             <h2>Panneau latéral</h2>
             <p>Contenu dynamique de l&apos;overlay.</p>
-            <Button variant="outline" onClick={closeOverlay}>
+            <Button variant="outline" onClick={() => updateOverlayOpen(false)}>
               Fermer
             </Button>
           </div>
@@ -348,7 +350,7 @@ export const OverlayWithoutBackdrop: Story = {
 
 export const OverlayWithBackdrop: Story = {
   render: (args) => {
-    const { openOverlay, closeOverlay } = useOverlay();
+    const { updateOverlayOpen } = useOverlay();
 
     return (
       <PageLayout {...args}>
@@ -359,7 +361,7 @@ export const OverlayWithBackdrop: Story = {
         </PageLayout.SidebarLeft>
         <PageLayout.Content style={colStyle('content')}>
           <div style={innerStyle('content')}>
-            <Button onClick={openOverlay}>
+            <Button onClick={() => updateOverlayOpen(true)}>
               Ouvrir le panneau (avec backdrop)
             </Button>
           </div>
@@ -367,11 +369,11 @@ export const OverlayWithBackdrop: Story = {
         <PageLayout.SidebarRight style={colStyle('sidebarRight')}>
           <div style={innerStyle('sidebarRight')}>Sidebar Right</div>
         </PageLayout.SidebarRight>
-        <PageLayout.Overlay onClose={closeOverlay} backdrop>
+        <PageLayout.Overlay onClose={() => updateOverlayOpen(false)} backdrop>
           <div style={{ padding: '24px' }}>
             <h2>Panneau latéral</h2>
             <p>Avec backdrop — cliquez en dehors pour fermer.</p>
-            <Button variant="outline" onClick={closeOverlay}>
+            <Button variant="outline" onClick={() => updateOverlayOpen(false)}>
               Fermer
             </Button>
           </div>
@@ -383,7 +385,7 @@ export const OverlayWithBackdrop: Story = {
 
 export const OverlayWithCloseButton: Story = {
   render: (args) => {
-    const { toggleOverlay } = useOverlay();
+    const { updateOverlayOpen } = useOverlay();
 
     return (
       <PageLayout {...args}>
@@ -394,7 +396,9 @@ export const OverlayWithCloseButton: Story = {
         </PageLayout.SidebarLeft>
         <PageLayout.Content style={colStyle('content')}>
           <div style={innerStyle('content')}>
-            <Button onClick={toggleOverlay}>Ouvrir le panneau</Button>
+            <Button onClick={() => updateOverlayOpen(true)}>
+              Ouvrir le panneau
+            </Button>
           </div>
         </PageLayout.Content>
         <PageLayout.SidebarRight style={colStyle('sidebarRight')}>
@@ -402,13 +406,13 @@ export const OverlayWithCloseButton: Story = {
         </PageLayout.SidebarRight>
         <PageLayout.Overlay
           closeButton={true}
-          onClose={() => console.log('Overlay close')}
+          onClose={() => updateOverlayOpen(false)}
           backdrop
         >
           <div style={{ padding: '24px' }}>
             <h2>Panneau latéral</h2>
             <p>Contenu dynamique de l&apos;overlay.</p>
-            <Button variant="outline" onClick={toggleOverlay}>
+            <Button variant="outline" onClick={() => updateOverlayOpen(false)}>
               Fermer
             </Button>
           </div>

--- a/packages/react/src/components/PageLayout/components/PageLayoutOverlay.tsx
+++ b/packages/react/src/components/PageLayout/components/PageLayoutOverlay.tsx
@@ -28,10 +28,10 @@ const PageLayoutOverlay = ({
   ...props
 }: PageLayoutOverlayProps) => {
   const { t } = useTranslation();
-  const { isOverlayOpen, closeOverlay } = useOverlay();
+  const { isOverlayOpen, updateOverlayOpen } = useOverlay();
 
   const handleClose = () => {
-    closeOverlay();
+    updateOverlayOpen(false);
     onClose?.();
   };
 
@@ -42,7 +42,7 @@ const PageLayoutOverlay = ({
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOverlayOpen, onClose, closeOverlay, handleClose]);
+  }, [isOverlayOpen, onClose, updateOverlayOpen, handleClose]);
 
   return (
     <>

--- a/packages/react/src/components/PageLayout/hook/useOverlay.ts
+++ b/packages/react/src/components/PageLayout/hook/useOverlay.ts
@@ -6,22 +6,13 @@ export const useOverlay = () => {
   const isOverlayOpen = useOverlayStore.use.overlayOpen();
   const updateOverlayOpen = useOverlayStore.use.updateOverlayOpen();
 
-  const openOverlay = useCallback(() => {
-    updateOverlayOpen(true);
-  }, [updateOverlayOpen]);
-
-  const closeOverlay = useCallback(() => {
-    updateOverlayOpen(false);
-  }, [updateOverlayOpen]);
-
   const toggleOverlay = useCallback(() => {
     updateOverlayOpen(!isOverlayOpen);
   }, [isOverlayOpen, updateOverlayOpen]);
 
   return {
     isOverlayOpen,
-    openOverlay,
-    closeOverlay,
+    updateOverlayOpen,
     toggleOverlay,
   };
 };

--- a/packages/react/src/modules/homepage/components/Favorites/Favorites.spec.tsx
+++ b/packages/react/src/modules/homepage/components/Favorites/Favorites.spec.tsx
@@ -32,11 +32,4 @@ describe('Favorites', () => {
     expect(links[0]).toHaveAttribute('href', '/mindmap');
     expect(links[0]).toHaveAttribute('aria-label', 'Mindmap App');
   });
-
-  it('renders at most 6 apps even when more are provided', () => {
-    const apps = Array.from({ length: 8 }, (_, i) => makeApp(`App${i + 1}`));
-    render(<Favorites apps={apps} />);
-
-    expect(screen.getAllByRole('link')).toHaveLength(6);
-  });
 });

--- a/packages/react/src/modules/homepage/components/Favorites/Favorites.stories.tsx
+++ b/packages/react/src/modules/homepage/components/Favorites/Favorites.stories.tsx
@@ -31,7 +31,7 @@ const meta: Meta<typeof Favorites> = {
     docs: {
       description: {
         component:
-          "Widget Favoris — affiche jusqu'à 6 applications favorites de l'utilisateur. Variante `secondary` de `HomeCard`. Affiche un état vide avec illustration si aucune application n'est marquée en favori.",
+          "Widget Favoris — affiche jusqu'à 2 lignes d'applications favorites de l'utilisateur. Variante `secondary` de `HomeCard`. Affiche un état vide avec illustration si aucune application n'est marquée en favori.",
       },
     },
   },
@@ -68,6 +68,34 @@ const mockApps: FavoritesProps['apps'] = [
     displayName: 'Messagerie',
     isExternal: false,
   },
+  {
+    address: '/workspace',
+    icon: 'workspace',
+    name: 'workspace',
+    scope: [],
+    display: true,
+    displayName: 'Espace documentaire',
+    isExternal: false,
+  },
+  {
+    address: '/rack',
+    icon: 'rack',
+    name: 'rack',
+    scope: [],
+    display: true,
+    displayName: 'Casier',
+    isExternal: false,
+  },
+  {
+    address: '/scrapbook',
+    icon: 'scrapbook',
+    name: 'scrapbook',
+    scope: [],
+    display: true,
+    displayName: 'Cahier multimédia',
+    isExternal: false,
+  },
+
   {
     address: '/workspace',
     icon: 'workspace',

--- a/packages/react/src/modules/homepage/components/Favorites/Favorites.tsx
+++ b/packages/react/src/modules/homepage/components/Favorites/Favorites.tsx
@@ -43,8 +43,8 @@ export function Favorites({
               </span>
             </Flex>
           ) : (
-            <Flex wrap="wrap" gap="16">
-              {apps.slice(0, 6).map((app) => {
+            <Flex wrap="wrap" gap="8 16">
+              {apps.map((app) => {
                 const appName = getAppName(app);
                 const opensInNewTab = app.isExternal || app.target === '_blank';
                 return (

--- a/packages/react/src/modules/homepage/components/Notifications/NotificationList.spec.tsx
+++ b/packages/react/src/modules/homepage/components/Notifications/NotificationList.spec.tsx
@@ -1,0 +1,19 @@
+import { mockNotifications } from '@edifice.io/config';
+import { render, screen } from '~/setup';
+import NotificationList from './NotificationList';
+
+describe('NotificationList', () => {
+  it('displays an empty screen when there are no notifications', () => {
+    render(<NotificationList notifications={[]} />);
+
+    expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+
+  it('renders as many items as notifications passed', () => {
+    const notifications = mockNotifications.slice(0, 3);
+
+    render(<NotificationList notifications={notifications} />);
+
+    expect(screen.getAllByRole('listitem')).toHaveLength(notifications.length);
+  });
+});

--- a/packages/react/src/modules/homepage/components/Notifications/NotificationList.tsx
+++ b/packages/react/src/modules/homepage/components/Notifications/NotificationList.tsx
@@ -54,16 +54,15 @@ const NotificationList = ({
           justify="between"
           align="center"
           wrap="nowrap"
-          className="notification-list-header py-16 ps-24 pe-8"
+          className="py-16 ps-24 pe-8"
         >
-          <h4 className="notification-list-title text-truncate">
+          <h4 className="text-truncate">
             {t('homepage.notifications-list.title')}
           </h4>
           {onCloseNotifications && (
             <ButtonBeta
               color="tertiary"
               variant="ghost"
-              className="notification-list-close"
               rightIcon={<IconClose />}
               onClick={handleCloseClick}
               aria-label={t('homepage.notifications-list.close')}

--- a/packages/react/src/modules/homepage/components/Notifications/components/SystemNotification.tsx
+++ b/packages/react/src/modules/homepage/components/Notifications/components/SystemNotification.tsx
@@ -32,7 +32,7 @@ const SystemNotification = ({ notification }: SystemNotificationProps) => {
         >
           <AppIcon
             app={params.appCode}
-            size="32"
+            size="24"
             variant="square"
             className="notification-app-icon"
           />

--- a/packages/react/src/modules/homepage/components/Notifications/components/notificationAdapter.spec.tsx
+++ b/packages/react/src/modules/homepage/components/Notifications/components/notificationAdapter.spec.tsx
@@ -1,0 +1,107 @@
+import { NotificationModel } from '@edifice.io/client';
+import {
+  bookingNotificationArgus,
+  infosNotification,
+  messageNotification,
+  supportNotification,
+  userMoodNotificationLoison,
+  userNotificationCollaborativeWall,
+  userNotificationForm,
+} from '@edifice.io/config';
+import { notificationAdapter } from './notificationAdapter';
+
+const makeNotification = (
+  overrides: Partial<NotificationModel>,
+): NotificationModel => ({
+  '_id': 'test-id',
+  'type': 'TEST',
+  'event-type': 'TEST',
+  'params': {},
+  'date': { $date: '2026-01-01T00:00:00.000Z' },
+  'message': 'test',
+  ...overrides,
+});
+
+describe('notificationAdapter', () => {
+  describe('type discrimination', () => {
+    it('returns type "user" when a sender is present', () => {
+      expect(notificationAdapter(messageNotification).type).toBe('user');
+    });
+
+    it('returns type "system" when no sender is present', () => {
+      expect(notificationAdapter(supportNotification).type).toBe('system');
+    });
+  });
+
+  describe('date conversion', () => {
+    it('converts MongoDB $date to a JS Date', () => {
+      const result = notificationAdapter(supportNotification);
+      expect(result.date).toEqual(new Date('2026-03-26T08:07:02.483Z'));
+    });
+  });
+
+  describe('message parsing', () => {
+    it('replaces <a> tags with <strong>', () => {
+      const notification = makeNotification({
+        message: '<a href="/foo">texte</a>',
+      });
+      expect(notificationAdapter(notification).message).toBe(
+        '<strong>texte</strong>',
+      );
+    });
+  });
+
+  describe('appCode normalization', () => {
+    it.each([
+      [
+        'COLLABORATIVEWALL',
+        userNotificationCollaborativeWall,
+        'collaborative-wall',
+      ],
+      ['FORMULAIRE', userNotificationForm, 'forms'],
+      ['MESSAGERIE', messageNotification, 'conversation'],
+      ['NEWS', infosNotification, 'actualites'],
+      ['USERBOOK_MOOD', userMoodNotificationLoison, 'userbook'],
+    ] as [string, NotificationModel, string][])(
+      'normalizes %s → %s',
+      (_type, notification, expectedAppCode) => {
+        expect(notificationAdapter(notification).params.appCode).toBe(
+          expectedAppCode,
+        );
+      },
+    );
+
+    it('converts underscores to hyphens for unknown types', () => {
+      const notification = makeNotification({
+        type: 'BLOG_POST',
+        sender: 'user-1',
+        params: { username: 'test' },
+      });
+      expect(notificationAdapter(notification).params.appCode).toBe(
+        'blog-post',
+      );
+    });
+  });
+
+  describe('URI resolution', () => {
+    it('prefers resourceUri over uri for user notifications', () => {
+      // bookingNotificationArgus has uri (userbook) and resourceUri (booking)
+      expect(notificationAdapter(bookingNotificationArgus).uri).toBe(
+        '/rbs#/booking/9171/2026-04-16',
+      );
+    });
+
+    it('falls back to uri when no resourceUri for user notifications', () => {
+      // userMoodNotificationLoison only has uri, no resourceUri
+      expect(notificationAdapter(userMoodNotificationLoison).uri).toBe(
+        '/directory/annuaire#b92e3d37-16b0-4ed9-b4c3-992091687132#Teacher',
+      );
+    });
+
+    it('finds the first *Uri param for system notifications', () => {
+      expect(notificationAdapter(supportNotification).uri).toBe(
+        '/support#/ticket/168',
+      );
+    });
+  });
+});


### PR DESCRIPTION

  # Description

  Corrections de suivi sur le module `Notifications` de la homepage après la PR #505 :

  - **`notificationAdapter`** : contrats de types renforcés (`username`, `userId`, `appCode` rendus requis), ajout du mapping
  `news → actualites`, utilisation d'assertions non-null pour les champs sender
  - **`NotificationList`** : corrections de layout, ajout du composant `NotificationListSkeleton`
  - **`useOverlay`** : interface simplifiée — suppression de `openOverlay`/`closeOverlay` au profit de `updateOverlayOpen`
  direct, `toggleOverlay` conservé
  - **Styles** : corrections d'icône de notification (`_notification.scss`) et du compteur favori (`_favorites.scss`)
  - **Tests** : ajout de `notificationAdapter.spec.tsx` (107 lignes) et `NotificationList.spec.tsx`

  Ticket : [IMPULS-5456](https://edifice-community.atlassian.net/browse/IMPULS-5456)

  ## Which Package changed?

  - [x] Components

  ## Has the documentation changed?

  - [ ] Storybook

  ## Type of change

  - [x] Bug fix (PATCH)

  # Checklist:

  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my code
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings

[IMPULS-5456]: https://edifice-community.atlassian.net/browse/IMPULS-5456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ