### PR TITLE
fix(homepage): #IMPULS-5548, UserSpace and HomeCard.Header design

### DIFF
--- a/packages/bootstrap/src/components/homepage/_user-space.scss
+++ b/packages/bootstrap/src/components/homepage/_user-space.scss
@@ -16,5 +16,6 @@
 
   &--avatar {
     max-height: var(--primitive-spacer-48);
+    margin-left: var(--primitive-spacer-8);
   }
 }

--- a/packages/react/src/modules/homepage/components/HomeCard/HomeCardHeader.tsx
+++ b/packages/react/src/modules/homepage/components/HomeCard/HomeCardHeader.tsx
@@ -9,7 +9,7 @@ export interface HomeCardHeaderProps extends Omit<
   'title'
 > {
   /** Title displayed on the left side of the header. */
-  title?: ReactNode;
+  title: ReactNode;
   /** Label of the action button displayed on the right side of the header. */
   actionLabel?: ReactNode;
   /** Callback invoked when the action button is clicked. */
@@ -27,39 +27,33 @@ const HomeCardHeader = ({
   actionLeftIcon,
   actionRightIcon,
   className,
-  children,
   ...rest
 }: HomeCardHeaderProps) => {
   const hasAction = Boolean(actionLabel) && Boolean(onActionClick);
 
   return (
-    <>
-      {(title || hasAction) && (
-        <Flex
-          align="center"
-          justify="between"
-          gap="8"
-          className={clsx('home-card-header', className)}
-          {...rest}
+    <Flex
+      align="center"
+      justify="between"
+      gap="8"
+      className={clsx('home-card-header', className)}
+      {...rest}
+    >
+      <h3 className="home-card-header-title">{title}</h3>
+      {hasAction && (
+        <ButtonBeta
+          color="tertiary"
+          size="sm"
+          variant="ghost"
+          onClick={onActionClick}
+          leftIcon={actionLeftIcon}
+          rightIcon={actionRightIcon}
+          data-testid="home-card-header-action"
         >
-          {title && <h3 className="home-card-header-title">{title}</h3>}
-          {hasAction && (
-            <ButtonBeta
-              color="tertiary"
-              size="sm"
-              variant="ghost"
-              onClick={onActionClick}
-              leftIcon={actionLeftIcon}
-              rightIcon={actionRightIcon}
-              data-testid="home-card-header-action"
-            >
-              {actionLabel}
-            </ButtonBeta>
-          )}
-        </Flex>
+          {actionLabel}
+        </ButtonBeta>
       )}
-      {children}
-    </>
+    </Flex>
   );
 };
 

--- a/packages/react/src/modules/homepage/components/HomeCard/HomeCardHeader.tsx
+++ b/packages/react/src/modules/homepage/components/HomeCard/HomeCardHeader.tsx
@@ -9,7 +9,7 @@ export interface HomeCardHeaderProps extends Omit<
   'title'
 > {
   /** Title displayed on the left side of the header. */
-  title: ReactNode;
+  title?: ReactNode;
   /** Label of the action button displayed on the right side of the header. */
   actionLabel?: ReactNode;
   /** Callback invoked when the action button is clicked. */
@@ -27,32 +27,39 @@ const HomeCardHeader = ({
   actionLeftIcon,
   actionRightIcon,
   className,
+  children,
   ...rest
 }: HomeCardHeaderProps) => {
   const hasAction = Boolean(actionLabel) && Boolean(onActionClick);
 
   return (
-    <Flex
-      align="center"
-      justify="between"
-      gap="8"
-      className={clsx('home-card-header', className)}
-      {...rest}
-    >
-      <h3 className="home-card-header-title">{title}</h3>
-      {hasAction && (
-        <ButtonBeta
-          color="default"
-          variant="ghost"
-          onClick={onActionClick}
-          leftIcon={actionLeftIcon}
-          rightIcon={actionRightIcon}
-          data-testid="home-card-header-action"
+    <>
+      {(title || hasAction) && (
+        <Flex
+          align="center"
+          justify="between"
+          gap="8"
+          className={clsx('home-card-header', className)}
+          {...rest}
         >
-          {actionLabel}
-        </ButtonBeta>
+          {title && <h3 className="home-card-header-title">{title}</h3>}
+          {hasAction && (
+            <ButtonBeta
+              color="tertiary"
+              size="sm"
+              variant="ghost"
+              onClick={onActionClick}
+              leftIcon={actionLeftIcon}
+              rightIcon={actionRightIcon}
+              data-testid="home-card-header-action"
+            >
+              {actionLabel}
+            </ButtonBeta>
+          )}
+        </Flex>
       )}
-    </Flex>
+      {children}
+    </>
   );
 };
 

--- a/packages/react/src/modules/homepage/components/UserSpace/UserSpace.tsx
+++ b/packages/react/src/modules/homepage/components/UserSpace/UserSpace.tsx
@@ -21,28 +21,26 @@ export default function UserSpace({
 
   return (
     <HomeCard variant="user">
-      <HomeCard.Header>
-        <Flex className={'user-space'} direction="row" gap="8">
-          <Avatar
-            className={'user-space--avatar'}
-            size={'auto'}
-            alt={name}
-            src={avatar}
-            variant="circle"
-          />
-          <Flex direction="column">
-            <div data-testid="user-space-name" className={'user-space--name'}>
-              {name}
-            </div>
-            <div
-              data-testid="user-space-profile"
-              className={'user-space--profile'}
-            >
-              {t(profile)}
-            </div>
-          </Flex>
+      <Flex className={'user-space'} direction="row" gap="8">
+        <Avatar
+          className={'user-space--avatar'}
+          size={'auto'}
+          alt={name}
+          src={avatar}
+          variant="circle"
+        />
+        <Flex direction="column">
+          <div data-testid="user-space-name" className={'user-space--name'}>
+            {name}
+          </div>
+          <div
+            data-testid="user-space-profile"
+            className={'user-space--profile'}
+          >
+            {t(profile)}
+          </div>
         </Flex>
-      </HomeCard.Header>
+      </Flex>
       {children && <HomeCard.Content>{children}</HomeCard.Content>}
     </HomeCard>
   );

--- a/packages/react/src/modules/homepage/components/UserSpace/UserSpace.tsx
+++ b/packages/react/src/modules/homepage/components/UserSpace/UserSpace.tsx
@@ -21,30 +21,28 @@ export default function UserSpace({
 
   return (
     <HomeCard variant="user">
-      <HomeCard.Header
-        title={
-          <Flex className={'user-space'} direction="row" gap="8">
-            <Avatar
-              className={'user-space--avatar'}
-              size={'auto'}
-              alt={name}
-              src={avatar}
-              variant="circle"
-            />
-            <Flex direction="column">
-              <div data-testid="user-space-name" className={'user-space--name'}>
-                {name}
-              </div>
-              <div
-                data-testid="user-space-profile"
-                className={'user-space--profile'}
-              >
-                {t(profile)}
-              </div>
-            </Flex>
+      <HomeCard.Header>
+        <Flex className={'user-space'} direction="row" gap="8">
+          <Avatar
+            className={'user-space--avatar'}
+            size={'auto'}
+            alt={name}
+            src={avatar}
+            variant="circle"
+          />
+          <Flex direction="column">
+            <div data-testid="user-space-name" className={'user-space--name'}>
+              {name}
+            </div>
+            <div
+              data-testid="user-space-profile"
+              className={'user-space--profile'}
+            >
+              {t(profile)}
+            </div>
           </Flex>
-        }
-      ></HomeCard.Header>
+        </Flex>
+      </HomeCard.Header>
       {children && <HomeCard.Content>{children}</HomeCard.Content>}
     </HomeCard>
   );


### PR DESCRIPTION
# Description

This PR updates the homepage “UserSpace” header composition and adjusts HomeCard.Header so it can be used without a title prop, aligning the header layout with the requested design changes ([#IMPULS-5548](https://edifice-community.atlassian.net/browse/IMPULS-5548)).

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [X] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
