### PR TITLE
fix: #PEDAGO-4164, fix delete attachment in editor

### DIFF
--- a/packages/extensions/src/attachment/attachment.ts
+++ b/packages/extensions/src/attachment/attachment.ts
@@ -126,6 +126,8 @@ export const Attachment = Node.create<AttachmentOptions>({
               return true;
             }
 
+            const mappedPos = transaction.mapping.map(pos);
+
             const links = node.attrs.links ?? [];
             const newLinks = links.filter((link) => {
               const linkDocumentId =
@@ -143,12 +145,13 @@ export const Attachment = Node.create<AttachmentOptions>({
             hasChanged = true;
 
             if (newLinks.length > 0) {
-              transaction = transaction.setNodeMarkup(pos, undefined, {
+              transaction = transaction.setNodeMarkup(mappedPos, undefined, {
                 ...node.attrs,
                 links: newLinks,
               });
             } else {
-              transaction = transaction.delete(pos, pos + node.nodeSize);
+              const mappedEnd = transaction.mapping.map(pos + node.nodeSize);
+              transaction = transaction.delete(mappedPos, mappedEnd);
             }
 
             return false;

--- a/packages/extensions/src/attachment/attachment.ts
+++ b/packages/extensions/src/attachment/attachment.ts
@@ -118,22 +118,47 @@ export const Attachment = Node.create<AttachmentOptions>({
       unsetAttachment:
         (documentId: string) =>
         ({ state, dispatch }) => {
-          const { selection } = state;
-          const { from, to } = selection;
-          state.doc.nodesBetween(from, to, (node, pos) => {
-            if (node.type.name === this.name && node.attrs.links.length > 1) {
-              const newLinks = node.attrs.links.filter(
-                (link) => link.documentId !== documentId,
-              );
-              if (newLinks.length !== node.attrs.links.length) {
-                const newAttrs = { ...node.attrs, links: newLinks };
-                dispatch(state.tr.setNodeMarkup(pos, undefined, newAttrs));
-              }
-            } else {
-              dispatch(state.tr.delete(from, to));
+          let transaction = state.tr;
+          let hasChanged = false;
+
+          state.doc.descendants((node, pos) => {
+            if (node.type.name !== this.name) {
+              return true;
             }
+
+            const links = node.attrs.links ?? [];
+            const newLinks = links.filter((link) => {
+              const linkDocumentId =
+                link.dataDocumentId ??
+                link.documentId ??
+                link['data-document-id'] ??
+                link.href;
+              return String(linkDocumentId ?? '') !== String(documentId ?? '');
+            });
+
+            if (newLinks.length === links.length) {
+              return true;
+            }
+
+            hasChanged = true;
+
+            if (newLinks.length > 0) {
+              transaction = transaction.setNodeMarkup(pos, undefined, {
+                ...node.attrs,
+                links: newLinks,
+              });
+            } else {
+              transaction = transaction.delete(pos, pos + node.nodeSize);
+            }
+
+            return false;
           });
-          return true;
+
+          if (hasChanged && dispatch) {
+            dispatch(transaction);
+          }
+
+          return hasChanged;
         },
     };
   },

--- a/packages/react/src/modules/editor/components/Renderer/AttachmentRenderer.tsx
+++ b/packages/react/src/modules/editor/components/Renderer/AttachmentRenderer.tsx
@@ -15,8 +15,9 @@ interface AttachmentProps {
 interface AttachmentAttrsProps {
   'name': string;
   'href': string;
-  'dataDocumentId': string;
-  'dataContentType': string;
+  'dataDocumentId'?: string;
+  'dataContentType'?: string;
+  'documentId'?: string;
   'data-document-id'?: string;
 }
 
@@ -37,7 +38,7 @@ const AttachmentRenderer = (props: AttachmentProps) => {
 
   const handleDelete = (index: number, documentId: string) => {
     const nextAttachments = (node.attrs.links ?? []).filter(
-      (link: AttachmentAttrsProps & Record<string, any>, i: number) => {
+      (link: AttachmentAttrsProps, i: number) => {
         const linkDocumentId =
           link.dataDocumentId ??
           link.documentId ??

--- a/packages/react/src/modules/editor/components/Renderer/AttachmentRenderer.tsx
+++ b/packages/react/src/modules/editor/components/Renderer/AttachmentRenderer.tsx
@@ -13,14 +13,15 @@ interface AttachmentProps {
 }
 
 interface AttachmentAttrsProps {
-  name: string;
-  href: string;
-  dataDocumentId: string;
-  dataContentType: string;
+  'name': string;
+  'href': string;
+  'dataDocumentId': string;
+  'dataContentType': string;
+  'data-document-id'?: string;
 }
 
 const AttachmentRenderer = (props: AttachmentProps) => {
-  const { node, editor } = props;
+  const { node, editor, updateAttributes, deleteNode } = props;
   const [attachmentArrayAttrs, setAttachmentArrayAttrs] = useState<
     AttachmentAttrsProps[]
   >(node.attrs.links);
@@ -34,11 +35,34 @@ const AttachmentRenderer = (props: AttachmentProps) => {
     }
   }, [node.attrs.links, attachmentArrayAttrs]);
 
-  const handleDelete = (index: any, documentId: any) => {
-    editor.commands.unsetAttachment(documentId);
-    setAttachmentArrayAttrs((oldAttachments) =>
-      oldAttachments.filter((_, i) => i !== index),
+  const handleDelete = (index: number, documentId: string) => {
+    const nextAttachments = (node.attrs.links ?? []).filter(
+      (link: AttachmentAttrsProps & Record<string, any>, i: number) => {
+        const linkDocumentId =
+          link.dataDocumentId ??
+          link.documentId ??
+          link['data-document-id'] ??
+          link.href;
+
+        return !(
+          i === index ||
+          String(linkDocumentId ?? '') === String(documentId ?? '')
+        );
+      },
     );
+
+    if (nextAttachments.length > 0) {
+      updateAttributes?.({ ...node.attrs, links: nextAttachments });
+    } else {
+      deleteNode?.();
+    }
+
+    // Fallback for environments where node-view helpers are not wired.
+    if (!updateAttributes && !deleteNode) {
+      editor.commands.unsetAttachment(documentId);
+    }
+
+    setAttachmentArrayAttrs(nextAttachments);
   };
 
   return (
@@ -82,7 +106,12 @@ const AttachmentRenderer = (props: AttachmentProps) => {
                           icon={<IconDelete />}
                           variant="ghost"
                           onClick={() =>
-                            handleDelete(index, attachment.dataDocumentId)
+                            handleDelete(
+                              index,
+                              attachment.dataDocumentId ??
+                                attachment['data-document-id'] ??
+                                attachment.href,
+                            )
                           }
                         />
                       )}


### PR DESCRIPTION
# Description

Fix sur les pièces jointes car actuellement on ne peut pas supprimer une pièces jointes lorsqu'il y en a plus d'une qui est ajouté dans l'éditeur. 

Ticket : https://edifice-community.atlassian.net/browse/PEDAGO-4164

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
