### PR TITLE
test: #ENABLING-931, add unit tests to @edifice.io/react 

### DIFF
--- a/packages/react/src/components/Heading/Heading.spec.tsx
+++ b/packages/react/src/components/Heading/Heading.spec.tsx
@@ -15,15 +15,13 @@ describe('Heading', () => {
     expect(screen.getByText('Title')).toHaveClass('h1');
   });
 
-  it('renders the correct heading element for each level', () => {
-    const levels = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
-    const { rerender } = render(<Heading level="h1">Title</Heading>);
-
-    for (const level of levels) {
-      rerender(<Heading level={level}>Title</Heading>);
+  it.each(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const)(
+    'renders a %s element',
+    (level) => {
+      render(<Heading level={level}>Title</Heading>);
       expect(screen.getByText('Title').tagName).toBe(level.toUpperCase());
-    }
-  });
+    },
+  );
 
   it('applies the headingStyle class independently from the level', () => {
     render(

--- a/packages/react/src/components/Heading/Heading.spec.tsx
+++ b/packages/react/src/components/Heading/Heading.spec.tsx
@@ -1,0 +1,70 @@
+import { createRef } from 'react';
+import { render, screen } from '~/setup';
+import { describe, expect, it } from 'vitest';
+import Heading from './Heading';
+
+describe('Heading', () => {
+  it('renders an h1 element by default', () => {
+    render(<Heading>Title</Heading>);
+    const el = screen.getByText('Title');
+    expect(el.tagName).toBe('H1');
+  });
+
+  it('applies the h1 headingStyle class by default', () => {
+    render(<Heading>Title</Heading>);
+    expect(screen.getByText('Title')).toHaveClass('h1');
+  });
+
+  it('renders the correct heading element for each level', () => {
+    const levels = ['h1', 'h2', 'h3', 'h4', 'h5', 'h6'] as const;
+    const { rerender } = render(<Heading level="h1">Title</Heading>);
+
+    for (const level of levels) {
+      rerender(<Heading level={level}>Title</Heading>);
+      expect(screen.getByText('Title').tagName).toBe(level.toUpperCase());
+    }
+  });
+
+  it('applies the headingStyle class independently from the level', () => {
+    render(
+      <Heading level="h3" headingStyle="h1">
+        Title
+      </Heading>,
+    );
+    const el = screen.getByText('Title');
+    expect(el.tagName).toBe('H3');
+    expect(el).toHaveClass('h1');
+  });
+
+  it('merges a custom className with the headingStyle class', () => {
+    render(<Heading className="custom-class">Title</Heading>);
+    const el = screen.getByText('Title');
+    expect(el).toHaveClass('h1', 'custom-class');
+  });
+
+  it('renders children correctly', () => {
+    render(
+      <Heading>
+        <span>Nested</span>
+      </Heading>,
+    );
+    expect(screen.getByText('Nested')).toBeInTheDocument();
+  });
+
+  it('forwards a ref to the underlying heading element', () => {
+    const ref = createRef<HTMLHeadingElement>();
+    render(<Heading ref={ref}>Title</Heading>);
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.tagName).toBe('H1');
+  });
+
+  it('passes additional HTML attributes to the heading element', () => {
+    render(
+      <Heading data-testid="heading" aria-label="section title">
+        Title
+      </Heading>,
+    );
+    const el = screen.getByTestId('heading');
+    expect(el).toHaveAttribute('aria-label', 'section title');
+  });
+});

--- a/packages/react/src/components/Layout/components/HeaderNotificationsOverlay.spec.tsx
+++ b/packages/react/src/components/Layout/components/HeaderNotificationsOverlay.spec.tsx
@@ -19,7 +19,7 @@ vi.mock(
 );
 
 afterEach(() => {
-  useOverlayStore.setState({ overlayOpen: false });
+  act(() => useOverlayStore.setState({ overlayOpen: false }));
 });
 
 describe('HeaderNotificationsOverlay', () => {

--- a/packages/react/src/hooks/useCheckable/useCheckable.spec.tsx
+++ b/packages/react/src/hooks/useCheckable/useCheckable.spec.tsx
@@ -1,0 +1,104 @@
+import { act, renderHook } from '@testing-library/react';
+import { useCheckable } from './useCheckable';
+
+type Item = { _id: string; name: string };
+
+const items: Item[] = [
+  { _id: '1', name: 'Item 1' },
+  { _id: '2', name: 'Item 2' },
+  { _id: '3', name: 'Item 3' },
+];
+
+describe('useCheckable', () => {
+  it('starts with no selected items', () => {
+    const { result } = renderHook(() => useCheckable(items));
+    expect(result.current.selectedItems).toEqual([]);
+  });
+
+  it('reports allItemsSelected as false and isIndeterminate as false initially', () => {
+    const { result } = renderHook(() => useCheckable(items));
+    expect(result.current.allItemsSelected).toBe(false);
+    expect(result.current.isIndeterminate).toBe(false);
+  });
+
+  it('selects an item when handleOnSelectItem is called', () => {
+    const { result } = renderHook(() => useCheckable(items));
+
+    act(() => result.current.handleOnSelectItem('1'));
+
+    expect(result.current.selectedItems).toContain('1');
+    expect(result.current.selectedItems).toHaveLength(1);
+  });
+
+  it('deselects an item when handleOnSelectItem is called on an already-selected item', () => {
+    const { result } = renderHook(() => useCheckable(items));
+
+    act(() => result.current.handleOnSelectItem('1'));
+    act(() => result.current.handleOnSelectItem('1'));
+
+    expect(result.current.selectedItems).not.toContain('1');
+    expect(result.current.selectedItems).toHaveLength(0);
+  });
+
+  it('sets isIndeterminate to true when some but not all items are selected', () => {
+    const { result } = renderHook(() => useCheckable(items));
+
+    act(() => result.current.handleOnSelectItem('1'));
+
+    expect(result.current.isIndeterminate).toBe(true);
+    expect(result.current.allItemsSelected).toBe(false);
+  });
+
+  it('sets allItemsSelected to true when all items are selected via handleOnSelectAllItems', () => {
+    const { result } = renderHook(() => useCheckable(items));
+
+    act(() => result.current.handleOnSelectAllItems(false));
+
+    expect(result.current.allItemsSelected).toBe(true);
+    expect(result.current.isIndeterminate).toBe(false);
+    expect(result.current.selectedItems).toEqual(['1', '2', '3']);
+  });
+
+  it('clears all selections when handleOnSelectAllItems is called with deselect=true', () => {
+    const { result } = renderHook(() => useCheckable(items));
+
+    act(() => result.current.handleOnSelectAllItems(false));
+    act(() => result.current.handleOnSelectAllItems(true));
+
+    expect(result.current.selectedItems).toEqual([]);
+    expect(result.current.allItemsSelected).toBe(false);
+  });
+
+  it('removes stale selected ids when data shrinks and no longer contains them', () => {
+    const { result, rerender } = renderHook(
+      ({ data }: { data: Item[] }) => useCheckable(data),
+      { initialProps: { data: items } },
+    );
+
+    act(() => result.current.handleOnSelectAllItems(false));
+    expect(result.current.selectedItems).toHaveLength(3);
+
+    // Remove item '3' from the data
+    rerender({ data: [items[0], items[1]] });
+
+    expect(result.current.selectedItems).not.toContain('3');
+    expect(result.current.selectedItems).toHaveLength(2);
+  });
+
+  it('handles undefined data gracefully', () => {
+    const { result } = renderHook(() => useCheckable<Item>(undefined));
+
+    expect(result.current.selectedItems).toEqual([]);
+    expect(result.current.allItemsSelected).toBe(false);
+    expect(result.current.isIndeterminate).toBe(false);
+  });
+
+  it('reports allItemsSelected as false when data is empty', () => {
+    const { result } = renderHook(() => useCheckable<Item>([]));
+
+    act(() => result.current.handleOnSelectAllItems(false));
+
+    expect(result.current.allItemsSelected).toBe(false);
+    expect(result.current.selectedItems).toEqual([]);
+  });
+});

--- a/packages/react/src/hooks/useDebounce/useDebounce.spec.tsx
+++ b/packages/react/src/hooks/useDebounce/useDebounce.spec.tsx
@@ -1,0 +1,120 @@
+import { act, renderHook } from '@testing-library/react';
+import useDebounce from './useDebounce';
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the initial value immediately', () => {
+    const { result } = renderHook(() => useDebounce('initial', 300));
+    expect(result.current).toBe('initial');
+  });
+
+  it('does not update the value before the delay has elapsed', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: 'initial' } },
+    );
+
+    rerender({ value: 'updated' });
+    act(() => {
+      vi.advanceTimersByTime(299);
+    });
+
+    expect(result.current).toBe('initial');
+  });
+
+  it('updates the value after the specified delay', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: 'initial' } },
+    );
+
+    rerender({ value: 'updated' });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('updated');
+  });
+
+  it('uses 500ms as the default delay when none is provided', () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value), {
+      initialProps: { value: 'initial' },
+    });
+
+    rerender({ value: 'updated' });
+
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe('updated');
+  });
+
+  it('resets the timer when the value changes before the delay elapses', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: 'initial' } },
+    );
+
+    rerender({ value: 'first' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    rerender({ value: 'second' });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // 400ms total but last change was only 200ms ago — should still be debouncing
+    expect(result.current).toBe('initial');
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(result.current).toBe('second');
+  });
+
+  it('does not update state after the hook is unmounted', () => {
+    const { result, rerender, unmount } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: 'initial' } },
+    );
+
+    rerender({ value: 'updated' });
+    unmount();
+
+    // Advancing timers after unmount should not cause any state update or error
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe('initial');
+  });
+
+  it('works with non-string types', () => {
+    const { result, rerender } = renderHook(
+      ({ value }) => useDebounce(value, 300),
+      { initialProps: { value: 0 } },
+    );
+
+    rerender({ value: 42 });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(result.current).toBe(42);
+  });
+});

--- a/packages/react/src/hooks/useKeyPress/useKeyPress.spec.tsx
+++ b/packages/react/src/hooks/useKeyPress/useKeyPress.spec.tsx
@@ -1,0 +1,87 @@
+import { renderHook } from '@testing-library/react';
+import useKeyPress from './useKeyPress';
+
+describe('useKeyPress', () => {
+  const fireKeydown = (code: string) => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { code }));
+  };
+
+  it('calls the callback when a matching key is pressed', () => {
+    const callback = vi.fn();
+    renderHook(() => useKeyPress(callback, ['Enter']));
+
+    fireKeydown('Enter');
+
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call the callback for non-matching keys', () => {
+    const callback = vi.fn();
+    renderHook(() => useKeyPress(callback, ['Enter']));
+
+    fireKeydown('Escape');
+    fireKeydown('Space');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('calls the callback for any key in the provided list', () => {
+    const callback = vi.fn();
+    renderHook(() => useKeyPress(callback, ['ArrowUp', 'ArrowDown']));
+
+    fireKeydown('ArrowUp');
+    fireKeydown('ArrowDown');
+
+    expect(callback).toHaveBeenCalledTimes(2);
+  });
+
+  it('removes the event listener on unmount', () => {
+    const callback = vi.fn();
+    const { unmount } = renderHook(() => useKeyPress(callback, ['Enter']));
+
+    unmount();
+    fireKeydown('Enter');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('does not call the callback when keyCodes list is empty', () => {
+    const callback = vi.fn();
+    renderHook(() => useKeyPress(callback, []));
+
+    fireKeydown('Enter');
+    fireKeydown('Space');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('calls the updated callback after re-render', () => {
+    const firstCallback = vi.fn();
+    const secondCallback = vi.fn();
+
+    const { rerender } = renderHook(({ cb }) => useKeyPress(cb, ['Enter']), {
+      initialProps: { cb: firstCallback },
+    });
+
+    rerender({ cb: secondCallback });
+    fireKeydown('Enter');
+
+    expect(firstCallback).not.toHaveBeenCalled();
+    expect(secondCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('responds to an updated keyCodes list after re-render', () => {
+    const callback = vi.fn();
+
+    const { rerender } = renderHook(({ keys }) => useKeyPress(callback, keys), {
+      initialProps: { keys: ['Enter'] },
+    });
+
+    rerender({ keys: ['Escape'] });
+    fireKeydown('Enter');
+    expect(callback).not.toHaveBeenCalled();
+
+    fireKeydown('Escape');
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/hooks/useToggle/useToggle.spec.tsx
+++ b/packages/react/src/hooks/useToggle/useToggle.spec.tsx
@@ -1,0 +1,51 @@
+import { act, renderHook } from '@testing-library/react';
+import useToggle from './useToggle';
+
+describe('useToggle', () => {
+  it('returns false as the default initial state', () => {
+    const { result } = renderHook(() => useToggle());
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('returns the provided initial state', () => {
+    const { result: resultTrue } = renderHook(() => useToggle(true));
+    expect(resultTrue.current[0]).toBe(true);
+
+    const { result: resultFalse } = renderHook(() => useToggle(false));
+    expect(resultFalse.current[0]).toBe(false);
+  });
+
+  it('returns a toggle function as the second element', () => {
+    const { result } = renderHook(() => useToggle());
+    expect(typeof result.current[1]).toBe('function');
+  });
+
+  it('toggles state from false to true', () => {
+    const { result } = renderHook(() => useToggle(false));
+
+    act(() => {
+      result.current[1]();
+    });
+
+    expect(result.current[0]).toBe(true);
+  });
+
+  it('toggles state from true to false', () => {
+    const { result } = renderHook(() => useToggle(true));
+
+    act(() => {
+      result.current[1]();
+    });
+
+    expect(result.current[0]).toBe(false);
+  });
+
+  it('returns a stable toggle function reference across renders', () => {
+    const { result, rerender } = renderHook(() => useToggle(false));
+    const firstToggle = result.current[1];
+
+    rerender();
+
+    expect(result.current[1]).toBe(firstToggle);
+  });
+});

--- a/packages/react/src/modules/comments/components/TextCounter.spec.tsx
+++ b/packages/react/src/modules/comments/components/TextCounter.spec.tsx
@@ -1,5 +1,4 @@
-import { render, screen } from '@testing-library/react';
-import { expect } from 'vitest';
+import { render, screen } from '~/setup';
 import { TextCounter } from './TextCounter';
 
 describe('TextCounter', () => {

--- a/packages/react/src/modules/comments/components/TextCounter.spec.tsx
+++ b/packages/react/src/modules/comments/components/TextCounter.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { expect } from 'vitest';
+import { TextCounter } from './TextCounter';
+
+describe('TextCounter', () => {
+  it('renders the current length and maxLength', () => {
+    render(<TextCounter content="hello" maxLength={100} />);
+    expect(screen.getByText('5 / 100')).toBeInTheDocument();
+  });
+
+  it('shows 0 as length when content is an empty string', () => {
+    render(<TextCounter content="" maxLength={200} />);
+    expect(screen.getByText('0 / 200')).toBeInTheDocument();
+  });
+
+  it('shows the correct count as content length grows', () => {
+    const { rerender } = render(<TextCounter content="hi" maxLength={50} />);
+    expect(screen.getByText('2 / 50')).toBeInTheDocument();
+
+    rerender(<TextCounter content="hello world" maxLength={50} />);
+    expect(screen.getByText('11 / 50')).toBeInTheDocument();
+  });
+
+  it('renders a <p> element with the expected classes', () => {
+    render(<TextCounter content="test" maxLength={10} />);
+    const el = screen.getByText('4 / 10');
+    expect(el.tagName).toBe('P');
+    expect(el).toHaveClass('small', 'text-gray-700', 'p-2', 'text-end');
+  });
+
+  it('displays maxLength correctly when content equals maxLength', () => {
+    const content = 'a'.repeat(140);
+    render(<TextCounter content={content} maxLength={140} />);
+    expect(screen.getByText('140 / 140')).toBeInTheDocument();
+  });
+
+  it('displays count above maxLength when content exceeds it', () => {
+    const content = 'a'.repeat(160);
+    render(<TextCounter content={content} maxLength={140} />);
+    expect(screen.getByText('160 / 140')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/utilities/refs/ref.spec.tsx
+++ b/packages/react/src/utilities/refs/ref.spec.tsx
@@ -1,4 +1,4 @@
-import { createRef } from 'react';
+import { createRef, type MutableRefObject } from 'react';
 import { mergeRefs, setRef } from './ref';
 
 describe('setRef', () => {
@@ -51,9 +51,11 @@ describe('setRef', () => {
   });
 
   it('assigns null to a ref when val is null', () => {
-    const ref = { current: document.createElement('div') };
+    const ref: MutableRefObject<HTMLDivElement | null> = {
+      current: document.createElement('div'),
+    };
 
-    setRef(null, ref as any);
+    setRef<HTMLDivElement | null>(null, ref);
 
     expect(ref.current).toBeNull();
   });
@@ -104,11 +106,11 @@ describe('mergeRefs', () => {
   });
 
   it('propagates null when the node is unmounted', () => {
-    const ref = createRef<HTMLDivElement>();
+    const ref: MutableRefObject<HTMLDivElement | null> = { current: null };
     const callback = vi.fn();
 
-    const merged = mergeRefs(ref, callback);
-    merged(null as any);
+    const merged = mergeRefs<HTMLDivElement | null>(ref, callback);
+    merged(null);
 
     expect(ref.current).toBeNull();
     expect(callback).toHaveBeenCalledWith(null);

--- a/packages/react/src/utilities/refs/ref.spec.tsx
+++ b/packages/react/src/utilities/refs/ref.spec.tsx
@@ -1,0 +1,116 @@
+import { createRef } from 'react';
+import { mergeRefs, setRef } from './ref';
+
+describe('setRef', () => {
+  it('assigns the value to a MutableRefObject', () => {
+    const ref = createRef<HTMLDivElement>();
+    const el = document.createElement('div');
+
+    setRef(el, ref);
+
+    expect(ref.current).toBe(el);
+  });
+
+  it('calls a RefCallback with the value', () => {
+    const callback = vi.fn();
+    const el = document.createElement('div');
+
+    setRef(el, callback);
+
+    expect(callback).toHaveBeenCalledOnce();
+    expect(callback).toHaveBeenCalledWith(el);
+  });
+
+  it('sets multiple refs in a single call', () => {
+    const ref1 = createRef<HTMLDivElement>();
+    const ref2 = createRef<HTMLDivElement>();
+    const callback = vi.fn();
+    const el = document.createElement('div');
+
+    setRef(el, ref1, ref2, callback);
+
+    expect(ref1.current).toBe(el);
+    expect(ref2.current).toBe(el);
+    expect(callback).toHaveBeenCalledWith(el);
+  });
+
+  it('ignores null refs', () => {
+    const ref = createRef<HTMLDivElement>();
+    const el = document.createElement('div');
+
+    expect(() => setRef(el, null, ref)).not.toThrow();
+    expect(ref.current).toBe(el);
+  });
+
+  it('ignores undefined refs', () => {
+    const ref = createRef<HTMLDivElement>();
+    const el = document.createElement('div');
+
+    expect(() => setRef(el, undefined, ref)).not.toThrow();
+    expect(ref.current).toBe(el);
+  });
+
+  it('assigns null to a ref when val is null', () => {
+    const ref = { current: document.createElement('div') };
+
+    setRef(null, ref as any);
+
+    expect(ref.current).toBeNull();
+  });
+});
+
+describe('mergeRefs', () => {
+  it('returns a RefCallback function', () => {
+    const ref = createRef<HTMLDivElement>();
+    const merged = mergeRefs(ref);
+
+    expect(typeof merged).toBe('function');
+  });
+
+  it('assigns the value to all provided MutableRefObjects when called', () => {
+    const ref1 = createRef<HTMLDivElement>();
+    const ref2 = createRef<HTMLDivElement>();
+    const el = document.createElement('div');
+
+    const merged = mergeRefs(ref1, ref2);
+    merged(el);
+
+    expect(ref1.current).toBe(el);
+    expect(ref2.current).toBe(el);
+  });
+
+  it('calls all provided RefCallbacks when invoked', () => {
+    const cb1 = vi.fn();
+    const cb2 = vi.fn();
+    const el = document.createElement('div');
+
+    const merged = mergeRefs(cb1, cb2);
+    merged(el);
+
+    expect(cb1).toHaveBeenCalledWith(el);
+    expect(cb2).toHaveBeenCalledWith(el);
+  });
+
+  it('handles a mix of MutableRefObjects, RefCallbacks, null and undefined', () => {
+    const ref = createRef<HTMLDivElement>();
+    const callback = vi.fn();
+    const el = document.createElement('div');
+
+    const merged = mergeRefs(ref, callback, null, undefined);
+
+    expect(() => merged(el)).not.toThrow();
+    expect(ref.current).toBe(el);
+    expect(callback).toHaveBeenCalledWith(el);
+  });
+
+  it('propagates null when the node is unmounted', () => {
+    const ref = createRef<HTMLDivElement>();
+    const callback = vi.fn();
+
+    const merged = mergeRefs(ref, callback);
+    merged(null as any);
+
+    expect(ref.current).toBeNull();
+    expect(callback).toHaveBeenCalledWith(null);
+  });
+});

--- a/packages/react/src/utilities/rotate-transition-style/get-rotate-transition-style.spec.tsx
+++ b/packages/react/src/utilities/rotate-transition-style/get-rotate-transition-style.spec.tsx
@@ -1,0 +1,52 @@
+import { getRotateTransitionStyle } from './get-rotate-transition-style';
+
+describe('getRotateTransitionStyle', () => {
+  it('returns 0deg rotation when closed with default options', () => {
+    const style = getRotateTransitionStyle(false);
+    expect(style.rotate).toBe('0deg');
+  });
+
+  it('returns the default -180deg rotation when open', () => {
+    const style = getRotateTransitionStyle(true);
+    expect(style.rotate).toBe('-180deg');
+  });
+
+  it('uses the default 0.2s transition duration', () => {
+    const style = getRotateTransitionStyle(false);
+    expect(style.transition).toBe('rotate 0.2s ease-out');
+  });
+
+  it('applies a custom degrees value when open', () => {
+    const style = getRotateTransitionStyle(true, { degrees: 90 });
+    expect(style.rotate).toBe('90deg');
+  });
+
+  it('applies a custom degrees value when closed (always 0deg)', () => {
+    const style = getRotateTransitionStyle(false, { degrees: 90 });
+    expect(style.rotate).toBe('0deg');
+  });
+
+  it('applies a custom duration to the transition', () => {
+    const style = getRotateTransitionStyle(false, { duration: 0.5 });
+    expect(style.transition).toBe('rotate 0.5s ease-out');
+  });
+
+  it('applies both custom degrees and custom duration', () => {
+    const style = getRotateTransitionStyle(true, {
+      degrees: 45,
+      duration: 0.3,
+    });
+    expect(style.rotate).toBe('45deg');
+    expect(style.transition).toBe('rotate 0.3s ease-out');
+  });
+
+  it('works with negative custom degrees', () => {
+    const style = getRotateTransitionStyle(true, { degrees: -90 });
+    expect(style.rotate).toBe('-90deg');
+  });
+
+  it('works with zero degrees', () => {
+    const style = getRotateTransitionStyle(true, { degrees: 0 });
+    expect(style.rotate).toBe('0deg');
+  });
+});


### PR DESCRIPTION
# Description

Ajout de tests unitaires pour les éléments suivants du package react : 

Hooks :
- useDebounce
- useToggle
- useKeyPress
- useCheckable

Utilitaires :
- utilities/refs/ref.ts
- rotate-transition-style

Composants simples :
- TextCounter 
- Heading

⚠️ A noter l'ajout de la dépendance "vitest" pour l'utiliser dans le package react, nécessaire pour pouvoir appeler la fonction `toBeInTheDocument` sur `expect()`. J'ai mis la version dans le workspace pour partager aux différents packages si besoin dans le futur...

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
