### PR TITLE
fix(react):#IMPULS-5997-color-profil

### DIFF
--- a/packages/bootstrap/src/components/_badge.scss
+++ b/packages/bootstrap/src/components/_badge.scss
@@ -24,23 +24,23 @@
 
   &.badge-profile {
     &-student {
-      color: var(--primitive-orange-700);
+      color: var(--color-profil-student);
     }
 
     &-teacher {
-      color: var(--primitive-green-700);
+      color: var(--color-profil-teacher);
     }
 
     &-relative {
-      color: var(--primitive-blue-500);
+      color: var(--color-profil-relative);
     }
 
     &-personnel {
-      color: var(--primitive-pink-700);
+      color: var(--color-profil-personnel);
     }
 
     &-guest {
-      color: var(--primitive-yellow-700);
+      color: var(--color-profil-guest);
     }
   }
 

--- a/packages/bootstrap/src/themes/configs/_crna.scss
+++ b/packages/bootstrap/src/themes/configs/_crna.scss
@@ -63,7 +63,14 @@ $crna: (
       pale: $clients-crna-200,
       light: $clients-crna-300,
       default: $clients-crna-500,
-      dark: $clients-crna-700
+      dark: $clients-crna-700,
+    ),
+    profil: (
+      guest: $yellow-700,
+      personnel: $pink-700,
+      relative: $blue-700,
+      student: $orange-700,
+      teacher: $green-700,
     ),
     support: (
       danger: (

--- a/packages/bootstrap/src/themes/configs/_edifice1d.scss
+++ b/packages/bootstrap/src/themes/configs/_edifice1d.scss
@@ -65,6 +65,13 @@ $edifice1d: (
       default: $orange-500,
       dark: $orange-700,
     ),
+    profil: (
+      guest: $yellow-700,
+      personnel: $pink-700,
+      relative: $blue-700,
+      student: $orange-700,
+      teacher: $green-700,
+    ),
     support: (
       danger: (
         700: $danger-700,

--- a/packages/bootstrap/src/themes/configs/_edifice2d.scss
+++ b/packages/bootstrap/src/themes/configs/_edifice2d.scss
@@ -65,6 +65,13 @@ $edifice2d: (
       default: $yellow-400,
       dark: $yellow-500,
     ),
+    profil: (
+      guest: $yellow-700,
+      personnel: $pink-700,
+      relative: $blue-700,
+      student: $orange-700,
+      teacher: $green-700,
+    ),
     support: (
       danger: (
         700: $danger-700,

--- a/packages/bootstrap/src/themes/configs/_neo.scss
+++ b/packages/bootstrap/src/themes/configs/_neo.scss
@@ -66,6 +66,13 @@ $neo: (
       default: $neo-orange-500,
       dark: $neo-orange-700,
     ),
+    profil: (
+      guest: $neo-pink-500,
+      personnel: $neo-purple-500,
+      relative: $neo-blue-500,
+      student: $neo-orange-500,
+      teacher: $neo-green-500,
+    ),
     support: (
       danger: (
         700: $danger-700,

--- a/packages/bootstrap/src/themes/configs/_one.scss
+++ b/packages/bootstrap/src/themes/configs/_one.scss
@@ -66,6 +66,13 @@ $one: (
       default: $neo-blue-500,
       dark: $neo-blue-700,
     ),
+    profil: (
+      guest: $one-red-500,
+      personnel: $one-purple-500,
+      relative: $one-blue-500,
+      student: $one-orange-500,
+      teacher: $one-green-500,
+    ),
     support: (
       danger: (
         700: $danger-700,


### PR DESCRIPTION
# Description

Correction du ticket #IMPULS-5997 : les badges de profil utilisateur (student, teacher, relative, personnel, guest) référençaient directement des tokens primitifs (`--primitive-*`) au lieu de tokens sémantiques liés au thème. Ce fix introduit une carte de couleurs `profil` dans chaque config de thème et met à jour le composant badge pour en consommer les variables CSS.

Ticket : [IMPULS-5997](https://edifice-community.atlassian.net/browse/IMPULS-5997)

---

## Which Package changed?

- [x] Components (`@edifice.io/bootstrap` — `_badge.scss`, configs thèmes)
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [x] Storybook (stories Header + NotificationItem mises à jour)

## Type of change

- [x] Bug fix (PATCH)

---

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

---
Résumé des changements

┌───────────────────────────────────────────┬──────────────────────────────────────────────────────────────────────────────────────────────┐
│                  Fichier                  │                                        Ce qui change                                         │
├───────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ _badge.scss                               │ --primitive-* → --color-profil-* pour les 5 rôles                                            │
├───────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ _crna/edifice1d/edifice2d/neo/one.scss    │ Ajout du bloc profil: (guest/personnel/relative/student/teacher) dans chaque config de thème │
├───────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ Notification → NotificationItem           │ Renommage des composants React pour clarté (inclus dans le commit react IMPULS-5997)         │
├───────────────────────────────────────────┼──────────────────────────────────────────────────────────────────────────────────────────────┤
│ Header stories + NotificationItem stories │ Storybook mis à jour                                                                         │
└───────────────────────────────────────────┴──────────────────────────────────────────────────────────────────────────────────────────────┘

[IMPULS-5997]: https://edifice-community.atlassian.net/browse/IMPULS-5997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ