### PR TITLE
test: #ENABLING-989 add unit tests to @edifice.io/react (lot 6)

### DIFF
--- a/packages/react/src/hooks/useBookmark/useBookmark.spec.tsx
+++ b/packages/react/src/hooks/useBookmark/useBookmark.spec.tsx
@@ -1,0 +1,51 @@
+import type { ReactNode } from 'react';
+import { renderHook, wrapper } from '~/setup';
+import { EdificeClientContext } from '../../providers/EdificeClientProvider/EdificeClientProvider.context';
+import useBookmark from './useBookmark';
+
+function createWrapper(bookmarkedApps?: Array<{ displayName: string }>) {
+  return ({ children }: { children: ReactNode }) => (
+    <EdificeClientContext.Provider
+      value={
+        {
+          sessionQuery: {
+            data: bookmarkedApps ? { bookmarkedApps } : undefined,
+          },
+        } as any
+      }
+    >
+      {children}
+    </EdificeClientContext.Provider>
+  );
+}
+
+describe('useBookmark', () => {
+  it('returns an empty list with the default session (no bookmarks)', () => {
+    const { result } = renderHook(() => useBookmark(), { wrapper });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns undefined when the session has no data', () => {
+    const { result } = renderHook(() => useBookmark(), {
+      wrapper: createWrapper(undefined),
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('deduplicates bookmarked apps by displayName', () => {
+    const { result } = renderHook(() => useBookmark(), {
+      wrapper: createWrapper([
+        { displayName: 'Blog' },
+        { displayName: 'Wiki' },
+        { displayName: 'Blog' },
+      ]),
+    });
+
+    expect(result.current).toEqual([
+      { displayName: 'Blog' },
+      { displayName: 'Wiki' },
+    ]);
+  });
+});

--- a/packages/react/src/hooks/useDate/useDate.spec.tsx
+++ b/packages/react/src/hooks/useDate/useDate.spec.tsx
@@ -1,0 +1,118 @@
+import { renderHook, wrapper } from '~/setup';
+import useDate from './useDate';
+
+// The MockedProvider wrapper supplies currentLanguage = 'fr'.
+function render() {
+  return renderHook(() => useDate(), { wrapper });
+}
+
+describe('useDate', () => {
+  describe('formatDate', () => {
+    it('formats a short date using the localized L pattern', () => {
+      const { result } = render();
+
+      expect(result.current.formatDate('2021-03-24', 'short')).toBe(
+        '24/03/2021',
+      );
+    });
+
+    it('honors a custom dayjs format string', () => {
+      const { result } = render();
+
+      expect(result.current.formatDate('2021-03-24', 'YYYY-MM-DD')).toBe(
+        '2021-03-24',
+      );
+    });
+
+    it('formats a numeric (epoch) date', () => {
+      const { result } = render();
+
+      // 2021-06-15T12:00:00Z
+      expect(result.current.formatDate(1623758400000, 'YYYY')).toBe('2021');
+    });
+
+    it('formats a MongoDate ($date epoch)', () => {
+      const { result } = render();
+
+      expect(result.current.formatDate({ $date: 1623758400000 }, 'YYYY')).toBe(
+        '2021',
+      );
+    });
+
+    it('returns an empty string for an invalid date', () => {
+      const { result } = render();
+
+      expect(
+        result.current.formatDate('not a valid date at all', 'short'),
+      ).toBe('');
+    });
+  });
+
+  describe('comparisons', () => {
+    it('dateIsSame compares by day and by unit', () => {
+      const { result } = render();
+
+      expect(result.current.dateIsSame('2021-03-24', '2021-03-24')).toBe(true);
+      expect(result.current.dateIsSame('2021-03-24', '2021-03-25')).toBe(false);
+      expect(
+        result.current.dateIsSame('2021-03-24', '2021-03-25', 'month'),
+      ).toBe(true);
+    });
+
+    it('dateIsSameOrAfter checks the ordering', () => {
+      const { result } = render();
+
+      expect(result.current.dateIsSameOrAfter('2021-03-25', '2021-03-24')).toBe(
+        true,
+      );
+      expect(result.current.dateIsSameOrAfter('2021-03-23', '2021-03-24')).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('now-relative helpers', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('dateIsToday reflects the system date', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2021, 5, 15, 12, 0, 0));
+      const { result } = render();
+
+      expect(result.current.dateIsToday('2021-06-15')).toBe(true);
+      expect(result.current.dateIsToday('2000-01-01')).toBe(false);
+    });
+
+    it('formatTimeAgo returns the localized "Yesterday" label', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2021, 5, 15, 12, 0, 0));
+      const { result } = render();
+
+      expect(result.current.formatTimeAgo('2021-06-14')).toBe('Yesterday');
+    });
+
+    it('formatTimeAgo returns an empty string for an invalid date', () => {
+      const { result } = render();
+
+      expect(result.current.formatTimeAgo('not a valid date at all')).toBe('');
+    });
+
+    it('fromNow returns a non-empty string for a valid date', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date(2021, 5, 15, 12, 0, 0));
+      const { result } = render();
+
+      const value = result.current.fromNow('2021-06-14');
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    });
+
+    it('fromNow returns an empty string for an invalid date', () => {
+      const { result } = render();
+
+      expect(result.current.fromNow('not a valid date at all')).toBe('');
+    });
+  });
+});

--- a/packages/react/src/hooks/useDirectory/useDirectory.spec.tsx
+++ b/packages/react/src/hooks/useDirectory/useDirectory.spec.tsx
@@ -1,0 +1,46 @@
+import { renderHook } from '~/setup';
+import useDirectory from './useDirectory';
+
+const { getAvatarUrl, getDirectoryUrl } = vi.hoisted(() => ({
+  getAvatarUrl: vi.fn(),
+  getDirectoryUrl: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    directory: () => ({ getAvatarUrl, getDirectoryUrl }),
+  },
+}));
+
+describe('useDirectory', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds an avatar URL through the directory service', () => {
+    getAvatarUrl.mockReturnValue('/avatar/user-1');
+    const { result } = renderHook(() => useDirectory());
+
+    expect(result.current.getAvatarURL('user-1', 'user')).toBe(
+      '/avatar/user-1',
+    );
+    expect(getAvatarUrl).toHaveBeenCalledWith('user-1', 'user');
+  });
+
+  it('returns undefined for an empty user id without calling the service', () => {
+    const { result } = renderHook(() => useDirectory());
+
+    expect(result.current.getAvatarURL('', 'user')).toBeUndefined();
+    expect(getAvatarUrl).not.toHaveBeenCalled();
+  });
+
+  it('builds a userbook URL through the directory service', () => {
+    getDirectoryUrl.mockReturnValue('/userbook/user-1');
+    const { result } = renderHook(() => useDirectory());
+
+    expect(result.current.getUserbookURL('user-1', 'user')).toBe(
+      '/userbook/user-1',
+    );
+    expect(getDirectoryUrl).toHaveBeenCalledWith('user-1', 'user');
+  });
+});

--- a/packages/react/src/hooks/useHttpErrorToast/useHttpErrorToast.spec.tsx
+++ b/packages/react/src/hooks/useHttpErrorToast/useHttpErrorToast.spec.tsx
@@ -1,0 +1,98 @@
+import { renderHook } from '~/setup';
+import useHttpErrorToast from './useHttpErrorToast';
+
+const { subscribe, revoke, toastError } = vi.hoisted(() => ({
+  subscribe: vi.fn(),
+  revoke: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  LAYER_NAME: { TRANSPORT: 'TRANSPORT' },
+  odeServices: {
+    notify: () => ({
+      events: () => ({ subscribe }),
+    }),
+  },
+}));
+
+vi.mock('../..', () => ({
+  useToast: () => ({ error: toastError }),
+}));
+
+/** Returns the transport-error callback captured by the mocked subscribe(). */
+function capturedCallback() {
+  return subscribe.mock.calls[0][1] as (event: any) => void;
+}
+
+describe('useHttpErrorToast', () => {
+  beforeEach(() => {
+    subscribe.mockReturnValue({ revoke });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('subscribes to transport errors on mount and revokes on unmount', () => {
+    const { unmount } = renderHook(() => useHttpErrorToast({}));
+
+    expect(subscribe).toHaveBeenCalledWith('TRANSPORT', expect.any(Function));
+
+    unmount();
+    expect(revoke).toHaveBeenCalled();
+  });
+
+  it('does not subscribe when inactive', () => {
+    renderHook(() => useHttpErrorToast({ active: false }));
+
+    expect(subscribe).not.toHaveBeenCalled();
+  });
+
+  it('maps a known HTTP status to an eXXX i18n key', () => {
+    renderHook(() => useHttpErrorToast({}));
+
+    capturedCallback()({ data: { response: { status: 404 } } });
+
+    const [element] = toastError.mock.calls[0];
+    expect(element.props.children).toEqual(['e404']);
+  });
+
+  it('prefers the payload error key over the status code', () => {
+    renderHook(() => useHttpErrorToast({}));
+
+    capturedCallback()({
+      data: { response: { status: 404 }, payload: { error: 'custom.error' } },
+    });
+
+    const [element] = toastError.mock.calls[0];
+    expect(element.props.children).toEqual(['custom.error']);
+  });
+
+  it('falls back to the statusText for an unknown status', () => {
+    renderHook(() => useHttpErrorToast({}));
+
+    capturedCallback()({
+      data: { response: { status: 418, statusText: 'I am a teapot' } },
+    });
+
+    const [element] = toastError.mock.calls[0];
+    expect(element.props.children).toEqual(['I am a teapot']);
+  });
+
+  it('does not toast when there is no usable message', () => {
+    renderHook(() => useHttpErrorToast({}));
+
+    capturedCallback()({ data: { response: { status: 418 } } });
+
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('ignores events without data', () => {
+    renderHook(() => useHttpErrorToast({}));
+
+    capturedCallback()({});
+
+    expect(toastError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/hooks/useInfiniteScroll/useInfiniteScroll.spec.tsx
+++ b/packages/react/src/hooks/useInfiniteScroll/useInfiniteScroll.spec.tsx
@@ -1,0 +1,79 @@
+import { act, renderHook } from '~/setup';
+import useInfiniteScroll from './useInfiniteScroll';
+
+const observe = vi.fn();
+const disconnect = vi.fn();
+let ioCallback: (entries: Array<{ isIntersecting: boolean }>) => void;
+
+class MockIntersectionObserver {
+  constructor(cb: any) {
+    ioCallback = cb;
+  }
+  observe = observe;
+  disconnect = disconnect;
+}
+
+describe('useInfiniteScroll', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it('observes the node attached through the ref callback', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useInfiniteScroll({ callback }));
+    const node = document.createElement('div');
+
+    act(() => result.current(node));
+
+    expect(observe).toHaveBeenCalledWith(node);
+  });
+
+  it('invokes the callback when the sentinel intersects', async () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useInfiniteScroll({ callback }));
+    act(() => result.current(document.createElement('div')));
+
+    await act(async () => {
+      await ioCallback([{ isIntersecting: true }]);
+    });
+
+    expect(callback).toHaveBeenCalled();
+  });
+
+  it('does not invoke the callback when the sentinel is not intersecting', async () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useInfiniteScroll({ callback }));
+    act(() => result.current(document.createElement('div')));
+
+    await act(async () => {
+      await ioCallback([{ isIntersecting: false }]);
+    });
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('disconnects the observer when the ref is detached (null node)', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useInfiniteScroll({ callback }));
+    act(() => result.current(document.createElement('div')));
+
+    act(() => result.current(null));
+
+    expect(disconnect).toHaveBeenCalled();
+  });
+
+  it('disconnects the previous observer when a new node is attached', () => {
+    const callback = vi.fn();
+    const { result } = renderHook(() => useInfiniteScroll({ callback }));
+
+    act(() => result.current(document.createElement('div')));
+    act(() => result.current(document.createElement('div')));
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/hooks/useResource/useResource.spec.tsx
+++ b/packages/react/src/hooks/useResource/useResource.spec.tsx
@@ -1,0 +1,50 @@
+import { renderHook, waitFor } from '~/setup';
+import useResource from './useResource';
+
+const { resource, searchResource } = vi.hoisted(() => ({
+  resource: vi.fn(),
+  searchResource: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: { resource },
+}));
+
+describe('useResource', () => {
+  beforeEach(() => {
+    resource.mockReturnValue({ searchResource });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches and returns the resource on mount', async () => {
+    const fetched = { assetId: 'id-1', name: 'My resource' };
+    searchResource.mockResolvedValue(fetched);
+
+    const { result } = renderHook(() => useResource('blog', 'id-1'));
+
+    await waitFor(() => expect(result.current).toEqual(fetched));
+    expect(resource).toHaveBeenCalledWith('blog');
+    expect(searchResource).toHaveBeenCalledWith({
+      application: 'blog',
+      id: 'id-1',
+    });
+  });
+
+  it('does not fetch when the id is empty', () => {
+    renderHook(() => useResource('blog', ''));
+
+    expect(searchResource).not.toHaveBeenCalled();
+  });
+
+  it('stays null when the fetch fails', async () => {
+    searchResource.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useResource('blog', 'id-1'));
+
+    await waitFor(() => expect(searchResource).toHaveBeenCalled());
+    expect(result.current).toBeNull();
+  });
+});

--- a/packages/react/src/hooks/useResourceSearch/useResourceSearch.spec.tsx
+++ b/packages/react/src/hooks/useResourceSearch/useResourceSearch.spec.tsx
@@ -1,0 +1,57 @@
+import { act, renderHook, waitFor } from '~/setup';
+import { useResourceSearch } from './useResourceSearch';
+
+const { initialize, registerBehaviours, behaviour, loadResources } = vi.hoisted(
+  () => ({
+    initialize: vi.fn(),
+    registerBehaviours: vi.fn(),
+    behaviour: vi.fn(),
+    loadResources: vi.fn(),
+  }),
+);
+
+vi.mock('@edifice.io/client', () => ({
+  SnipletsService: {
+    initialize,
+    registerBehaviours,
+    resourceProducingApps: ['blog', 'wiki'],
+  },
+  odeServices: { behaviour },
+}));
+
+describe('useResourceSearch', () => {
+  beforeEach(() => {
+    initialize.mockResolvedValue(undefined);
+    registerBehaviours.mockResolvedValue(undefined);
+    behaviour.mockReturnValue({ loadResources });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('initializes the sniplets service and exposes producing apps', async () => {
+    const { result } = renderHook(() => useResourceSearch('blog' as any));
+
+    await waitFor(() =>
+      expect(result.current.resourceApplications).toEqual(['blog', 'wiki']),
+    );
+    expect(registerBehaviours).toHaveBeenCalledWith('blog');
+  });
+
+  it('loads resources for the first requested type', async () => {
+    const payload = [{ id: 'r-1' }];
+    loadResources.mockResolvedValue(payload);
+    const { result } = renderHook(() => useResourceSearch('blog' as any));
+
+    const filters = { types: ['blog'], search: 'foo' } as any;
+    let returned;
+    await act(async () => {
+      returned = await result.current.loadResources(filters);
+    });
+
+    expect(behaviour).toHaveBeenCalledWith('blog', 'blog');
+    expect(loadResources).toHaveBeenCalledWith(filters);
+    expect(returned).toBe(payload);
+  });
+});

--- a/packages/react/src/hooks/useToast/useToast.spec.tsx
+++ b/packages/react/src/hooks/useToast/useToast.spec.tsx
@@ -1,0 +1,86 @@
+import { renderHook } from '~/setup';
+import useToast from './useToast';
+
+const { toast } = vi.hoisted(() => ({
+  toast: {
+    custom: vi.fn(() => 'toast-id'),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+    remove: vi.fn(),
+  },
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: toast,
+}));
+
+describe('useToast', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ['success', 'success'],
+    ['error', 'danger'],
+    ['info', 'info'],
+    ['warning', 'warning'],
+  ])(
+    'renders a "%s" toast with the "%s" alert type and default options',
+    (method, alertType) => {
+      const { result } = renderHook(() => useToast());
+
+      (result.current as any)[method]('Hello');
+
+      const [element, options] = toast.custom.mock.calls[0];
+      expect(element.props.type).toBe(alertType);
+      expect(element.props.isToast).toBe(true);
+      expect(element.props.children).toBe('Hello');
+      expect(options).toMatchObject({
+        duration: 5000,
+        position: 'top-right',
+        id: undefined,
+      });
+    },
+  );
+
+  it('forwards custom options (id, duration, position, isDismissible)', () => {
+    const { result } = renderHook(() => useToast());
+
+    result.current.success('Hi', {
+      id: 'my-id',
+      duration: 1000,
+      position: 'bottom-left',
+      isDismissible: true,
+    });
+
+    const [element, options] = toast.custom.mock.calls[0];
+    expect(element.props.isDismissible).toBe(true);
+    expect(options).toMatchObject({
+      id: 'my-id',
+      duration: 1000,
+      position: 'bottom-left',
+    });
+  });
+
+  it('dismisses a toast by id', () => {
+    const { result } = renderHook(() => useToast());
+
+    result.current.dismiss('to-dismiss');
+
+    expect(toast.dismiss).toHaveBeenCalledWith('to-dismiss');
+  });
+
+  it('removes a toast by id', () => {
+    const { result } = renderHook(() => useToast());
+
+    result.current.remove('to-remove');
+
+    expect(toast.remove).toHaveBeenCalledWith('to-remove');
+  });
+
+  it('re-exports the loading helper from react-hot-toast', () => {
+    const { result } = renderHook(() => useToast());
+
+    expect(result.current.loading).toBe(toast.loading);
+  });
+});

--- a/packages/react/src/hooks/useTrashedResource/useTrashedResource.spec.tsx
+++ b/packages/react/src/hooks/useTrashedResource/useTrashedResource.spec.tsx
@@ -1,0 +1,93 @@
+import { Component, type ReactNode } from 'react';
+import { render, renderHook, screen, waitFor } from '~/setup';
+import useTrashedResource from './useTrashedResource';
+
+const { get } = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    http: () => ({ get }),
+  },
+}));
+
+vi.mock('..', () => ({
+  useUser: () => ({ user: { userId: 'user-1' } }),
+}));
+
+vi.mock(
+  '../../providers/EdificeClientProvider/EdificeClientProvider.hook',
+  () => ({
+    useEdificeClient: () => ({ appCode: 'blog' }),
+  }),
+);
+
+// Error boundary catching the Response thrown when a resource is trashed.
+class Boundary extends Component<{ children: ReactNode }, { caught: boolean }> {
+  state = { caught: false };
+  static getDerivedStateFromError() {
+    return { caught: true };
+  }
+  render() {
+    return this.state.caught ? <div>error-caught</div> : this.props.children;
+  }
+}
+
+function Trasher({ id }: { id: string }) {
+  useTrashedResource(id);
+  return <div>resource-ok</div>;
+}
+
+describe('useTrashedResource', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requests the explorer API with the appCode and asset id', async () => {
+    get.mockResolvedValue({ resources: [] });
+
+    renderHook(() => useTrashedResource('res-1'));
+
+    await waitFor(() =>
+      expect(get).toHaveBeenCalledWith(
+        '/explorer/resources?application=blog&resource_type=blog&asset_id[]=res-1',
+      ),
+    );
+  });
+
+  it('does not throw when the resource is not trashed', async () => {
+    get.mockResolvedValue({
+      resources: [{ assetId: 'res-1', trashed: false, trashedBy: [] }],
+    });
+
+    render(<Trasher id="res-1" />, { wrapper: Boundary });
+
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(screen.getByText('resource-ok')).toBeInTheDocument();
+  });
+
+  it('throws a 404 when the resource is trashed', async () => {
+    get.mockResolvedValue({
+      resources: [{ assetId: 'res-1', trashed: true, trashedBy: [] }],
+    });
+
+    render(<Trasher id="res-1" />, { wrapper: Boundary });
+
+    await waitFor(() =>
+      expect(screen.getByText('error-caught')).toBeInTheDocument(),
+    );
+  });
+
+  it('throws a 404 when the resource was trashed by the current user', async () => {
+    get.mockResolvedValue({
+      resources: [{ assetId: 'res-1', trashed: false, trashedBy: ['user-1'] }],
+    });
+
+    render(<Trasher id="res-1" />, { wrapper: Boundary });
+
+    await waitFor(() =>
+      expect(screen.getByText('error-caught')).toBeInTheDocument(),
+    );
+  });
+});


### PR DESCRIPTION
## Contexte

[ENABLING-989](https://edifice-community.atlassian.net/browse/ENABLING-989) — Lot 6 de l'amorçage de couverture de tests du package `@edifice.io/react` (suite de ENABLING-931/932/935/987/988). Complémentaire : aucune cible ne recouvre celles des autres lots.

Ce lot cible les **hooks de données / ressources** et les **hooks de date & notifications** — logique de fetch, de contexte et de gestion d'erreur largement consommée par les apps.

## Changements

9 fichiers de specs, **47 tests** — aucune modification de code de prod. Tous les candidats prioritaires du ticket sont couverts.

| Catégorie | Cibles | Tests |
|---|---|---|
| Ressources / data | `useResource`, `useResourceSearch`, `useTrashedResource`, `useBookmark`, `useDirectory`, `useInfiniteScroll` | 20 |
| Date & notifications | `useDate`, `useToast`, `useHttpErrorToast` | 27 |

## Choix techniques

- **Stratégie de mock** : ces hooks « data » n'utilisent pas TanStack Query directement et le `server` MSW du setup n'est pas exportable (`vitest.setup.ts` = DO NOT MODIFY). On suit donc la convention du repo : **mock direct de `@edifice.io/client`** via `vi.hoisted` + `vi.mock` (pattern `useHasWorkflow.spec.tsx`), plutôt que `server.use`.
- `useTrashedResource` : le `throw` d'une `Response` 404 (déclenché dans un `useEffect` pour l'ErrorBoundary de React Router) est testé via un **ErrorBoundary** dédié + `render`.
- `useInfiniteScroll` : `IntersectionObserver` (absent de jsdom) stubbé via `vi.stubGlobal`, callback d'intersection déclenché manuellement.
- `useBookmark` : wrapper custom sur `EdificeClientContext` pour piloter `sessionQuery.data.bookmarkedApps` (déduplication par `displayName`).
- `useDate` : fake timers (`vi.setSystemTime`) pour les formats relatifs déterministes ; label « Yesterday » stable via l'i18n de test (`en`).
- `useToast` / `useHttpErrorToast` : `react-hot-toast` et le service `odeServices.notify()` mockés ; vérification du mapping type d'Alert et code HTTP → clé i18n (`e404`, priorité payload > code > statusText), et du cleanup (`revoke`).

## Recette / Risque

Risque faible — ajout de tests uniquement, pas de changement d'API publique. Tests déterministes : pas de timers réels, pas de dépendance réseau non mockée. Suite complète du package verte (33 fichiers / 189 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENABLING-989]: https://edifice-community.atlassian.net/browse/ENABLING-989?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ