### PR TITLE
docs: ENABLING-951 UserRights & UserSearch Storybook guides

### DIFF
--- a/apps/docs/.storybook/Mermaid.tsx
+++ b/apps/docs/.storybook/Mermaid.tsx
@@ -1,0 +1,58 @@
+import mermaid from 'mermaid';
+import { useEffect, useRef, useState } from 'react';
+
+mermaid.initialize({
+  startOnLoad: false,
+  theme: 'neutral',
+  securityLevel: 'loose',
+  flowchart: { htmlLabels: true, curve: 'basis' },
+});
+
+// Unique id per rendered diagram (mermaid.render requires a unique DOM id).
+let diagramCount = 0;
+
+/**
+ * Renders a Mermaid diagram from a chart definition string.
+ * Used inside MDX documentation pages to draw flows and sequences.
+ */
+export const Mermaid = ({ chart }: { chart: string }) => {
+  const [svg, setSvg] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const idRef = useRef(`mermaid-diagram-${diagramCount++}`);
+
+  useEffect(() => {
+    let active = true;
+    mermaid
+      .render(idRef.current, chart.trim())
+      .then(({ svg }) => {
+        if (active) {
+          setSvg(svg);
+          setError(null);
+        }
+      })
+      .catch((err: unknown) => {
+        if (active) setError(err instanceof Error ? err.message : String(err));
+      });
+    return () => {
+      active = false;
+    };
+  }, [chart]);
+
+  if (error) {
+    return (
+      <pre style={{ color: '#b00020', whiteSpace: 'pre-wrap' }}>
+        Mermaid error: {error}
+      </pre>
+    );
+  }
+
+  return (
+    <div
+      style={{ display: 'flex', justifyContent: 'center', margin: '1.5rem 0' }}
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: svg }}
+    />
+  );
+};
+
+export default Mermaid;

--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -11,18 +11,24 @@ const config: StorybookConfig = {
     '../src/stories/**/*.mdx',
   ],
   staticDirs: ['../public'],
-  addons: ['@storybook/addon-a11y', {
-    name: '@storybook/addon-docs',
-    options: {
-      mdxPluginOptions: {
-        mdxCompileOptions: {
-          providerImportSource: '@mdx-js/react',
-          // Enable GitHub Flavored Markdown (tables, strikethrough, etc.) in MDX docs.
-          remarkPlugins: [remarkGfm],
+  addons: [
+    '@storybook/addon-a11y',
+    {
+      name: '@storybook/addon-docs',
+      options: {
+        mdxPluginOptions: {
+          mdxCompileOptions: {
+            providerImportSource: '@mdx-js/react',
+            // Enable GitHub Flavored Markdown (tables, strikethrough, etc.) in MDX docs.
+            remarkPlugins: [remarkGfm],
+          },
         },
       },
     },
-  }, '@chromatic-com/storybook', '@storybook/addon-vitest', '@github-ui/storybook-addon-performance-panel'],
+    '@chromatic-com/storybook',
+    '@storybook/addon-vitest',
+    '@github-ui/storybook-addon-performance-panel',
+  ],
   typescript: {
     reactDocgen: 'react-docgen',
   },
@@ -45,6 +51,11 @@ const config: StorybookConfig = {
           '@images': resolve(
             dirname(fileURLToPath(import.meta.url)),
             '../node_modules/@edifice.io/bootstrap/dist/images',
+          ),
+          // Mermaid renderer used by MDX docs pages (e.g. UserRightsList guide).
+          '@docs/Mermaid': resolve(
+            dirname(fileURLToPath(import.meta.url)),
+            'Mermaid.tsx',
           ),
         },
       },

--- a/apps/docs/.storybook/main.ts
+++ b/apps/docs/.storybook/main.ts
@@ -1,5 +1,6 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 import { dirname, resolve } from 'path';
+import remarkGfm from 'remark-gfm';
 import { fileURLToPath } from 'url';
 
 const config: StorybookConfig = {
@@ -16,6 +17,8 @@ const config: StorybookConfig = {
       mdxPluginOptions: {
         mdxCompileOptions: {
           providerImportSource: '@mdx-js/react',
+          // Enable GitHub Flavored Markdown (tables, strikethrough, etc.) in MDX docs.
+          remarkPlugins: [remarkGfm],
         },
       },
     },

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -37,6 +37,7 @@
   },
   "devDependencies": {
     "@edifice.io/config": "workspace:*",
+    "remark-gfm": "^4.0.1",
     "vite": "catalog:"
   }
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,13 +31,14 @@
     "i18next": "catalog:",
     "i18next-browser-languagedetector": "8.2.0",
     "i18next-http-backend": "catalog:",
+    "mermaid": "11.15.0",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-i18next": "catalog:"
   },
   "devDependencies": {
     "@edifice.io/config": "workspace:*",
-    "remark-gfm": "^4.0.1",
+    "remark-gfm": "4.0.1",
     "vite": "catalog:"
   }
 }

--- a/packages/react/src/components/UserRightsList/UserRightsList.docs.mdx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.docs.mdx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
+import { Mermaid } from '@docs/Mermaid';
 
 <Meta title="Components/UserRightsList/Guide" />
 
@@ -25,28 +26,15 @@ Two components work together to build a sharing experience:
   users, groups, bookmarks) and lets the user toggle each permission before
   saving.
 
-```text
-            ┌─────────────────────────────────────────────────────────┐
-            │                     Sharing screen                        │
-            │                                                           │
-   search   │   ┌──────────────┐        adds recipient                 │
- ──────────►│   │  UserSearch  │ ───────────────────────────┐          │
-            │   └──────────────┘   onSearchResultsChange     │          │
-            │          ▲                                      ▼          │
-            │          │ removeSharing(id)         ref.addItem(item)     │
-            │          │ (when a row is removed)              │          │
-            │          │                                      ▼          │
-            │   ┌───────────────────────────────────────────────────┐  │
-            │   │                 UserRightsList                     │  │
-            │   │  owner · users · groups · bookmarks (collapsible)  │  │
-            │   │  one checkbox per right (read/contrib/…)           │  │
-            │   └───────────────────────────────────────────────────┘  │
-            │                          │ onChange / onAddItems /          │
-            │                          │ onDeleteItems / onSaveBookmark   │
-            └──────────────────────────┼──────────────────────────────────┘
-                                       ▼
-                       PUT /homeworks/share/resource/{id}
-```
+<Mermaid
+  chart={`
+flowchart TD
+  Q["User types a query"] --> US["UserSearch (combobox)<br/>users · groups · bookmarks"]
+  US -->|"onSearchResultsChange<br/>host calls ref.addItem(item)"| URL["UserRightsList<br/>owner · users · groups · bookmarks (collapsible)<br/>one checkbox per right"]
+  URL -.->|"removeSharing(id)<br/>when a row is removed"| US
+  URL -->|"onChange · onAddItems · onDeleteItems · onSaveBookmark"| SAVE["PUT /homeworks/share/resource/:id"]
+`}
+/>
 
 The host application owns the data fetching (REST calls) and wires the two
 components together. The components themselves are **presentational + local
@@ -299,22 +287,26 @@ inject a recipient picked in `UserSearch`.
 
 ## 8. End-to-end flow
 
-```text
-1. User types in UserSearch
-   └─► getSearchResults(query)  → users / groups / bookmarks
-
-2. User picks a bookmark
-   └─► host: GET /directory/sharebookmark/{id}
-   └─► host: ref.addItem(BookmarkInput)
-       └─► UserRightsList: collapsible row + one SharingItem per visible user
-                            (default rights applied)
-
-3. User adjusts rights
-   ├─ bookmark row checkbox  → applies to every user of the bookmark
-   └─ individual user row     → overrides that single user
-
-4. onChange(items) keeps the host's state in sync
-
-5. User confirms
-   └─► host: PUT /homeworks/share/resource/{id}  { bookmarks, users, groups }
-```
+<Mermaid
+  chart={`
+sequenceDiagram
+  actor U as User
+  participant S as UserSearch
+  participant H as Host app
+  participant L as UserRightsList
+  participant API as Backend
+  U->>S: type a query
+  S->>H: getSearchResults(query)
+  H-->>S: users / groups / bookmarks
+  U->>S: pick a bookmark
+  S->>H: onSearchResultsChange(bookmark)
+  H->>API: GET /directory/sharebookmark/:id
+  API-->>H: BookmarkInput (visible users)
+  H->>L: ref.addItem(BookmarkInput)
+  L->>L: collapsible row + 1 SharingItem per user (default rights)
+  U->>L: adjust rights (bookmark row or individual user)
+  L->>H: onChange(items)
+  U->>L: confirm
+  H->>API: PUT /homeworks/share/resource/:id {bookmarks, users, groups}
+`}
+/>

--- a/packages/react/src/components/UserRightsList/UserRightsList.docs.mdx
+++ b/packages/react/src/components/UserRightsList/UserRightsList.docs.mdx
@@ -1,0 +1,320 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Components/UserRightsList/Guide" />
+
+# User Rights & Sharing — Developer Guide
+
+This guide documents how user rights (UserRights) are managed when sharing a
+resource: how share bookmarks (favorites) are loaded, how rights can be edited
+individually before sharing, the complete share flow, the data structures
+involved, and the known edge cases.
+
+It complements the interactive
+[UserRightsList stories](?path=/docs/components-userrightslist--docs) and the
+[UserSearch guide](?path=/docs/components-usersearch-guide--docs).
+
+---
+
+## 1. Overview
+
+Two components work together to build a sharing experience:
+
+- **`UserSearch`** — a combobox to find users, groups and share bookmarks
+  (favorites), and to add them to the current selection.
+- **`UserRightsList`** — a table that lists the selected recipients (owner,
+  users, groups, bookmarks) and lets the user toggle each permission before
+  saving.
+
+```text
+            ┌─────────────────────────────────────────────────────────┐
+            │                     Sharing screen                        │
+            │                                                           │
+   search   │   ┌──────────────┐        adds recipient                 │
+ ──────────►│   │  UserSearch  │ ───────────────────────────┐          │
+            │   └──────────────┘   onSearchResultsChange     │          │
+            │          ▲                                      ▼          │
+            │          │ removeSharing(id)         ref.addItem(item)     │
+            │          │ (when a row is removed)              │          │
+            │          │                                      ▼          │
+            │   ┌───────────────────────────────────────────────────┐  │
+            │   │                 UserRightsList                     │  │
+            │   │  owner · users · groups · bookmarks (collapsible)  │  │
+            │   │  one checkbox per right (read/contrib/…)           │  │
+            │   └───────────────────────────────────────────────────┘  │
+            │                          │ onChange / onAddItems /          │
+            │                          │ onDeleteItems / onSaveBookmark   │
+            └──────────────────────────┼──────────────────────────────────┘
+                                       ▼
+                       PUT /homeworks/share/resource/{id}
+```
+
+The host application owns the data fetching (REST calls) and wires the two
+components together. The components themselves are **presentational + local
+state**: they never call the API directly.
+
+---
+
+## 2. Share bookmarks (favorites)
+
+A **share bookmark** (favorite) is a saved set of recipients (users and groups)
+that an author can reuse across resources. In the sharing UI a bookmark appears
+as a single **collapsible row** grouping all of its users.
+
+### 2.1 Loading the users of a bookmark
+
+When the user selects a bookmark in `UserSearch`, the host application fetches
+the underlying recipients:
+
+```http
+GET /directory/sharebookmark/{id}
+```
+
+**Response** — the list of users attached to the bookmark:
+
+```jsonc
+{
+  "id": "_9a1d29c3d2864ed8a3d72198fadf4a96",
+  "name": "Parents délégués CE2",
+  "notVisibleCount": 0,
+  "groups": [],
+  "users": [
+    {
+      "id": "c0824335-ab0e-41fb-9ed3-d5c28a93087d",
+      "displayName": "CARPENTIER Béatrice",
+      "profile": "Relative",
+      "activationCode": false,
+    },
+    {
+      "id": "6a7495f8-bec7-4f68-b891-0b05c6e8e0ce",
+      "displayName": "ROUSTIN Christophe",
+      "profile": "Relative",
+      "activationCode": false,
+    },
+  ],
+}
+```
+
+This response maps directly to the `BookmarkInput` type (see
+[§4 Data structures](#4-data-structures)).
+
+### 2.2 Adding a bookmark to the list
+
+The host passes the fetched `BookmarkInput` to `UserRightsList` through the
+imperative ref:
+
+```tsx
+const ref = useRef<UserRightsListRef>(null);
+
+// after GET /directory/sharebookmark/{id}
+ref.current?.addItem(bookmarkInput); // BookmarkInput → collapsible group
+```
+
+`UserRightsList.addItem` accepts **either** a `SharingItem` (a single user or
+group) **or** a `BookmarkInput` (a group of users). It discriminates them with
+the `isBookmarkInput` type guard (presence of a `users` array).
+
+When a bookmark is added (`useBookmarkEntries.addBookmark`):
+
+1. The bookmark is ignored if its `id` is already present.
+2. Only users **not already** in the list are inserted (de-duplication by
+   `recipientId`). See the [`notVisibleCount` and overlap](#5-edge-cases) note.
+3. Each new user becomes a `SharingItem` with the **default permissions**
+   (every right whose `default` is `true`, usually `read`).
+4. A `BookmarkState` is stored (collapsed by default).
+
+### 2.3 Editing rights individually before sharing
+
+Rights can be edited at two levels:
+
+- **Per bookmark row** — toggling a checkbox on the bookmark header applies the
+  change to **all** users of the bookmark
+  (`useBookmarkEntries.toggleBookmarkRight` → `applyRightToIds`).
+- **Per user row** — expand the bookmark and toggle the checkbox on an
+  individual user (`useSharingItems.changeRight`). This overrides the value set
+  at the bookmark level for that single user.
+
+Both paths go through the same permission logic (requires/excludes, transitive
+removal) described in [§3](#3-permission-logic).
+
+### 2.4 Removing a bookmark
+
+`deleteBookmark` removes the `BookmarkState` **and** every `SharingItem` that
+belonged to it (`deleteItemsByIds`). Users that had been added individually
+(outside the bookmark) are not affected.
+
+---
+
+## 3. Permission logic
+
+Rights are described by `ResourceRights` — a record keyed by right name
+(`read`, `contrib`, `publish`, `manager`, `comment`). Each definition declares
+dependencies:
+
+```ts
+type ResourceRightDefinition = {
+  priority: number;
+  default: boolean; // granted automatically to new recipients
+  requires: ResourceRightName[]; // rights implicitly added when this one is set
+  excludes: ResourceRightName[]; // rights removed when this one is set
+  displayName?: string;
+  isReadOnlyCheckbox?: boolean; // checkbox shown but not editable
+};
+```
+
+`createRightsHelpers` implements two pure operations:
+
+- **`applyRight(item, right, add)`**
+  - **add** → adds `right`, adds all its `requires`, removes any `excludes`.
+  - **remove** → removes `right` **and every right that transitively depends on
+    it** (fixed-point over `requires`). E.g. removing `read` removes `contrib`,
+    `publish` and `manager` too.
+- **`toggleRight(item, right)`** → `applyRight` with the opposite of the current
+  state.
+
+The owner row is always built with **all** rights and is always read-only
+(`getOwnerItem`).
+
+---
+
+## 4. Data structures
+
+### `SharingItem` — a single recipient in the list
+
+```ts
+type SearchResultType = 'user' | 'group' | 'bookmark';
+
+interface SharingItem {
+  recipientId: string;
+  recipientType: SearchResultType;
+  permission: string[]; // e.g. ['read', 'contrib']
+  displayName: string;
+}
+```
+
+### `BookmarkInput` — payload returned by `GET /directory/sharebookmark/{id}`
+
+```ts
+interface BookmarkUser {
+  id: string;
+  displayName: string;
+  profile?: string; // e.g. 'Relative', 'Teacher'
+  activationCode?: boolean; // account not yet activated when true
+}
+
+interface BookmarkInput {
+  id: string;
+  name: string;
+  notVisibleCount?: number; // recipients the current user cannot see
+  groups?: { id: string; displayName: string }[];
+  users: BookmarkUser[];
+}
+```
+
+### `BookmarkState` — internal collapsible-row state
+
+```ts
+interface BookmarkState {
+  id: string;
+  name: string;
+  permission: string[]; // rights applied to the whole bookmark
+  userIds: string[]; // recipientIds of the users it owns in the list
+  isExpanded: boolean;
+}
+```
+
+### Save payload — `PUT /homeworks/share/resource/{id}`
+
+When the user confirms, the host serializes the current state into the share
+request. It carries both the **bookmark** reference(s) and the **users** with
+their resolved permissions:
+
+```jsonc
+{
+  "bookmarks": {
+    "_9a1d29c3d2864ed8a3d72198fadf4a96": ["read", "comment"],
+  },
+  "users": {
+    "c0824335-ab0e-41fb-9ed3-d5c28a93087d": ["read", "comment"],
+    "6a7495f8-bec7-4f68-b891-0b05c6e8e0ce": ["read"],
+  },
+  "groups": {},
+}
+```
+
+> The exact wire format is owned by the backend / REST client; the table above
+> reflects the `bookmark + users` contract referenced by the feature. Keep this
+> section in sync with `@edifice.io/client` if the shape changes.
+
+---
+
+## 5. Edge cases
+
+- **`notVisibleCount` > 0** — a bookmark can reference recipients the current
+  user is not allowed to see. They are **not** returned in `users`, so they are
+  never displayed or editable in the list. Surface the count to the user so the
+  share is not perceived as incomplete.
+- **Empty groups / empty bookmark** — a bookmark may resolve to zero visible
+  users. `addBookmark` still creates the collapsible row; expanding it shows no
+  user sub-rows.
+- **Overlap with existing recipients** — users already present in the list are
+  skipped when a bookmark is added (`existingRecipientIds`). The bookmark row
+  therefore only "owns" the users it actually inserted; deleting it will not
+  remove a user that was already shared individually.
+- **Owner row** — always read-only and always granted all rights; it cannot be
+  removed.
+- **`isReadOnlyCheckbox`** — a right can be displayed but locked; its checkbox
+  is disabled regardless of `isReadOnly`.
+
+---
+
+## 6. Callbacks reference
+
+| Prop                          | When it fires                                                                                                   |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `onChange(items)`             | Any change to the full list (add/remove/toggle). Source of truth for the save payload.                          |
+| `onAddItems(items)`           | Batch add (single user, or all users of a bookmark).                                                            |
+| `onDeleteItems(items)`        | Batch delete (single user, or all users of a removed bookmark).                                                 |
+| `onSaveBookmark(name, items)` | User saves the current selection as a new favorite. Optional; hides the "Save as bookmark" button when omitted. |
+
+The `ref` exposes `addItem(item: SharingItem | BookmarkInput)` so the host can
+inject a recipient picked in `UserSearch`.
+
+---
+
+## 7. Known bug
+
+> ⚠️ **On edit, the bookmark disappears.**
+> When re-opening the share dialog on a resource that was shared via a bookmark,
+> the bookmark row is not rebuilt from the persisted sharing: the previously
+> shared users come back as **individual rows** instead of being re-grouped
+> under their favorite. This is because the persisted share only stores the
+> resolved recipients/permissions, while the collapsible grouping lives in
+> `BookmarkState`, which is rebuilt only when `addItem(BookmarkInput)` is called
+> at runtime.
+>
+> Tracking: see the related JIRA item. Documenting it here so maintainers know
+> the grouping is **runtime-only** and is not restored from `initialSharings`.
+
+---
+
+## 8. End-to-end flow
+
+```text
+1. User types in UserSearch
+   └─► getSearchResults(query)  → users / groups / bookmarks
+
+2. User picks a bookmark
+   └─► host: GET /directory/sharebookmark/{id}
+   └─► host: ref.addItem(BookmarkInput)
+       └─► UserRightsList: collapsible row + one SharingItem per visible user
+                            (default rights applied)
+
+3. User adjusts rights
+   ├─ bookmark row checkbox  → applies to every user of the bookmark
+   └─ individual user row     → overrides that single user
+
+4. onChange(items) keeps the host's state in sync
+
+5. User confirms
+   └─► host: PUT /homeworks/share/resource/{id}  { bookmarks, users, groups }
+```

--- a/packages/react/src/components/UserSearch/UserSearch.docs.mdx
+++ b/packages/react/src/components/UserSearch/UserSearch.docs.mdx
@@ -1,0 +1,172 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Components/UserSearch/Guide" />
+
+# UserSearch — Developer Guide
+
+`UserSearch` is the entry point of the sharing flow: a debounced combobox used
+to find **users**, **groups** and **share bookmarks** (favorites) and to add
+them to the current selection. It is designed to be wired to
+[`UserRightsList`](?path=/docs/components-userrightslist-guide--docs), which
+displays the selected recipients and lets the author edit their rights.
+
+See the interactive examples in the
+[UserSearch stories](?path=/docs/components-usersearch--docs).
+
+---
+
+## 1. Responsibilities
+
+`UserSearch` owns **search-time** concerns only:
+
+- debounce the input (500 ms) and enforce a minimum length;
+- call the host-provided `getSearchResults` and manage its own loading state;
+- merge bookmarks + API results and **hide recipients already selected**;
+- notify the host when an item is picked (`onSearchResultsChange`);
+- expose `removeSharing(id)` so a recipient can re-appear in the dropdown when
+  it is removed elsewhere.
+
+It does **not** fetch data itself and does **not** know about permissions — that
+is the host's and `UserRightsList`'s job.
+
+---
+
+## 2. Props & ref
+
+```ts
+interface UserSearchProps {
+  placeholder?: string;
+  isAdmlcOrAdmc?: boolean; // admin context → min length 3 instead of 1
+  bookmarks?: Visible[]; // favorites shown before/with results
+  initialSharings?: SharingItem[]; // already-shared recipients to hide
+  getSearchResults: (query: string) => Promise<{ results: Visible[] }>;
+  onSearchResultsChange?: (result: Visible) => void;
+}
+
+interface UserSearchRef {
+  removeSharing: (recipientId: string) => void;
+}
+```
+
+### `Visible` — a search result
+
+```ts
+enum VisibleType {
+  User = 'User',
+  Group = 'Group',
+  ShareBookmark = 'ShareBookmark',
+  BroadcastGroup = 'BroadcastGroup',
+}
+
+type Visible = {
+  id: string;
+  displayName: string;
+  type: VisibleType;
+  profile?: string;
+  nbUsers?: number;
+  // …structureName, relatives, children, usedIn — see types/visible.ts
+};
+```
+
+Each type renders a distinct icon (user / group / bookmark).
+
+---
+
+## 3. Search behavior
+
+- **Minimum length** — `1` character by default, `3` when `isAdmlcOrAdmc` is
+  `true` (admin searches can be very broad).
+- **Debounce** — input changes are debounced 500 ms (`useDebounce`) before
+  `getSearchResults` runs.
+- **Loading** — managed internally; the combobox shows a spinner while the
+  promise is pending. Errors fall back to showing the (filtered) bookmarks.
+- **Below minimum length** — only bookmarks are shown, so stale API results do
+  not linger.
+- **Cancellation** — a `cancelled` flag prevents a late response from a previous
+  query from overwriting newer results.
+
+---
+
+## 4. Selection & de-duplication
+
+`UserSearch` tracks which recipients are already selected so they are not
+offered twice:
+
+- `sharingsIds` — the set of selected `recipientId`s, seeded from
+  `initialSharings`. Anything in this set is filtered out of the dropdown.
+- `sharedItemsCache` — a `recipientId → Visible` map so a removed recipient can
+  be **re-injected** into the results.
+
+```text
+pick result            → add id to sharingsIds, cache it, hide from dropdown
+                       → onSearchResultsChange(result)   (host adds it to the list)
+
+removeSharing(id)      → drop id from sharingsIds
+(called by the host)   → if cached, push the Visible back into the results
+```
+
+---
+
+## 5. Wiring with UserRightsList
+
+`UserSearch` and `UserRightsList` are complementary. The host connects them:
+
+```tsx
+const rightsRef = useRef<UserRightsListRef>(null);
+const searchRef = useRef<UserSearchRef>(null);
+
+<UserSearch
+  ref={searchRef}
+  bookmarks={bookmarks}
+  initialSharings={sharings}
+  getSearchResults={getSearchResults}
+  onSearchResultsChange={async (result) => {
+    if (result.type === VisibleType.ShareBookmark) {
+      // Resolve the bookmark's users before adding it
+      const bookmark = await getShareBookmark(result.id); // GET /directory/sharebookmark/{id}
+      rightsRef.current?.addItem(bookmark);               // BookmarkInput → collapsible group
+    } else {
+      rightsRef.current?.addItem({
+        recipientId: result.id,
+        recipientType: result.type === VisibleType.User ? 'user' : 'group',
+        displayName: result.displayName,
+        permission: [],
+      });
+    }
+  }}
+/>
+
+<UserRightsList
+  ref={rightsRef}
+  /* … */
+  onDeleteItems={(items) =>
+    // keep search in sync: removed recipients become searchable again
+    items.forEach((i) => searchRef.current?.removeSharing(i.recipientId))
+  }
+/>
+```
+
+Key interaction points:
+
+1. **Picking a bookmark** in `UserSearch` triggers
+   `GET /directory/sharebookmark/{id}`; the resolved `BookmarkInput` is handed to
+   `UserRightsList.addItem`, which renders it as a collapsible group with default
+   rights. (Full flow in the
+   [UserRightsList guide](?path=/docs/components-userrightslist-guide--docs#8-end-to-end-flow).)
+2. **Removing a recipient** in `UserRightsList` should call
+   `searchRef.current?.removeSharing(id)` so the recipient reappears in search
+   results.
+3. **Already-shared recipients** are passed as `initialSharings` to both
+   components so they start hidden in search and visible in the list.
+
+---
+
+## 6. Edge cases
+
+- **Bookmark vs. its users** — `UserSearch` only knows the bookmark as a single
+  `Visible`; the expansion into individual users happens after the
+  `GET /directory/sharebookmark/{id}` call, inside `UserRightsList`. A bookmark
+  whose users are not visible (`notVisibleCount > 0`) still selects fine here.
+- **Admin contexts** — with `isAdmlcOrAdmc`, the 3-char minimum avoids
+  fetching enormous result sets.
+- **Empty query** — never hits the API; shows bookmarks only.

--- a/packages/react/src/components/UserSearch/UserSearch.docs.mdx
+++ b/packages/react/src/components/UserSearch/UserSearch.docs.mdx
@@ -1,4 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
+import { Mermaid } from '@docs/Mermaid';
 
 <Meta title="Components/UserSearch/Guide" />
 
@@ -97,13 +98,15 @@ offered twice:
 - `sharedItemsCache` — a `recipientId → Visible` map so a removed recipient can
   be **re-injected** into the results.
 
-```text
-pick result            → add id to sharingsIds, cache it, hide from dropdown
-                       → onSearchResultsChange(result)   (host adds it to the list)
-
-removeSharing(id)      → drop id from sharingsIds
-(called by the host)   → if cached, push the Visible back into the results
-```
+<Mermaid
+  chart={`
+flowchart LR
+  P["pick result"] --> A["add id to sharingsIds<br/>cache it · hide from dropdown"]
+  A --> B["onSearchResultsChange(result)<br/>host adds it to the list"]
+  R["removeSharing(id)<br/>(called by the host)"] --> C["drop id from sharingsIds"]
+  C --> D["if cached, push the Visible<br/>back into the results"]
+`}
+/>
 
 ---
 


### PR DESCRIPTION
# Description

Documentation technique de la gestion des droits utilisateurs (UserRights) et de son interaction avec `UserSearch`, sous forme de pages Storybook dédiées (en anglais).

Jira : [ENABLING-951](https://edifice-community.atlassian.net/browse/ENABLING-951)

Contenu :
- **Guide `UserRightsList`** : favoris de partage (chargement via `GET /directory/sharebookmark/{id}`, ajout via `ref.addItem`, édition unitaire/groupée des droits, suppression), logique de permissions (requires/excludes, retrait transitif), structures de données / DTOs (`SharingItem`, `BookmarkInput`, `BookmarkState`, payload `PUT /homeworks/share/resource/{id}`), cas limites (`notVisibleCount`, groupes vides, overlap), **bug connu** (favori qui disparaît à l'édition), flux end-to-end.
- **Guide `UserSearch`** : comportement de recherche (debounce, min length, loading), déduplication, wiring avec `UserRightsList`.
- **Outillage Storybook** (corrige des soucis récurrents de rendu MDX) :
  - `remark-gfm` ajouté → les **tables Markdown** s'affichent enfin comme de vraies tables.
  - Composant **`Mermaid`** (+ alias Vite `@docs/Mermaid`) → diagrammes vectoriels (flowchart + sequence) à la place de l'ASCII art.

## Which Package changed?

- [x] Components

## Has the documentation changed?

- [x] Storybook

## Type of change

- [x] Doc (PATCH)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENABLING-951]: https://edifice-community.atlassian.net/browse/ENABLING-951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ