### PR TITLE
fix(react,bootstrap): #IMPULS-5548, small size of ButtonBeta, with pa…

### DIFF
--- a/packages/bootstrap/src/components/_buttons-beta.scss
+++ b/packages/bootstrap/src/components/_buttons-beta.scss
@@ -103,7 +103,7 @@
   }
 
   &.btn-beta--with-right-icon {
-    padding-right: prim.$spacer-12;
+    padding-inline-end: prim.$spacer-12;
   }
 
   &.btn-beta--icon-only {

--- a/packages/bootstrap/src/components/_buttons-beta.scss
+++ b/packages/bootstrap/src/components/_buttons-beta.scss
@@ -119,7 +119,7 @@
     }
 
     &.btn-beta--with-right-icon {
-      padding-right: prim.$spacer-8;
+      padding-inline-end: prim.$spacer-8;
     }
 
     &.btn-beta--icon-only {

--- a/packages/bootstrap/src/components/_buttons-beta.scss
+++ b/packages/bootstrap/src/components/_buttons-beta.scss
@@ -99,7 +99,7 @@
   }
 
   &.btn-beta--with-left-icon {
-    padding-left: prim.$spacer-12;
+    padding-inline-start: prim.$spacer-12;
   }
 
   &.btn-beta--with-right-icon {

--- a/packages/bootstrap/src/components/_buttons-beta.scss
+++ b/packages/bootstrap/src/components/_buttons-beta.scss
@@ -115,7 +115,7 @@
     padding: prim.$spacer-4 prim.$spacer-16;
 
     &.btn-beta--with-left-icon {
-      padding-left: prim.$spacer-8;
+      padding-inline-start: prim.$spacer-8;
     }
 
     &.btn-beta--with-right-icon {

--- a/packages/bootstrap/src/components/_buttons-beta.scss
+++ b/packages/bootstrap/src/components/_buttons-beta.scss
@@ -98,12 +98,33 @@
     }
   }
 
-  &.btn-beta--with-icon {
-    padding-inline: prim.$spacer-12;
+  &.btn-beta--with-left-icon {
+    padding-left: prim.$spacer-12;
+  }
+
+  &.btn-beta--with-right-icon {
+    padding-right: prim.$spacer-12;
   }
 
   &.btn-beta--icon-only {
     padding-inline: prim.$spacer-8;
+  }
+
+  // Small
+  &.btn-beta--small {
+    padding: prim.$spacer-4 prim.$spacer-16;
+
+    &.btn-beta--with-left-icon {
+      padding-left: prim.$spacer-8;
+    }
+
+    &.btn-beta--with-right-icon {
+      padding-right: prim.$spacer-8;
+    }
+
+    &.btn-beta--icon-only {
+      padding-inline: prim.$spacer-8;
+    }
   }
 }
 

--- a/packages/react/src/components/ButtonBeta/ButtonBeta.tsx
+++ b/packages/react/src/components/ButtonBeta/ButtonBeta.tsx
@@ -30,7 +30,7 @@ export interface ButtonBetaProps extends React.ComponentPropsWithRef<'button'> {
    */
   variant?: ButtonBetaVariant;
   /**
-   * `small` or `medium`
+   * `sm` or `md`
    */
   size?: ButtonBetaSizes;
   /**

--- a/packages/react/src/components/ButtonBeta/ButtonBeta.tsx
+++ b/packages/react/src/components/ButtonBeta/ButtonBeta.tsx
@@ -12,7 +12,7 @@ export type ButtonBetaColor =
   | 'secondary'
   | 'tertiary';
 
-export type ButtonBetaSizes = 'small' | 'medium';
+export type ButtonBetaSizes = 'sm' | 'md';
 
 export type ButtonBetaVariant = 'filled' | 'outline' | 'ghost';
 
@@ -67,7 +67,7 @@ const ButtonBeta = forwardRef(
     {
       color = 'default',
       type = 'button',
-      size = 'medium',
+      size = 'md',
       variant = 'filled',
       children,
       isLoading,
@@ -84,7 +84,7 @@ const ButtonBeta = forwardRef(
       {
         'btn-beta--outline': variant === 'outline',
         'btn-beta--ghost': variant === 'ghost',
-        'btn-beta--small': size === 'small',
+        'btn-beta--small': size === 'sm',
         'btn-beta--icon-only': !children,
         'btn-beta--with-left-icon': Boolean(leftIcon && children),
         'btn-beta--with-right-icon': Boolean(rightIcon && children),

--- a/packages/react/src/components/ButtonBeta/ButtonBeta.tsx
+++ b/packages/react/src/components/ButtonBeta/ButtonBeta.tsx
@@ -12,6 +12,8 @@ export type ButtonBetaColor =
   | 'secondary'
   | 'tertiary';
 
+export type ButtonBetaSizes = 'small' | 'medium';
+
 export type ButtonBetaVariant = 'filled' | 'outline' | 'ghost';
 
 export interface ButtonBetaProps extends React.ComponentPropsWithRef<'button'> {
@@ -27,6 +29,10 @@ export interface ButtonBetaProps extends React.ComponentPropsWithRef<'button'> {
    * `filled`, `outline` or `ghost`
    */
   variant?: ButtonBetaVariant;
+  /**
+   * `small` or `medium`
+   */
+  size?: ButtonBetaSizes;
   /**
    * Does it has a text ?
    */
@@ -61,6 +67,7 @@ const ButtonBeta = forwardRef(
     {
       color = 'default',
       type = 'button',
+      size = 'medium',
       variant = 'filled',
       children,
       isLoading,
@@ -71,16 +78,16 @@ const ButtonBeta = forwardRef(
     }: ButtonBetaProps,
     ref: Ref<ButtonBetaRef>,
   ) => {
-    const hasIcon = Boolean(leftIcon || rightIcon);
-
     const classes = clsx(
       'btn-beta',
       `btn-beta-${color}`,
       {
         'btn-beta--outline': variant === 'outline',
         'btn-beta--ghost': variant === 'ghost',
+        'btn-beta--small': size === 'small',
         'btn-beta--icon-only': !children,
-        'btn-beta--with-icon': hasIcon && Boolean(children),
+        'btn-beta--with-left-icon': Boolean(leftIcon && children),
+        'btn-beta--with-right-icon': Boolean(rightIcon && children),
         'btn-beta--loading': isLoading,
       },
       className,

--- a/packages/react/src/components/ButtonBeta/stories/ButtonBeta.stories.tsx
+++ b/packages/react/src/components/ButtonBeta/stories/ButtonBeta.stories.tsx
@@ -20,9 +20,14 @@ const meta: Meta<typeof ButtonBeta> = {
       options: ['button', 'submit', 'reset'],
       control: { type: 'select' },
     },
+    size: {
+      options: ['small', 'medium'],
+      control: { type: 'select' },
+    },
   },
   args: {
     color: 'default',
+    size: 'medium',
     disabled: false,
   },
   parameters: {
@@ -154,6 +159,16 @@ export const IconOnly: Story = {
           'When no children are provided, the btn-beta--icon-only class is applied for square padding.',
       },
     },
+  },
+};
+
+export const SmallButton: Story = {
+  args: {
+    color: 'default',
+    children: 'Label',
+    type: 'button',
+    disabled: false,
+    size: 'small',
   },
 };
 

--- a/packages/react/src/components/ButtonBeta/stories/ButtonBeta.stories.tsx
+++ b/packages/react/src/components/ButtonBeta/stories/ButtonBeta.stories.tsx
@@ -21,13 +21,13 @@ const meta: Meta<typeof ButtonBeta> = {
       control: { type: 'select' },
     },
     size: {
-      options: ['small', 'medium'],
+      options: ['sm', 'md'],
       control: { type: 'select' },
     },
   },
   args: {
     color: 'default',
-    size: 'medium',
+    size: 'md',
     disabled: false,
   },
   parameters: {
@@ -168,7 +168,7 @@ export const SmallButton: Story = {
     children: 'Label',
     type: 'button',
     disabled: false,
-    size: 'small',
+    size: 'sm',
   },
 };
 


### PR DESCRIPTION
…dding fixes of icons

# Description

Ajout de la propriété `size='sm'` ou `'md'` au  `ButtonBeta`
Application des paddings correspondants
Correction des paddings en cas d'icone à gauche ou droite

Voir ticket https://edifice-community.atlassian.net/browse/IMPULS-5548

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [X] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [X] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
