### PR TITLE
test: #ENABLING-990 add unit tests to @edifice.io/react (lot 7)

### DIFF
--- a/packages/react/src/components/BetaSwitch/BetaSwitch.spec.tsx
+++ b/packages/react/src/components/BetaSwitch/BetaSwitch.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '~/setup';
+import { BetaSwitch } from './BetaSwitch';
+
+describe('BetaSwitch', () => {
+  beforeAll(() => {
+    // useBreakpoint relies on window.matchMedia, absent from jsdom.
+    vi.stubGlobal('matchMedia', (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it('renders the opt-out call-to-action button', () => {
+    render(<BetaSwitch />);
+
+    expect(screen.getByTestId('beta-switch-button')).toBeInTheDocument();
+  });
+
+  it('calls onSwitchClick when the button is clicked', async () => {
+    const onSwitchClick = vi.fn();
+    const { user } = render(<BetaSwitch onSwitchClick={onSwitchClick} />);
+
+    await user.click(screen.getByTestId('beta-switch-button'));
+
+    expect(onSwitchClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the button while switching', async () => {
+    const onSwitchClick = vi.fn();
+    const { user } = render(
+      <BetaSwitch isSwitching onSwitchClick={onSwitchClick} />,
+    );
+
+    const button = screen.getByTestId('beta-switch-button');
+    expect(button).toBeDisabled();
+
+    await user.click(button);
+    expect(onSwitchClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/components/Form/Form.spec.tsx
+++ b/packages/react/src/components/Form/Form.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '~/setup';
+import { Input } from '../Input';
+import FormControl from './FormControl';
+
+describe('FormControl', () => {
+  it('exposes the Label, Input and Text compound subcomponents', () => {
+    expect(FormControl.Label).toBeDefined();
+    expect(FormControl.Input).toBeDefined();
+    expect(FormControl.Text).toBeDefined();
+  });
+
+  it('shares its id, required and invalid status with its children', () => {
+    render(
+      <FormControl id="email" isRequired status="invalid">
+        <FormControl.Label>Email</FormControl.Label>
+        <FormControl.Input type="email" size="md" />
+        <FormControl.Text>Required field</FormControl.Text>
+      </FormControl>,
+    );
+
+    const input = screen.getByLabelText(/Email/);
+    expect(input).toHaveAttribute('id', 'email');
+    expect(input).toBeRequired();
+    expect(input).toHaveClass('is-invalid');
+
+    const helpText = screen.getByText('Required field');
+    expect(helpText.closest('.form-text')).toHaveClass('is-invalid');
+  });
+
+  it('forwards extra props to the wrapping div', () => {
+    render(
+      <FormControl id="email" data-testid="form-control" className="my-field">
+        <FormControl.Input type="email" size="md" />
+      </FormControl>,
+    );
+
+    expect(screen.getByTestId('form-control')).toHaveClass('my-field');
+  });
+
+  it('throws when a field is rendered outside a FormControl', () => {
+    // useFormControl() throws synchronously during render without a provider.
+    expect(() => render(<Input type="text" size="md" />)).toThrow(
+      /outside the FormControl/,
+    );
+  });
+});

--- a/packages/react/src/components/Input/Input.spec.tsx
+++ b/packages/react/src/components/Input/Input.spec.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '~/setup';
+import { FormControl } from '../Form';
+import { Label } from '../Label';
+import Input from './Input';
+
+describe('Input', () => {
+  it('renders an input wired to the FormControl id and label', () => {
+    render(
+      <FormControl id="firstname">
+        <Label>First name</Label>
+        <Input type="text" size="md" placeholder="Type here" />
+      </FormControl>,
+    );
+
+    const input = screen.getByLabelText('First name');
+    expect(input).toHaveAttribute('id', 'firstname');
+    expect(input).toHaveAttribute('placeholder', 'Type here');
+  });
+
+  it('calls onChange with the native event and updates its value', async () => {
+    const handleChange = vi.fn();
+    const { user } = render(
+      <FormControl id="firstname">
+        <Input type="text" size="md" onChange={handleChange} />
+      </FormControl>,
+    );
+
+    const input = screen.getByRole('textbox');
+    await user.type(input, 'abc');
+
+    expect(handleChange).toHaveBeenCalledTimes(3);
+    expect(input).toHaveValue('abc');
+  });
+
+  it('is disabled when the disabled prop is set', () => {
+    render(
+      <FormControl id="firstname">
+        <Input type="text" size="md" disabled />
+      </FormControl>,
+    );
+
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('is required and readonly from the FormControl context', () => {
+    const { rerender } = render(
+      <FormControl id="firstname" isRequired>
+        <Input type="text" size="md" />
+      </FormControl>,
+    );
+    expect(screen.getByRole('textbox')).toBeRequired();
+
+    rerender(
+      <FormControl id="firstname" isReadOnly>
+        <Input type="text" size="md" />
+      </FormControl>,
+    );
+    const input = screen.getByRole('textbox');
+    expect(input).toHaveAttribute('readonly');
+    expect(input).toHaveClass('form-control-plaintext');
+  });
+
+  it('reflects the validation status through CSS classes', () => {
+    const { rerender } = render(
+      <FormControl id="firstname" status="invalid">
+        <Input type="text" size="md" />
+      </FormControl>,
+    );
+    expect(screen.getByRole('textbox')).toHaveClass('is-invalid');
+
+    rerender(
+      <FormControl id="firstname" status="valid">
+        <Input type="text" size="md" />
+      </FormControl>,
+    );
+    expect(screen.getByRole('textbox')).toHaveClass('is-valid');
+  });
+
+  it('shows a character counter when showCounter is set', () => {
+    render(
+      <FormControl id="firstname">
+        <Input
+          type="text"
+          size="md"
+          showCounter
+          maxLength={10}
+          defaultValue="hi"
+        />
+      </FormControl>,
+    );
+
+    expect(screen.getByText('2 / 10')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/Label/Label.spec.tsx
+++ b/packages/react/src/components/Label/Label.spec.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '~/setup';
+import { FormControl } from '../Form';
+import Label from './Label';
+
+describe('Label', () => {
+  it('associates the label with the FormControl id via htmlFor', () => {
+    render(
+      <FormControl id="email">
+        <Label>Email</Label>
+      </FormControl>,
+    );
+
+    expect(screen.getByText('Email').closest('label')).toHaveAttribute(
+      'for',
+      'email',
+    );
+  });
+
+  it('renders the required indicator when the field is required', () => {
+    render(
+      <FormControl id="email" isRequired>
+        <Label requiredText="*">Email</Label>
+      </FormControl>,
+    );
+
+    const indicator = screen.getByText('*');
+    expect(indicator).toHaveClass('required');
+  });
+
+  it('renders the optional indicator when the field is optional', () => {
+    render(
+      <FormControl id="email" isOptional>
+        <Label optionalText="optional">Email</Label>
+      </FormControl>,
+    );
+
+    expect(screen.getByText('- optional')).toHaveClass('optional');
+  });
+
+  it('renders a left icon when provided', () => {
+    render(
+      <FormControl id="email">
+        <Label leftIcon={<span>icon</span>}>Email</Label>
+      </FormControl>,
+    );
+
+    expect(screen.getByText('icon')).toBeInTheDocument();
+    expect(screen.getByText('Email').closest('label')).toHaveClass('has-icon');
+  });
+});

--- a/packages/react/src/components/SearchBar/SearchBar.spec.tsx
+++ b/packages/react/src/components/SearchBar/SearchBar.spec.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '~/setup';
+import SearchBar from './SearchBar';
+
+describe('SearchBar', () => {
+  describe('default variant (with submit button)', () => {
+    it('renders a search input and a submit button', () => {
+      render(<SearchBar isVariant={false} onClick={vi.fn()} />);
+
+      expect(screen.getByRole('searchbox')).toBeInTheDocument();
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+
+    it('triggers onClick when the submit button is clicked', async () => {
+      const onClick = vi.fn();
+      const { user } = render(
+        <SearchBar isVariant={false} onClick={onClick} />,
+      );
+
+      await user.click(screen.getByRole('button'));
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('triggers onClick when Enter is pressed in the input', async () => {
+      const onClick = vi.fn();
+      const { user } = render(
+        <SearchBar isVariant={false} onClick={onClick} />,
+      );
+
+      await user.type(screen.getByRole('searchbox'), 'hello{Enter}');
+
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onChange while typing', async () => {
+      const onChange = vi.fn();
+      const { user } = render(
+        <SearchBar isVariant={false} onClick={vi.fn()} onChange={onChange} />,
+      );
+
+      await user.type(screen.getByRole('searchbox'), 'abc');
+
+      expect(onChange).toHaveBeenCalledTimes(3);
+    });
+
+    it('disables the input and the button independently', () => {
+      render(
+        <SearchBar
+          isVariant={false}
+          onClick={vi.fn()}
+          disabled
+          buttonDisabled
+        />,
+      );
+
+      expect(screen.getByRole('searchbox')).toBeDisabled();
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+  });
+
+  describe('dynamic variant (live search)', () => {
+    it('renders no submit button', () => {
+      render(<SearchBar isVariant onChange={vi.fn()} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+
+    it('shows a clear button that resets the value through onChange', async () => {
+      const onChange = vi.fn();
+      const { user } = render(
+        <SearchBar isVariant clearable value="foo" onChange={onChange} />,
+      );
+
+      const clearButton = screen.getByRole('button');
+      await user.click(clearButton);
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0].target.value).toBe('');
+    });
+
+    it('does not show the clear button when there is no value', () => {
+      render(<SearchBar isVariant clearable value="" onChange={vi.fn()} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react/src/components/SegmentedControl/SegmentedControl.spec.tsx
+++ b/packages/react/src/components/SegmentedControl/SegmentedControl.spec.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '~/setup';
+import SegmentedControl from './SegmentedControl';
+
+const options = [
+  { label: 'List', value: 'list' },
+  { label: 'Kanban', value: 'kanban' },
+];
+
+describe('SegmentedControl', () => {
+  beforeAll(() => {
+    // antd Segmented relies on ResizeObserver, absent from jsdom.
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+  });
+
+  it('renders every option', () => {
+    render(<SegmentedControl options={options} value="list" />);
+
+    expect(screen.getByText('List')).toBeInTheDocument();
+    expect(screen.getByText('Kanban')).toBeInTheDocument();
+    expect(screen.getByTestId('segmented-option-list')).toBeInTheDocument();
+  });
+
+  it('marks the controlled value as selected', () => {
+    render(<SegmentedControl options={options} value="kanban" />);
+
+    expect(
+      screen.getByText('Kanban').closest('.ant-segmented-item'),
+    ).toHaveClass('ant-segmented-item-selected');
+  });
+
+  it('calls onChange with the selected value string', async () => {
+    const onChange = vi.fn();
+    const { user } = render(
+      <SegmentedControl options={options} value="list" onChange={onChange} />,
+    );
+
+    await user.click(screen.getByTestId('segmented-option-kanban'));
+
+    expect(onChange).toHaveBeenCalledWith('kanban');
+  });
+
+  it('renders an optional badge next to the label', () => {
+    render(
+      <SegmentedControl
+        options={[{ label: 'Inbox', value: 'inbox', badge: <span>5</span> }]}
+        value="inbox"
+      />,
+    );
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('applies the ghost variant class', () => {
+    const { container } = render(
+      <SegmentedControl options={options} value="list" variant="ghost" />,
+    );
+
+    expect(container.querySelector('.ghost')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/Switch/Switch.spec.tsx
+++ b/packages/react/src/components/Switch/Switch.spec.tsx
@@ -1,0 +1,54 @@
+import { createRef } from 'react';
+import { render, screen } from '~/setup';
+import Switch from './Switch';
+
+describe('Switch', () => {
+  it('renders a checkbox with its label', () => {
+    render(<Switch label="Notifications" readOnly />);
+
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByText('Notifications')).toBeInTheDocument();
+  });
+
+  it('applies size, variant and disabled classes on the wrapping label', () => {
+    render(<Switch label="On" size="sm" variant="success" disabled readOnly />);
+
+    const label = screen.getByRole('checkbox').closest('label');
+    expect(label).toHaveClass('switch', 'switch-sm', 'switch-success');
+    expect(label).toHaveClass('switch-disabled');
+  });
+
+  it('reflects the controlled checked and disabled props', () => {
+    render(<Switch checked disabled onChange={() => {}} />);
+
+    const input = screen.getByRole('checkbox');
+    expect(input).toBeChecked();
+    expect(input).toBeDisabled();
+  });
+
+  it('calls onChange with a native event when toggled', async () => {
+    const handleChange = vi.fn();
+    const { user } = render(<Switch onChange={handleChange} />);
+
+    await user.click(screen.getByRole('checkbox'));
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange.mock.calls[0][0].target.checked).toBe(true);
+  });
+
+  it('does not call onChange when disabled', async () => {
+    const handleChange = vi.fn();
+    const { user } = render(<Switch disabled onChange={handleChange} />);
+
+    await user.click(screen.getByRole('checkbox'));
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('forwards the ref to the input element', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<Switch ref={ref} readOnly />);
+
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+});

--- a/packages/react/src/components/TextArea/TextArea.spec.tsx
+++ b/packages/react/src/components/TextArea/TextArea.spec.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '~/setup';
+import { FormControl } from '../Form';
+import TextArea from './TextArea';
+
+describe('TextArea', () => {
+  it('renders a textarea wired to the FormControl id', () => {
+    render(
+      <FormControl id="bio">
+        <TextArea size="md" placeholder="About you" />
+      </FormControl>,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveAttribute('id', 'bio');
+    expect(textarea).toHaveAttribute('placeholder', 'About you');
+  });
+
+  it('calls onChange with the native event and updates its value', async () => {
+    const handleChange = vi.fn();
+    const { user } = render(
+      <FormControl id="bio">
+        <TextArea size="md" onChange={handleChange} />
+      </FormControl>,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    await user.type(textarea, 'hey');
+
+    expect(handleChange).toHaveBeenCalledTimes(3);
+    expect(textarea).toHaveValue('hey');
+  });
+
+  it('is disabled when the disabled prop is set', () => {
+    render(
+      <FormControl id="bio">
+        <TextArea size="md" disabled />
+      </FormControl>,
+    );
+
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('applies the height and validation classes', () => {
+    render(
+      <FormControl id="bio" status="invalid">
+        <TextArea size="md" height="lg" />
+      </FormControl>,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    expect(textarea).toHaveClass('textarea-height-lg');
+    expect(textarea).toHaveClass('is-invalid');
+  });
+
+  it('shows a character counter when showCounter is set', () => {
+    render(
+      <FormControl id="bio">
+        <TextArea size="md" showCounter maxLength={20} defaultValue="abc" />
+      </FormControl>,
+    );
+
+    expect(screen.getByText('3 / 20')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Contexte

[ENABLING-990](https://edifice-community.atlassian.net/browse/ENABLING-990) — Lot 7 de l'amorçage de couverture de tests du package `@edifice.io/react` (suite de ENABLING-931 à 989). Complémentaire : aucune cible ne recouvre celles des autres lots.

Ce lot ouvre la couverture des **composants de formulaire / input** — composants contrôlés très réutilisés, dont le contrat (`value` / `onChange` / disabled / erreur) doit être protégé contre les régressions.

## Changements

8 fichiers de specs, **41 tests** — aucune modification de code de prod. Tous les candidats prioritaires du ticket sont couverts.

| Catégorie | Cibles | Tests |
|---|---|---|
| Inputs & champs | `Input`, `TextArea`, `Label`, `Form` (FormControl compound), `SearchBar` | 27 |
| Contrôles d'état | `Switch`, `BetaSwitch`, `SegmentedControl` | 14 |

## Choix techniques

- Interactions via `userEvent` (`const { user } = render(...)` depuis `~/setup`), assertions comportementales plutôt que markup exact.
- `Input` / `TextArea` / `Label` sont testés dans leur `<FormControl id>` obligatoire (`useFormControl()` throw sinon) : contrat contrôlé vérifié (`onChange` = event natif, `disabled`, `required`/`readOnly`/`status` fournis par le contexte → classe `is-invalid`), plus le compteur de caractères.
- `Form` : compound components (`.Label` / `.Input` / `.Text`) ; on vérifie aussi qu'un champ rendu hors `FormControl` **throw** (contrat du contexte).
- `SearchBar` : les deux variantes (bouton submit + touche Enter ; live via `onChange` avec bouton clear conditionnel).
- Stubs jsdom nécessaires : `window.matchMedia` (BetaSwitch → `useBreakpoint`), `ResizeObserver` (SegmentedControl → antd `Segmented`).

### Doublon remonté par l'audit — clarifié

`Switch` (toggle basé sur `<input type="checkbox">`) et `BetaSwitch` (bannière d'opt-out de la homepage beta, avec CTA) **ne sont pas des doublons** — juste une collision de nommage, API et rôle totalement différents.

## Recette / Risque

Risque faible — ajout de tests uniquement, pas de changement d'API publique. Tests déterministes : pas de timers réels, pas de dépendance réseau non mockée. Suite complète du package verte (32 fichiers / 183 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENABLING-990]: https://edifice-community.atlassian.net/browse/ENABLING-990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ