### PR TITLE
fix(bootstrap): #IMPULS-5997 badge css

### DIFF
--- a/packages/bootstrap/src/components/_badge.scss
+++ b/packages/bootstrap/src/components/_badge.scss
@@ -24,11 +24,11 @@
 
   &.badge-profile {
     &-student {
-      color: var(--primitive-orange-400);
+      color: var(--primitive-orange-700);
     }
 
     &-teacher {
-      color: var(--primitive-green-500);
+      color: var(--primitive-green-700);
     }
 
     &-relative {
@@ -36,11 +36,11 @@
     }
 
     &-personnel {
-      color: var(--primitive-pink-900);
+      color: var(--primitive-pink-700);
     }
 
     &-guest {
-      color: var(--primitive-pink-700);
+      color: var(--primitive-yellow-700);
     }
   }
 
@@ -50,7 +50,7 @@
 
   &.badge-link {
     a {
-      color: var(--primitive-info-500);
+      color: var(--primitive-info-700);
       font-size: 1.6rem;
       font-weight: 400;
       text-decoration: underline;

--- a/packages/bootstrap/src/components/_badge.scss
+++ b/packages/bootstrap/src/components/_badge.scss
@@ -1,14 +1,21 @@
-@use '../abstracts/' as *;
-@use '../vendors/bootstrap';
-
 .badge {
-  --badge-border-color: #{$gray-400};
-  --badge-font-size: 1.4rem;
   --badge-padding-x: 1.2rem;
-  --badge-padding-y: 0.4rem;
-  --badge-color: inherit;
 
-  border: 1px solid var(--badge-border-color);
+  display: inline-block;
+  padding: 0.4rem var(--badge-padding-x);
+  font-size: var(--primitive-font-size-small);
+  font-weight: var(--primitive-font-weight-bold);
+  line-height: 1;
+  color: inherit;
+  text-align: center;
+  white-space: nowrap;
+  vertical-align: baseline;
+  border: 1px solid var(--primitive-grey-300);
+  border-radius: var(--primitive-border-radius-md);
+
+  &:empty {
+    display: none;
+  }
 
   &:not(.badge-notification) {
     height: 3rem;
@@ -17,23 +24,23 @@
 
   &.badge-profile {
     &-student {
-      color: var(--badge-orange);
+      color: var(--primitive-orange-400);
     }
 
     &-teacher {
-      color: var(--badge-green);
+      color: var(--primitive-green-500);
     }
 
     &-relative {
-      color: var(--badge-blue);
+      color: var(--primitive-blue-500);
     }
 
     &-personnel {
-      color: var(--badge-purple);
+      color: var(--primitive-pink-900);
     }
 
     &-guest {
-      color: var(--badge-pink);
+      color: var(--primitive-pink-700);
     }
   }
 
@@ -43,7 +50,7 @@
 
   &.badge-link {
     a {
-      color: var(--badge-info);
+      color: var(--primitive-info-500);
       font-size: 1.6rem;
       font-weight: 400;
       text-decoration: underline;


### PR DESCRIPTION
# Description

Migrate the `.badge` component in `@edifice.io/bootstrap` from legacy semantic variables (`--badge-*`, `$gray-400`, Bootstrap `@use`) to primitive design tokens (`--primitive-*`). The component is now self-contained: its base styles (display, padding, font, border-radius) are inlined instead of being inherited from the Bootstrap vendor import, which was a source of inconsistency.

Also adds the missing `:empty { display: none; }` guard.

Ticket : [IMPULS-5997](https://edifice-community.atlassian.net/browse/IMPULS-5997)

## Which Package changed?

- [ ] Components
- [x] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

[IMPULS-5997]: https://edifice-community.atlassian.net/browse/IMPULS-5997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ