### PR TITLE
test: #ENABLING-935 add unit tests to @edifice.io/react (lot 3)

### DIFF
--- a/packages/react/src/components/Alert/Alert.spec.tsx
+++ b/packages/react/src/components/Alert/Alert.spec.tsx
@@ -1,0 +1,112 @@
+import { createRef } from 'react';
+
+import { act, render, screen } from '~/setup';
+import Alert, { AlertRef } from './Alert';
+
+describe('Alert component', () => {
+  it('renders its content and is visible by default', () => {
+    render(<Alert>Hello</Alert>);
+    const alert = screen.getByRole('alert');
+
+    expect(alert).toBeInTheDocument();
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+
+  it('applies the success modifier class by default', () => {
+    render(<Alert>Hello</Alert>);
+
+    expect(screen.getByRole('alert')).toHaveClass('alert-success');
+  });
+
+  it.each([
+    ['warning', 'alert-warning'],
+    ['info', 'alert-info'],
+    ['danger', 'alert-danger'],
+  ] as const)('maps the "%s" type to "%s"', (type, expectedClass) => {
+    render(<Alert type={type}>Hello</Alert>);
+
+    expect(screen.getByRole('alert')).toHaveClass(expectedClass);
+  });
+
+  it('applies toast and position modifier classes', () => {
+    render(
+      <Alert isToast position="top-right">
+        Hello
+      </Alert>,
+    );
+    const alert = screen.getByRole('alert');
+
+    expect(alert).toHaveClass('is-toast');
+    expect(alert).toHaveClass('top-right');
+  });
+
+  it('renders a dismiss button when dismissible and hides on click', async () => {
+    const onClose = vi.fn();
+    const { user } = render(
+      <Alert isDismissible onClose={onClose}>
+        Hello
+      </Alert>,
+    );
+
+    const closeButton = screen.getByRole('button');
+    await user.click(closeButton);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  it('does not render a dismiss button when not dismissible', () => {
+    render(<Alert>Hello</Alert>);
+
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('notifies visibility changes through onVisibilityChange', async () => {
+    const onVisibilityChange = vi.fn();
+    const { user } = render(
+      <Alert isDismissible onVisibilityChange={onVisibilityChange}>
+        Hello
+      </Alert>,
+    );
+
+    expect(onVisibilityChange).toHaveBeenLastCalledWith(true);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onVisibilityChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('exposes imperative show/hide handlers through the ref', () => {
+    const ref = createRef<AlertRef>();
+    render(
+      <Alert ref={ref} isDismissible>
+        Hello
+      </Alert>,
+    );
+
+    expect(typeof ref.current?.show).toBe('function');
+    expect(typeof ref.current?.hide).toBe('function');
+  });
+
+  it('auto-closes after the configured delay', () => {
+    vi.useFakeTimers();
+    try {
+      const onClose = vi.fn();
+      render(
+        <Alert autoClose autoCloseDelay={3000} onClose={onClose}>
+          Hello
+        </Alert>,
+      );
+
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/react/src/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.spec.tsx
@@ -5,7 +5,7 @@ import Checkbox from './Checkbox';
 
 describe('Checkbox component', () => {
   it('renders an unchecked, enabled checkbox by default', () => {
-    render(<Checkbox />);
+    render(<Checkbox readOnly />);
     const input = screen.getByRole('checkbox') as HTMLInputElement;
 
     expect(input).toBeInTheDocument();
@@ -15,7 +15,7 @@ describe('Checkbox component', () => {
   });
 
   it('renders a label linked to the input when provided', () => {
-    render(<Checkbox label="Accept terms" />);
+    render(<Checkbox label="Accept terms" readOnly />);
     const input = screen.getByRole('checkbox');
     const label = screen.getByText('Accept terms');
 
@@ -24,7 +24,7 @@ describe('Checkbox component', () => {
   });
 
   it('does not render a label when none is provided', () => {
-    const { container } = render(<Checkbox />);
+    const { container } = render(<Checkbox readOnly />);
 
     expect(container.querySelector('label')).toBeNull();
   });
@@ -38,21 +38,21 @@ describe('Checkbox component', () => {
   });
 
   it('sets the indeterminate DOM property from the prop', () => {
-    render(<Checkbox indeterminate />);
+    render(<Checkbox indeterminate readOnly />);
     const input = screen.getByRole('checkbox') as HTMLInputElement;
 
     expect(input.indeterminate).toBe(true);
   });
 
   it('keeps the indeterminate DOM property false when not set', () => {
-    render(<Checkbox />);
+    render(<Checkbox readOnly />);
     const input = screen.getByRole('checkbox') as HTMLInputElement;
 
     expect(input.indeterminate).toBe(false);
   });
 
   it('forwards extra className alongside the default classes', () => {
-    render(<Checkbox className="custom-class" />);
+    render(<Checkbox className="custom-class" readOnly />);
     const input = screen.getByRole('checkbox');
 
     expect(input).toHaveClass('custom-class', 'form-check-input', 'c-pointer');
@@ -60,7 +60,7 @@ describe('Checkbox component', () => {
 
   it('populates the forwarded ref once mounted', () => {
     const ref = createRef<HTMLInputElement>();
-    render(<Checkbox ref={ref} />);
+    render(<Checkbox ref={ref} readOnly />);
 
     expect(ref.current).not.toBeNull();
   });

--- a/packages/react/src/components/Checkbox/Checkbox.spec.tsx
+++ b/packages/react/src/components/Checkbox/Checkbox.spec.tsx
@@ -1,0 +1,76 @@
+import { createRef } from 'react';
+
+import { render, screen } from '~/setup';
+import Checkbox from './Checkbox';
+
+describe('Checkbox component', () => {
+  it('renders an unchecked, enabled checkbox by default', () => {
+    render(<Checkbox />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+
+    expect(input).toBeInTheDocument();
+    expect(input).not.toBeChecked();
+    expect(input).toBeEnabled();
+    expect(input).toHaveClass('form-check-input', 'c-pointer');
+  });
+
+  it('renders a label linked to the input when provided', () => {
+    render(<Checkbox label="Accept terms" />);
+    const input = screen.getByRole('checkbox');
+    const label = screen.getByText('Accept terms');
+
+    expect(label).toBeInTheDocument();
+    expect(label).toHaveAttribute('for', input.id);
+  });
+
+  it('does not render a label when none is provided', () => {
+    const { container } = render(<Checkbox />);
+
+    expect(container.querySelector('label')).toBeNull();
+  });
+
+  it('reflects the checked and disabled props', () => {
+    render(<Checkbox checked disabled onChange={() => {}} />);
+    const input = screen.getByRole('checkbox');
+
+    expect(input).toBeChecked();
+    expect(input).toBeDisabled();
+  });
+
+  it('sets the indeterminate DOM property from the prop', () => {
+    render(<Checkbox indeterminate />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+
+    expect(input.indeterminate).toBe(true);
+  });
+
+  it('keeps the indeterminate DOM property false when not set', () => {
+    render(<Checkbox />);
+    const input = screen.getByRole('checkbox') as HTMLInputElement;
+
+    expect(input.indeterminate).toBe(false);
+  });
+
+  it('forwards extra className alongside the default classes', () => {
+    render(<Checkbox className="custom-class" />);
+    const input = screen.getByRole('checkbox');
+
+    expect(input).toHaveClass('custom-class', 'form-check-input', 'c-pointer');
+  });
+
+  it('populates the forwarded ref once mounted', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<Checkbox ref={ref} />);
+
+    expect(ref.current).not.toBeNull();
+  });
+
+  it('calls onChange when toggled', async () => {
+    const handleChange = vi.fn();
+    const { user } = render(<Checkbox onChange={handleChange} />);
+
+    await user.click(screen.getByRole('checkbox'));
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/components/Divider/Divider.spec.tsx
+++ b/packages/react/src/components/Divider/Divider.spec.tsx
@@ -1,0 +1,40 @@
+import { render } from '~/setup';
+import Divider from './Divider';
+
+describe('Divider component', () => {
+  it('renders a horizontal divider by default', () => {
+    const { container } = render(<Divider />);
+    const divider = container.querySelector('.ant-divider');
+
+    expect(divider).toBeInTheDocument();
+    expect(divider).toHaveClass('ant-divider-horizontal');
+  });
+
+  it('renders a vertical divider when "vertical" is set', () => {
+    const { container } = render(<Divider vertical />);
+    const divider = container.querySelector('.ant-divider');
+
+    expect(divider).toHaveClass('ant-divider-vertical');
+  });
+
+  it('applies the default className when none is provided', () => {
+    const { container } = render(<Divider />);
+    const divider = container.querySelector('.ant-divider');
+
+    expect(divider).toHaveClass('border-gray-500');
+  });
+
+  it('applies a custom className', () => {
+    const { container } = render(<Divider className="border-red-500" />);
+    const divider = container.querySelector('.ant-divider');
+
+    expect(divider).toHaveClass('border-red-500');
+    expect(divider).not.toHaveClass('border-gray-500');
+  });
+
+  it('renders its children as content', () => {
+    const { getByText } = render(<Divider>Section Title</Divider>);
+
+    expect(getByText('Section Title')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/Radio/Radio.spec.tsx
+++ b/packages/react/src/components/Radio/Radio.spec.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from '~/setup';
+import Radio from './Radio';
+
+describe('Radio component', () => {
+  it('renders an enabled radio input by default', () => {
+    render(<Radio model="a" value="a" checked onChange={() => {}} />);
+    const input = screen.getByRole('radio');
+
+    expect(input).toBeInTheDocument();
+    expect(input).toHaveAttribute('type', 'radio');
+    expect(input).toHaveClass('form-check-input', 'c-pointer');
+  });
+
+  it('does not render a label by default', () => {
+    const { container } = render(<Radio model="a" value="a" />);
+
+    expect(container.querySelector('label')).toBeNull();
+  });
+
+  it('renders a text label linked to the input when provided', () => {
+    render(<Radio model="a" value="a" label="Option A" />);
+    const input = screen.getByRole('radio');
+    const label = screen.getByText('Option A');
+
+    expect(label).toHaveAttribute('for', input.id);
+    expect(label).toHaveClass('form-check-label');
+  });
+
+  it('reflects the checked and disabled props', () => {
+    render(<Radio model="a" value="a" checked disabled onChange={() => {}} />);
+    const input = screen.getByRole('radio');
+
+    expect(input).toBeChecked();
+    expect(input).toBeDisabled();
+  });
+
+  it('renders an icon instead of the text label and hides the input', () => {
+    render(
+      <Radio model="a" value="a" label="Ignored" icon={<span>icon</span>} />,
+    );
+    const input = screen.getByRole('radio');
+
+    expect(screen.getByText('icon')).toBeInTheDocument();
+    expect(screen.queryByText('Ignored')).toBeNull();
+    expect(input).toHaveClass('d-none');
+  });
+
+  it('mutes the icon label when the model does not match the value', () => {
+    render(<Radio model="b" value="a" icon={<span>icon</span>} />);
+    const label = screen.getByText('icon').closest('label');
+
+    expect(label).toHaveClass('text-muted');
+  });
+
+  it('does not mute the icon label when the model matches the value', () => {
+    render(<Radio model="a" value="a" icon={<span>icon</span>} />);
+    const label = screen.getByText('icon').closest('label');
+
+    expect(label).not.toHaveClass('text-muted');
+  });
+
+  it('calls onChange when selected', async () => {
+    const handleChange = vi.fn();
+    const { user } = render(
+      <Radio model="a" value="a" onChange={handleChange} />,
+    );
+
+    await user.click(screen.getByRole('radio'));
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/components/SmartEllipsis/SmartEllipsis.spec.tsx
+++ b/packages/react/src/components/SmartEllipsis/SmartEllipsis.spec.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from '~/setup';
+import SmartEllipsis from './SmartEllipsis';
+
+/**
+ * Helper to fake element dimensions: jsdom always reports 0 for scrollWidth
+ * and clientWidth, so we stub them on the prototype to exercise both the
+ * "fits" and the "overflows" branches of the component.
+ */
+function stubWidths(scrollWidth: number, clientWidth: number) {
+  const original = {
+    scrollWidth: Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'scrollWidth',
+    ),
+    clientWidth: Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      'clientWidth',
+    ),
+  };
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollWidth', {
+    configurable: true,
+    get() {
+      return scrollWidth;
+    },
+  });
+  Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
+    configurable: true,
+    get() {
+      return clientWidth;
+    },
+  });
+
+  return () => {
+    if (original.scrollWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'scrollWidth',
+        original.scrollWidth,
+      );
+    }
+    if (original.clientWidth) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        'clientWidth',
+        original.clientWidth,
+      );
+    }
+  };
+}
+
+describe('SmartEllipsis component', () => {
+  it('renders the full text inside a span with the expected class', () => {
+    const { container } = render(<SmartEllipsis text="Hello world" />);
+    const span = container.querySelector('span');
+
+    expect(span).toHaveClass('smart-ellipsis');
+    expect(span).toHaveTextContent('Hello world');
+  });
+
+  it('keeps the text untouched when it fits the container', () => {
+    const restore = stubWidths(50, 100);
+    try {
+      render(<SmartEllipsis text="Short" />);
+
+      expect(screen.getByText('Short')).toBeInTheDocument();
+    } finally {
+      restore();
+    }
+  });
+
+  it('truncates the text with an ellipsis when it overflows', () => {
+    const restore = stubWidths(200, 50);
+    try {
+      const { container } = render(
+        <SmartEllipsis text="A very long text that overflows" />,
+      );
+      const span = container.querySelector('span');
+
+      expect(span?.textContent).toContain('…');
+      expect(span?.textContent).not.toBe('A very long text that overflows');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/packages/react/src/components/SmartEllipsis/SmartEllipsis.spec.tsx
+++ b/packages/react/src/components/SmartEllipsis/SmartEllipsis.spec.tsx
@@ -32,12 +32,17 @@ function stubWidths(scrollWidth: number, clientWidth: number) {
   });
 
   return () => {
+    // Restore the original descriptor when there was one, otherwise delete the
+    // stub so it does not leak into later tests (the property may be inherited,
+    // in which case getOwnPropertyDescriptor returns undefined).
     if (original.scrollWidth) {
       Object.defineProperty(
         HTMLElement.prototype,
         'scrollWidth',
         original.scrollWidth,
       );
+    } else {
+      delete (HTMLElement.prototype as { scrollWidth?: number }).scrollWidth;
     }
     if (original.clientWidth) {
       Object.defineProperty(
@@ -45,6 +50,8 @@ function stubWidths(scrollWidth: number, clientWidth: number) {
         'clientWidth',
         original.clientWidth,
       );
+    } else {
+      delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth;
     }
   };
 }

--- a/packages/react/src/hooks/useClickOutside/useClickOutside.spec.tsx
+++ b/packages/react/src/hooks/useClickOutside/useClickOutside.spec.tsx
@@ -1,0 +1,63 @@
+import { fireEvent, render, screen } from '~/setup';
+import useClickOutside from './useClickOutside';
+
+function TestComponent({
+  handler,
+  events,
+}: {
+  handler: () => void;
+  events?: string[] | null;
+}) {
+  const ref = useClickOutside<HTMLDivElement>(handler, events);
+  return (
+    <div>
+      <div ref={ref} data-testid="inside">
+        inside
+      </div>
+      <div data-testid="outside">outside</div>
+    </div>
+  );
+}
+
+describe('useClickOutside', () => {
+  it('calls the handler when clicking outside the referenced element', () => {
+    const handler = vi.fn();
+    render(<TestComponent handler={handler} />);
+
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call the handler when clicking inside the referenced element', () => {
+    const handler = vi.fn();
+    render(<TestComponent handler={handler} />);
+
+    fireEvent.mouseDown(screen.getByTestId('inside'));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('listens to custom events when provided', () => {
+    const handler = vi.fn();
+    render(<TestComponent handler={handler} events={['click']} />);
+
+    // Default events (mousedown) should be ignored.
+    fireEvent.mouseDown(screen.getByTestId('outside'));
+    expect(handler).not.toHaveBeenCalled();
+
+    // The custom event should trigger the handler.
+    fireEvent.click(screen.getByTestId('outside'));
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes its listeners on unmount', () => {
+    const handler = vi.fn();
+    const { unmount } = render(<TestComponent handler={handler} />);
+
+    unmount();
+    fireEvent.mouseDown(document.body);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/hooks/useDropdown/useDropdown.spec.tsx
+++ b/packages/react/src/hooks/useDropdown/useDropdown.spec.tsx
@@ -1,0 +1,89 @@
+import { act, renderHook } from '~/setup';
+import useDropdown, { KEYS } from './useDropdown';
+
+/** Builds a minimal keyboard event with the spies the hook relies on. */
+function keyEvent(code: string, extra: Record<string, unknown> = {}) {
+  return {
+    code,
+    stopPropagation: vi.fn(),
+    preventDefault: vi.fn(),
+    ...extra,
+  } as any;
+}
+
+describe('useDropdown', () => {
+  it('is closed by default', () => {
+    const { result } = renderHook(() => useDropdown('bottom-start'));
+
+    expect(result.current.visible).toBe(false);
+    expect(result.current.isFocused).toBeNull();
+    expect(result.current.triggerProps['aria-expanded']).toBe(false);
+  });
+
+  it('opens through openDropdown and reflects it in the trigger props', () => {
+    const { result } = renderHook(() => useDropdown('bottom-start'));
+
+    act(() => result.current.openDropdown());
+
+    expect(result.current.visible).toBe(true);
+    expect(result.current.triggerProps['aria-expanded']).toBe(true);
+  });
+
+  it('toggles visibility when the trigger is clicked', () => {
+    const { result } = renderHook(() => useDropdown('bottom-start'));
+
+    act(() => result.current.triggerProps.onClick(keyEvent('')));
+    expect(result.current.visible).toBe(true);
+
+    act(() => result.current.triggerProps.onClick(keyEvent('')));
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('opens on ArrowDown key press on the trigger', () => {
+    const { result } = renderHook(() => useDropdown('bottom-start'));
+
+    act(() => result.current.triggerProps.onKeyDown(keyEvent(KEYS.ArrowDown)));
+
+    expect(result.current.visible).toBe(true);
+  });
+
+  it('opens on Space by default', () => {
+    const { result } = renderHook(() => useDropdown('bottom-start'));
+
+    act(() => result.current.triggerProps.onKeyDown(keyEvent(KEYS.Space)));
+
+    expect(result.current.visible).toBe(true);
+  });
+
+  it('does not open on Space when openOnSpace is disabled', () => {
+    const { result } = renderHook(() =>
+      useDropdown('bottom-start', undefined, false, true, false),
+    );
+
+    act(() => result.current.triggerProps.onKeyDown(keyEvent(KEYS.Space)));
+
+    expect(result.current.visible).toBe(false);
+  });
+
+  it('forwards an extra trigger keydown handler', () => {
+    const extraHandler = vi.fn();
+    const { result } = renderHook(() =>
+      useDropdown('bottom-start', extraHandler),
+    );
+
+    act(() => result.current.triggerProps.onKeyDown(keyEvent(KEYS.Enter)));
+
+    expect(extraHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes accessible attributes on the trigger and menu props', () => {
+    const { result } = renderHook(() => useDropdown('bottom-start'));
+
+    expect(result.current.triggerProps['aria-haspopup']).toBe('menu');
+    expect(result.current.triggerProps.id).toMatch(/^dropdown-toggle-/);
+    expect(result.current.menuProps['aria-labelledby']).toBe(
+      result.current.triggerProps.id,
+    );
+    expect(result.current.menuProps.className).toBe('dropdown-menu');
+  });
+});

--- a/packages/react/src/hooks/useHasWorkflow/useHasWorkflow.spec.tsx
+++ b/packages/react/src/hooks/useHasWorkflow/useHasWorkflow.spec.tsx
@@ -16,12 +16,15 @@ vi.mock('@edifice.io/client', () => ({
 }));
 
 describe('useHasWorkflow', () => {
-  it('is undefined until the right has been resolved', () => {
+  it('is undefined until the right has been resolved', async () => {
     hasWorkflowRight.mockResolvedValue(true);
 
     const { result } = renderHook(() => useHasWorkflow('workflow.create'));
 
     expect(result.current).toBeUndefined();
+
+    // Let the pending promise settle so the state update happens inside act().
+    await waitFor(() => expect(result.current).toBe(true));
   });
 
   it('resolves a single workflow right as a boolean', async () => {

--- a/packages/react/src/hooks/useHasWorkflow/useHasWorkflow.spec.tsx
+++ b/packages/react/src/hooks/useHasWorkflow/useHasWorkflow.spec.tsx
@@ -1,0 +1,50 @@
+import { renderHook, waitFor } from '~/setup';
+import useHasWorkflow from './useHasWorkflow';
+
+const { hasWorkflowRight, hasWorkflowRights } = vi.hoisted(() => ({
+  hasWorkflowRight: vi.fn(),
+  hasWorkflowRights: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    rights: () => ({
+      sessionHasWorkflowRight: hasWorkflowRight,
+      sessionHasWorkflowRights: hasWorkflowRights,
+    }),
+  },
+}));
+
+describe('useHasWorkflow', () => {
+  it('is undefined until the right has been resolved', () => {
+    hasWorkflowRight.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useHasWorkflow('workflow.create'));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('resolves a single workflow right as a boolean', async () => {
+    hasWorkflowRight.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useHasWorkflow('workflow.create'));
+
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(hasWorkflowRight).toHaveBeenCalledWith('workflow.create');
+  });
+
+  it('resolves multiple workflow rights as a record', async () => {
+    const rights = { 'workflow.create': true, 'workflow.delete': false };
+    hasWorkflowRights.mockResolvedValue(rights);
+
+    const { result } = renderHook(() =>
+      useHasWorkflow(['workflow.create', 'workflow.delete']),
+    );
+
+    await waitFor(() => expect(result.current).toEqual(rights));
+    expect(hasWorkflowRights).toHaveBeenCalledWith([
+      'workflow.create',
+      'workflow.delete',
+    ]);
+  });
+});

--- a/packages/react/src/hooks/useHasWorkflow/useHasWorkflow.spec.tsx
+++ b/packages/react/src/hooks/useHasWorkflow/useHasWorkflow.spec.tsx
@@ -16,6 +16,10 @@ vi.mock('@edifice.io/client', () => ({
 }));
 
 describe('useHasWorkflow', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('is undefined until the right has been resolved', async () => {
     hasWorkflowRight.mockResolvedValue(true);
 

--- a/packages/react/src/hooks/useTrapFocus/useTrapFocus.spec.tsx
+++ b/packages/react/src/hooks/useTrapFocus/useTrapFocus.spec.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen } from '~/setup';
+import useTrapFocus from './useTrapFocus';
+
+function TestComponent({ isActive }: { isActive?: boolean }) {
+  const ref = useTrapFocus(isActive);
+  return (
+    <div ref={ref as React.RefObject<HTMLDivElement>} data-testid="container">
+      <button>first</button>
+      <button>last</button>
+    </div>
+  );
+}
+
+describe('useTrapFocus', () => {
+  it('wraps focus from the last to the first element on Tab', () => {
+    render(<TestComponent isActive />);
+    const container = screen.getByTestId('container');
+    const first = screen.getByText('first');
+    const last = screen.getByText('last');
+
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    fireEvent.keyDown(container, { key: 'Tab' });
+
+    expect(document.activeElement).toBe(first);
+  });
+
+  it('wraps focus from the first to the last element on Shift+Tab', () => {
+    render(<TestComponent isActive />);
+    const container = screen.getByTestId('container');
+    const first = screen.getByText('first');
+    const last = screen.getByText('last');
+
+    first.focus();
+    expect(document.activeElement).toBe(first);
+
+    fireEvent.keyDown(container, { key: 'Tab', shiftKey: true });
+
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('does not trap focus when inactive', () => {
+    render(<TestComponent isActive={false} />);
+    const container = screen.getByTestId('container');
+    const last = screen.getByText('last');
+
+    last.focus();
+    fireEvent.keyDown(container, { key: 'Tab' });
+
+    // Focus is left untouched because the listener is not attached.
+    expect(document.activeElement).toBe(last);
+  });
+
+  it('ignores keys other than Tab', () => {
+    render(<TestComponent isActive />);
+    const container = screen.getByTestId('container');
+    const last = screen.getByText('last');
+
+    last.focus();
+    fireEvent.keyDown(container, { key: 'Enter' });
+
+    expect(document.activeElement).toBe(last);
+  });
+});

--- a/packages/react/src/utilities/react-query/react-query-utils.spec.ts
+++ b/packages/react/src/utilities/react-query/react-query-utils.spec.ts
@@ -1,0 +1,48 @@
+import { QueryClient } from '@tanstack/react-query';
+
+import { invalidateQueriesWithFirstPage } from './react-query-utils';
+
+describe('invalidateQueriesWithFirstPage', () => {
+  it('does nothing and returns undefined when no queryKey is provided', () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const result = invalidateQueriesWithFirstPage(queryClient, {});
+
+    expect(result).toBeUndefined();
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('invalidates the matching queries', () => {
+    const queryClient = new QueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    invalidateQueriesWithFirstPage(queryClient, { queryKey: ['users'] });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['users'] });
+  });
+
+  it('keeps only the first page of infinite query data', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['users'], {
+      pages: [['a'], ['b'], ['c']],
+      pageParams: [0, 1, 2],
+    });
+
+    invalidateQueriesWithFirstPage(queryClient, { queryKey: ['users'] });
+
+    expect(queryClient.getQueryData(['users'])).toEqual({
+      pages: [['a']],
+      pageParams: [0],
+    });
+  });
+
+  it('leaves non-infinite query data untouched', () => {
+    const queryClient = new QueryClient();
+    queryClient.setQueryData(['count'], { value: 42 });
+
+    invalidateQueriesWithFirstPage(queryClient, { queryKey: ['count'] });
+
+    expect(queryClient.getQueryData(['count'])).toEqual({ value: 42 });
+  });
+});


### PR DESCRIPTION
# Description

Amorce la couverture de tests unitaires (Vitest) du package `@edifice.io/react`, qui en était quasi dépourvu (5 specs au total, aucun hook ni utilitaire couvert). Lot 3 de l'effort de couverture — complémentaire de ENABLING-931 et ENABLING-932, sans recouvrement de cibles.

55 tests ajoutés, un commit par cible :

**Hooks**
- `useClickOutside` — clic dehors/dedans, events custom, cleanup au démontage
- `useTrapFocus` — wrap focus Tab / Shift+Tab, état inactif, touches non-Tab
- `useDropdown` — états open/close, toggle au clic, ouverture clavier, `openOnSpace`, attributs a11y
- `useHasWorkflow` — droit unique (bool), droits multiples (record), état initial (mock `@edifice.io/client`)

**Utilitaire**
- `invalidateQueriesWithFirstPage` — no-op sans queryKey, invalidation, reset à la 1ʳᵉ page (infinite query), data non-infinite intacte

**Composants**
- `SmartEllipsis` — rendu plein, troncature `…` au débordement (stub `scrollWidth`/`clientWidth`)
- `Checkbox` / `Radio` — checked/disabled/indeterminate, label, icône+muted, `onChange`, ref
- `Alert` — visibilité, mapping type→classe, toast/position, dismiss, callbacks, ref impératif, auto-close (fake timers)
- `Divider` — orientation horizontale/verticale, classe défaut/custom, children

Aucune modification de code de production : tests uniquement, pas d'impact sur l'API publique.

Jira : https://edifice-community.atlassian.net/browse/ENABLING-935

## Which Package changed?

- [x] Components
- [x] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
