### PR TITLE
test: #ENABLING-987 add unit tests to @edifice.io/react (lot 4)

### DIFF
--- a/packages/react/src/hooks/useConf/useConf.spec.tsx
+++ b/packages/react/src/hooks/useConf/useConf.spec.tsx
@@ -1,0 +1,65 @@
+import type { App } from '@edifice.io/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '~/setup';
+import useConf from './useConf';
+
+const { getConf } = vi.hoisted(() => ({
+  getConf: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    conf: () => ({
+      getConf,
+    }),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useConf', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the configuration once the query resolves', async () => {
+    const conf = { app: 'blog', applications: [] };
+    getConf.mockResolvedValue(conf);
+
+    const { result } = renderHook(() => useConf({ appCode: 'blog' as App }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(conf);
+  });
+
+  it('requests the configuration for the given appCode', async () => {
+    getConf.mockResolvedValue({ app: 'blog' });
+
+    const { result } = renderHook(() => useConf({ appCode: 'blog' as App }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getConf).toHaveBeenCalledWith('blog');
+  });
+
+  it('exposes the error state when the query fails', async () => {
+    getConf.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useConf({ appCode: 'blog' as App }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/packages/react/src/hooks/useIsAdmc/useIsAdmc.spec.tsx
+++ b/packages/react/src/hooks/useIsAdmc/useIsAdmc.spec.tsx
@@ -1,0 +1,72 @@
+import { renderHook, waitFor } from '~/setup';
+import useIsAdmc from './useIsAdmc';
+
+const { getUser } = vi.hoisted(() => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    session: () => ({
+      getUser,
+    }),
+  },
+}));
+
+describe('useIsAdmc', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is false until the user has been resolved', async () => {
+    getUser.mockResolvedValue({
+      functions: { SUPER_ADMIN: { code: 'SUPER_ADMIN', scope: [] } },
+    });
+
+    const { result } = renderHook(() => useIsAdmc());
+
+    expect(result.current.isAdmc).toBe(false);
+
+    await waitFor(() => expect(result.current.isAdmc).toBe(true));
+  });
+
+  it('is true when the user has the SUPER_ADMIN function', async () => {
+    getUser.mockResolvedValue({
+      functions: { SUPER_ADMIN: { code: 'SUPER_ADMIN', scope: [] } },
+    });
+
+    const { result } = renderHook(() => useIsAdmc());
+
+    await waitFor(() => expect(result.current.isAdmc).toBe(true));
+  });
+
+  it('is false when the user has no SUPER_ADMIN function', async () => {
+    getUser.mockResolvedValue({
+      functions: { ADMIN_LOCAL: { code: 'ADMIN_LOCAL', scope: [] } },
+    });
+
+    const { result } = renderHook(() => useIsAdmc());
+
+    // Give the pending promise a chance to settle, then assert it stays false.
+    await waitFor(() => expect(getUser).toHaveBeenCalled());
+    expect(result.current.isAdmc).toBe(false);
+  });
+
+  it('is false when there is no session (user is undefined)', async () => {
+    getUser.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useIsAdmc());
+
+    await waitFor(() => expect(getUser).toHaveBeenCalled());
+    expect(result.current.isAdmc).toBe(false);
+  });
+
+  it('is false when getUser rejects', async () => {
+    getUser.mockRejectedValue(new Error('NOT_LOGGED_IN'));
+
+    const { result } = renderHook(() => useIsAdmc());
+
+    await waitFor(() => expect(getUser).toHaveBeenCalled());
+    expect(result.current.isAdmc).toBe(false);
+  });
+});

--- a/packages/react/src/hooks/useIsAdml/useIsAdml.spec.tsx
+++ b/packages/react/src/hooks/useIsAdml/useIsAdml.spec.tsx
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from '~/setup';
+import useIsAdml from './useIsAdml';
+
+const { isAdml } = vi.hoisted(() => ({
+  isAdml: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    session: () => ({
+      isAdml,
+    }),
+  },
+}));
+
+describe('useIsAdml', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is false until the session service has resolved', async () => {
+    isAdml.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useIsAdml());
+
+    expect(result.current.isAdml).toBe(false);
+
+    await waitFor(() => expect(result.current.isAdml).toBe(true));
+  });
+
+  it('is true when the user is an admin local', async () => {
+    isAdml.mockResolvedValue(true);
+
+    const { result } = renderHook(() => useIsAdml());
+
+    await waitFor(() => expect(result.current.isAdml).toBe(true));
+    expect(isAdml).toHaveBeenCalled();
+  });
+
+  it('is false when the user is not an admin local', async () => {
+    isAdml.mockResolvedValue(false);
+
+    const { result } = renderHook(() => useIsAdml());
+
+    await waitFor(() => expect(isAdml).toHaveBeenCalled());
+    expect(result.current.isAdml).toBe(false);
+  });
+});

--- a/packages/react/src/hooks/useIsAdmlcOrAdmc/useIsAdmlcOrAdmc.spec.tsx
+++ b/packages/react/src/hooks/useIsAdmlcOrAdmc/useIsAdmlcOrAdmc.spec.tsx
@@ -1,0 +1,57 @@
+import { renderHook } from '~/setup';
+import useIsAdmlcOrAdmc from './useIsAdmlcOrAdmc';
+
+const { useIsAdml, useIsAdmc } = vi.hoisted(() => ({
+  useIsAdml: vi.fn(),
+  useIsAdmc: vi.fn(),
+}));
+
+vi.mock('../useIsAdml', () => ({
+  useIsAdml,
+}));
+
+vi.mock('../useIsAdmc', () => ({
+  useIsAdmc,
+}));
+
+describe('useIsAdmlcOrAdmc', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is true when the user is only an admin local (ADML)', () => {
+    useIsAdml.mockReturnValue({ isAdml: true });
+    useIsAdmc.mockReturnValue({ isAdmc: false });
+
+    const { result } = renderHook(() => useIsAdmlcOrAdmc());
+
+    expect(result.current.isAdmlcOrAdmc).toBe(true);
+  });
+
+  it('is true when the user is only a super admin (ADMC)', () => {
+    useIsAdml.mockReturnValue({ isAdml: false });
+    useIsAdmc.mockReturnValue({ isAdmc: true });
+
+    const { result } = renderHook(() => useIsAdmlcOrAdmc());
+
+    expect(result.current.isAdmlcOrAdmc).toBe(true);
+  });
+
+  it('is true when the user is both ADML and ADMC', () => {
+    useIsAdml.mockReturnValue({ isAdml: true });
+    useIsAdmc.mockReturnValue({ isAdmc: true });
+
+    const { result } = renderHook(() => useIsAdmlcOrAdmc());
+
+    expect(result.current.isAdmlcOrAdmc).toBe(true);
+  });
+
+  it('is false when the user is neither ADML nor ADMC', () => {
+    useIsAdml.mockReturnValue({ isAdml: false });
+    useIsAdmc.mockReturnValue({ isAdmc: false });
+
+    const { result } = renderHook(() => useIsAdmlcOrAdmc());
+
+    expect(result.current.isAdmlcOrAdmc).toBe(false);
+  });
+});

--- a/packages/react/src/hooks/usePreferences/usePreferences.spec.tsx
+++ b/packages/react/src/hooks/usePreferences/usePreferences.spec.tsx
@@ -1,0 +1,62 @@
+import { renderHook } from '~/setup';
+import usePreferences from './usePreferences';
+
+const { getPreference, savePreference } = vi.hoisted(() => ({
+  getPreference: vi.fn(),
+  savePreference: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    conf: () => ({
+      getPreference,
+      savePreference,
+    }),
+  },
+}));
+
+describe('usePreferences', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reads a preference by name', async () => {
+    const preference = { theme: 'dark' };
+    getPreference.mockResolvedValue(preference);
+
+    const { result } = renderHook(() => usePreferences('my-pref'));
+
+    await expect(result.current.getPreference()).resolves.toEqual(preference);
+    expect(getPreference).toHaveBeenCalledWith('my-pref');
+  });
+
+  it('serializes the value as JSON when saving a preference', async () => {
+    savePreference.mockResolvedValue(undefined);
+    const value = { theme: 'dark', collapsed: true };
+
+    const { result } = renderHook(() => usePreferences('my-pref'));
+
+    await result.current.savePreference(value);
+
+    expect(savePreference).toHaveBeenCalledWith(
+      'my-pref',
+      JSON.stringify(value),
+    );
+  });
+
+  it('keeps the preference name bound across get and save', async () => {
+    getPreference.mockResolvedValue('value');
+    savePreference.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => usePreferences('language'));
+
+    await result.current.getPreference();
+    await result.current.savePreference('fr');
+
+    expect(getPreference).toHaveBeenCalledWith('language');
+    expect(savePreference).toHaveBeenCalledWith(
+      'language',
+      JSON.stringify('fr'),
+    );
+  });
+});

--- a/packages/react/src/hooks/usePublicConf/usePublicConf.spec.tsx
+++ b/packages/react/src/hooks/usePublicConf/usePublicConf.spec.tsx
@@ -1,0 +1,72 @@
+import type { App } from '@edifice.io/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '~/setup';
+import usePublicConf from './usePublicConf';
+
+const { getPublicConf } = vi.hoisted(() => ({
+  getPublicConf: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    conf: () => ({
+      getPublicConf,
+    }),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+interface PublicConf {
+  featureFlag: boolean;
+}
+
+describe('usePublicConf', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the public configuration once the query resolves', async () => {
+    const publicConf: PublicConf = { featureFlag: true };
+    getPublicConf.mockResolvedValue(publicConf);
+
+    const { result } = renderHook(
+      () => usePublicConf<PublicConf>('blog' as App),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(publicConf);
+  });
+
+  it('requests the public configuration for the given appCode', async () => {
+    getPublicConf.mockResolvedValue({ featureFlag: false });
+
+    const { result } = renderHook(
+      () => usePublicConf<PublicConf>('blog' as App),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getPublicConf).toHaveBeenCalledWith('blog');
+  });
+
+  it('exposes the error state when the query fails', async () => {
+    getPublicConf.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(
+      () => usePublicConf<PublicConf>('blog' as App),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/packages/react/src/hooks/useSession/useSession.spec.tsx
+++ b/packages/react/src/hooks/useSession/useSession.spec.tsx
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { renderHook, waitFor } from '~/setup';
+import useSession from './useSession';
+
+const { getSession } = vi.hoisted(() => ({
+  getSession: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    session: () => ({
+      getSession,
+    }),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useSession', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is loading before the session resolves', () => {
+    getSession.mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useSession(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('exposes the session once the query resolves', async () => {
+    const session = { user: { userId: 'user-id' }, currentLanguage: 'fr' };
+    getSession.mockResolvedValue(session);
+
+    const { result } = renderHook(() => useSession(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(session);
+    expect(getSession).toHaveBeenCalled();
+  });
+
+  it('exposes the error state when the query fails', async () => {
+    getSession.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useSession(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/packages/react/src/hooks/useUser/useUser.spec.tsx
+++ b/packages/react/src/hooks/useUser/useUser.spec.tsx
@@ -1,0 +1,106 @@
+import type {
+  IOdeTheme,
+  IUserDescription,
+  IUserInfo,
+} from '@edifice.io/client';
+import type { ReactNode } from 'react';
+import { renderHook, wrapper } from '~/setup';
+import { EdificeClientContext } from '../../providers/EdificeClientProvider/EdificeClientProvider.context';
+import { EdificeThemeContext } from '../../providers/EdificeThemeProvider/EdificeThemeProvider.context';
+import {
+  mockSession,
+  mockUser,
+} from '../../providers/MockedProvider/MockedProvider.mocks';
+import useUser from './useUser';
+
+/**
+ * Builds a wrapper providing the client and theme contexts consumed by
+ * useUser, so each test can drive the avatar-resolution branches.
+ */
+function createWrapper({
+  user,
+  userDescription,
+  basePath,
+}: {
+  user?: IUserInfo;
+  userDescription?: Partial<IUserDescription>;
+  basePath?: string;
+}) {
+  return ({ children }: { children: ReactNode }) => (
+    <EdificeClientContext.Provider value={{ user, userDescription } as any}>
+      <EdificeThemeContext.Provider
+        value={{ theme: { basePath } as IOdeTheme }}
+      >
+        {children}
+      </EdificeThemeContext.Provider>
+    </EdificeClientContext.Provider>
+  );
+}
+
+describe('useUser', () => {
+  it('returns the user and its description from the client context', () => {
+    const { result } = renderHook(() => useUser(), { wrapper });
+
+    expect(result.current.user).toEqual(mockUser);
+    expect(result.current.userDescription).toEqual(mockSession.userDescription);
+  });
+
+  it('uses the user picture as the avatar when one is set', () => {
+    const { result } = renderHook(() => useUser(), {
+      wrapper: createWrapper({
+        user: mockUser,
+        userDescription: { picture: '/userbook/avatar/some-id' },
+        basePath: '/basepath',
+      }),
+    });
+
+    expect(result.current.avatar).toBe('/userbook/avatar/some-id');
+  });
+
+  it('falls back to the default avatar when no picture is set', () => {
+    const { result } = renderHook(() => useUser(), {
+      wrapper: createWrapper({
+        user: mockUser,
+        userDescription: {},
+        basePath: '/basepath',
+      }),
+    });
+
+    expect(result.current.avatar).toBe(
+      '/basepath/img/illustrations/no-avatar.svg',
+    );
+  });
+
+  it.each(['no-avatar.jpg', 'no-avatar.svg'])(
+    'falls back to the default avatar when the picture is the placeholder "%s"',
+    (placeholder) => {
+      const { result } = renderHook(() => useUser(), {
+        wrapper: createWrapper({
+          user: mockUser,
+          userDescription: { picture: placeholder },
+          basePath: '/basepath',
+        }),
+      });
+
+      expect(result.current.avatar).toBe(
+        '/basepath/img/illustrations/no-avatar.svg',
+      );
+    },
+  );
+
+  it('returns an undefined user when the context has none', () => {
+    const { result } = renderHook(() => useUser(), {
+      wrapper: createWrapper({
+        user: undefined,
+        userDescription: undefined,
+        basePath: '/basepath',
+      }),
+    });
+
+    expect(result.current.user).toBeUndefined();
+    expect(result.current.userDescription).toBeUndefined();
+    expect(result.current.avatar).toBe(
+      '/basepath/img/illustrations/no-avatar.svg',
+    );
+  });
+});

--- a/packages/react/src/utilities/create-selectors/createSelectors.spec.tsx
+++ b/packages/react/src/utilities/create-selectors/createSelectors.spec.tsx
@@ -1,0 +1,60 @@
+import { act, renderHook } from '~/setup';
+import { create } from 'zustand';
+import { createSelectors } from './createSelectors';
+
+interface CounterState {
+  count: number;
+  name: string;
+  increment: () => void;
+}
+
+function createCounterStore() {
+  return create<CounterState>((set) => ({
+    count: 0,
+    name: 'counter',
+    increment: () => set((state) => ({ count: state.count + 1 })),
+  }));
+}
+
+describe('createSelectors', () => {
+  it('returns the same store instance, augmented with a `use` map', () => {
+    const store = createCounterStore();
+
+    const withSelectors = createSelectors(store);
+
+    expect(withSelectors).toBe(store);
+    expect(withSelectors.use).toBeTypeOf('object');
+  });
+
+  it('creates one selector hook per state key', () => {
+    const store = createSelectors(createCounterStore());
+
+    expect(Object.keys(store.use)).toEqual(['count', 'name', 'increment']);
+    expect(store.use.count).toBeTypeOf('function');
+    expect(store.use.name).toBeTypeOf('function');
+    expect(store.use.increment).toBeTypeOf('function');
+  });
+
+  it('each selector returns the current value of its key', () => {
+    const store = createSelectors(createCounterStore());
+
+    const { result: count } = renderHook(() => store.use.count());
+    const { result: name } = renderHook(() => store.use.name());
+
+    expect(count.current).toBe(0);
+    expect(name.current).toBe('counter');
+  });
+
+  it('re-renders selectors when the underlying state changes', () => {
+    const store = createSelectors(createCounterStore());
+
+    const { result } = renderHook(() => store.use.count());
+    expect(result.current).toBe(0);
+
+    act(() => {
+      store.getState().increment();
+    });
+
+    expect(result.current).toBe(1);
+  });
+});


### PR DESCRIPTION
## Contexte

[ENABLING-987](https://edifice-community.atlassian.net/browse/ENABLING-987) — Lot 4 de l'amorçage de couverture de tests du package `@edifice.io/react` (suite de ENABLING-931/932/935). Complémentaire aux lots précédents : aucune cible ne recouvre celles des lots 1 à 3.

Ce lot cible les **hooks de droits, de session et de configuration** (fort ROI, logique pure, criticité métier) + le dernier utilitaire non couvert.

## Changements

9 fichiers de specs, **34 tests** — aucune modification de code de prod.

| Catégorie | Cibles | Tests |
|---|---|---|
| Droits & rôles | `useIsAdmc`, `useIsAdml`, `useIsAdmlcOrAdmc`, `useUser` | 18 |
| Session & config | `useSession`, `useConf`, `usePublicConf`, `usePreferences` | 12 |
| Utilitaire pur | `utilities/create-selectors` | 4 |

## Choix techniques

- Hooks impératifs (`useIsAdmc`/`useIsAdml`/`usePreferences`) : mock de `@edifice.io/client` (`odeServices`) via `vi.hoisted`, pattern calé sur `useHasWorkflow.spec.tsx`.
- `useIsAdmlcOrAdmc` : mock des hooks internes → test unitaire pur de la composition OR.
- `useUser` : wrapper custom sur `EdificeClientContext` + `EdificeThemeContext` pour couvrir les branches d'avatar (picture / placeholders / fallback).
- Hooks TanStack (`useSession`/`useConf`/`usePublicConf`) : `QueryClient` frais par test (`retry: false`) pour l'isolation.

## Recette / Risque

Risque faible — ajout de tests uniquement, pas de changement d'API publique. Tests déterministes : pas de timers réels, pas de dépendance réseau non mockée. Suite complète du package verte (33 fichiers / 176 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENABLING-987]: https://edifice-community.atlassian.net/browse/ENABLING-987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ