### PR TITLE
feat: #ENABLING-1117 uiOverrides (theme-conf) — Header v2 sur Layout

### DIFF
--- a/UI-OVERRIDES-IMPLEMENTATION-PLAN.md
+++ b/UI-OVERRIDES-IMPLEMENTATION-PLAN.md
@@ -1,0 +1,215 @@
+# Implémentation des `uiOverrides` (theme-conf) — Header v2 pour `Layout`
+
+## Contexte
+
+Le ticket ENABLING-1117 (`UI-OVERRIDES-PLAN.md` à la racine du repo) décrit un mécanisme permettant à une plateforme (via son `theme-conf.js`) d'activer des variantes de composants — en premier lieu le nouveau Header — **sans `if CRNA` dans le code**, sans nouvelle API publique côté apps. Objectif immédiat : permettre à Intégration d'activer le nouveau Header sur CRNA pour la rentrée, en attendant la généralisation portée par IMPULSION en fin d'année.
+
+L'exploration du code a confirmé/précisé plusieurs points par rapport au plan original, validés avec l'utilisateur :
+
+1. **Le "Header v2" existe déjà** : c'est `packages/react/src/modules/homepage/components/Header/Header.tsx`. Il est déjà découplé de toute logique homepage-spécifique (hooks génériques `useConversation`/`useUser`/`useHasWorkflow`/`useHover`) et déjà utilisé en dehors de la homepage par `PageLayout.Header` (`components/PageLayout/components/PageLayoutHeader.tsx:5,24-27`). **On réutilise ce composant tel quel**, on n'en crée pas un nouveau.
+2. **Pas de sujet FlashMessagesHistory dans ce ticket** — la variante "historique Flash" du panneau notifications (plan §6, second exemple) reste un arbitrage produit non tranché, hors scope.
+3. **Vérification en recette CRNA** (theming scopé, cas accès public WB2-2660) : différée, pas bloquante pour l'implémentation.
+4. **Le vrai sujet du point "notifications" n'est pas un compound component, c'est un panneau manquant.** Le Header v2 a été conçu pour vivre dans `PageLayout`, qui lui offre la mécanique permettant d'afficher un panneau de notifications au clic sur la cloche (`useOverlay` + `PageLayout.Overlay`). En sortant ce Header vers `Layout` (legacy), on perd cette mécanique — `Layout` n'a pas d'équivalent. Il faut la reproduire, **a minima et sans toucher au code existant qui fonctionne** (fenêtre de MEP courte, pas de marge pour des retours QA). L'idée de restructurer `Header` en compound component (`withUiOverride`, `Header.Notifications`) est **abandonnée** : elle ajoutait un risque de régression sur un composant existant sans nécessité — voir section C.
+
+Scope de ce ticket, en deux phases séquentielles :
+- **Phase 1 — mécanisme de base** : PR `@edifice.io/client` (types + passthrough de conf) et PR `@edifice.io/react` (hook `useUiOverride` + switch dans `Layout` vers le Header existant, avec theming scopé).
+- **Phase 2 — panneau Notifications fonctionnel sur `Layout`** : réutilisation à l'identique de briques déjà existantes et déjà découplées (`useOverlay`, `PageLayoutOverlay`, `NotificationListContainer`), assemblées dans un unique nouveau fichier colocalisé avec `Layout`. **Aucune modification de `Header.tsx`, `PageLayout.tsx` ou du module Notifications.**
+
+## A. Phase 1 — `@edifice.io/client` : types + passthrough
+
+**`packages/client/src/ts/configure/interfaces.ts`**
+
+- Ajouter, à côté des autres exports du fichier :
+  ```ts
+  export type UiOverride = string | { variant: string; theme?: string };
+  ```
+- Étendre `IThemeConfOverriding` (ligne ~180-193) :
+  ```ts
+  export interface IThemeConfOverriding {
+    // … champs existants (parent, child, bootstrapVersion, skins, help, group?, edumedia) …
+    uiOverrides?: Record<string, UiOverride>;
+  }
+  ```
+- Étendre `IOdeTheme` (ligne ~235-246) — **c'est cette interface, pas `IThemeConfOverriding`, qui est réellement consommée côté React** via `useEdificeTheme()` :
+  ```ts
+  export interface IOdeTheme {
+    // … champs existants …
+    uiOverrides?: Record<string, UiOverride>;
+  }
+  ```
+
+**`packages/client/src/ts/configure/Service.ts`**
+
+Dans la méthode privée `getTheme()` (ligne ~115-169), le `themeOverride` est déjà résolu (ligne 130, `conf?.overriding?.find(...)`, typé `any` donc le passthrough ne casse rien côté compilation même avant l'étape A). Ajouter un champ au `return` final (ligne ~157-168) :
+```ts
+return {
+  // … champs existants …
+  uiOverrides: themeOverride?.uiOverrides,
+};
+```
+
+Pas de nouveau test unitaire pour `ConfService` : aucun test n'existe aujourd'hui pour cette classe (seul `transport/Service.spec.ts` existe, pour une autre classe), le changement est un passthrough additif d'une ligne. Couverture assurée par le typecheck + les tests du hook React (section D) + la vérification manuelle en recette (déjà actée comme différée).
+
+## B. Phase 1 — `@edifice.io/react` : hook + switch dans `Layout`
+
+**Nouveau hook `packages/react/src/hooks/useUiOverride/useUiOverride.ts`** (+ `index.ts`), suivant le pattern exact de `useZendeskGuide` (export par défaut dans le fichier d'implémentation, réexport nommé via `index.ts`) :
+```ts
+// useUiOverride.ts
+import { useEdificeTheme } from '../../providers/EdificeThemeProvider/EdificeThemeProvider.hook';
+
+export default function useUiOverride(key: string) {
+  const { theme } = useEdificeTheme();
+  const raw = theme?.uiOverrides?.[key];
+  return typeof raw === 'string' ? { variant: raw } : raw;
+}
+```
+```ts
+// index.ts
+export { default as useUiOverride } from './useUiOverride';
+```
+Ajouter `export * from './useUiOverride';` dans `hooks/index.ts` (ordre alphabétique).
+
+**`packages/react/src/modules/homepage/components/Header/Header.tsx`** — ajout additif d'une prop optionnelle pour le theming scopé (§3/§6 du plan : poser `data-product` sur la racine du sous-arbre). Attention : le nom `theme` est déjà pris par `useEdificeTheme()` (ligne 57) → nommer la prop différemment :
+```ts
+export interface HeaderProps {
+  src: string | undefined;
+  onNotificationsClick?: () => void;
+  dataProduct?: string;
+}
+
+const Header = ({ src = '', onNotificationsClick, dataProduct }: HeaderProps) => {
+  // … inchangé …
+  return (
+    <header className={classes} data-product={dataProduct}>
+      {/* … inchangé … */}
+```
+Quand `dataProduct` est `undefined` (cas `PageLayoutHeader`, qui ne passera pas cette prop), React n'émet pas l'attribut → comportement actuel préservé, le sous-arbre hérite du `data-product` ambiant.
+
+**`packages/react/src/components/Layout/Layout.tsx`** — switch lazy :
+```tsx
+import { lazy, Suspense, /* … */ } from 'react';
+// …
+const HeaderV2 = lazy(() => import('../../modules/homepage/components/Header/Header'));
+// …
+export const Layout = ({ children, headless = false, whiteBg = true, className, ...restProps }: LayoutProps) => {
+  const { theme } = useEdificeTheme();
+  const override = useUiOverride('layout.header');
+  // …
+  const renderHeader = !headless ? (
+    override?.variant === 'v2' ? (
+      <Suspense fallback={null}>
+        <HeaderV2 src={theme?.basePath} dataProduct={override?.theme} />
+      </Suspense>
+    ) : (
+      <Header is1d={theme?.is1d} src={theme?.basePath} />
+    )
+  ) : null;
+  // … reste inchangé
+```
+`lazy()` limite l'impact bundle pour les apps qui n'activent pas l'override (le Header v2 embarque des composants `*Beta` distincts). Précédent existant pour `lazy()` dans le package : `modules/comments/components/Comment.tsx`.
+
+## C. Phase 2 — panneau Notifications fonctionnel sur `Layout`
+
+À faire **après** la Phase 1. Constat vérifié dans le code (rien n'est câblé nulle part aujourd'hui, ni pour `PageLayout` ni ailleurs — pas de story, pas de doc, pas d'app dans ce repo qui connecte les trois) : les briques nécessaires existent déjà, **indépendamment de `PageLayout`**, et n'ont besoin d'aucune modification :
+
+- `useOverlay()` (`packages/react/src/components/PageLayout/hook/useOverlay.ts`) : simple store Zustand global (`overlayOpen: boolean`, `updateOverlayOpen`, `toggleOverlay`), déjà exporté publiquement depuis le barrel `components`. **Aucune dépendance à `PageLayoutContext`.**
+- `PageLayoutOverlay` (`packages/react/src/components/PageLayout/components/PageLayoutOverlay.tsx`) : un simple `<aside>` piloté par ce même `useOverlay()`, sans dépendance à `PageLayoutContext` non plus (juste des classes CSS + `inert`).
+- `NotificationListContainer` (`packages/react/src/modules/homepage/components/Notifications/NotificationListContainer.tsx`) : entièrement autonome, une seule prop (`onCloseNotifications?`), dépend uniquement de TanStack Query + `odeServices` (déjà montés à la racine de toute app React) — **aucune dépendance à `PageLayout`**.
+
+→ Ces trois briques sont *composables* sans que `Layout` ait besoin d'adopter la structure compound de `PageLayout`. On les assemble dans **un seul nouveau fichier**, sans toucher à `Header.tsx`, `PageLayout.tsx`, ni au module Notifications.
+
+**Nouveau fichier `packages/react/src/components/Layout/components/HeaderNotificationsOverlay.tsx`** :
+```tsx
+import PageLayoutOverlay from '../../PageLayout/components/PageLayoutOverlay';
+import { NotificationListContainer } from '../../../modules/homepage/components/Notifications/NotificationListContainer';
+import { useOverlay } from '../../PageLayout/hook/useOverlay';
+
+const HeaderNotificationsOverlay = () => {
+  const { isOverlayOpen, updateOverlayOpen } = useOverlay();
+  const handleClose = () => updateOverlayOpen(false);
+
+  return (
+    <PageLayoutOverlay onClose={handleClose}>
+      {/* monté seulement à l'ouverture : pas de fetch tant que le panneau n'a jamais été ouvert */}
+      {isOverlayOpen && (
+        <NotificationListContainer onCloseNotifications={handleClose} />
+      )}
+    </PageLayoutOverlay>
+  );
+};
+
+HeaderNotificationsOverlay.displayName = 'Layout.HeaderNotificationsOverlay';
+
+export default HeaderNotificationsOverlay;
+```
+
+**`packages/react/src/components/Layout/Layout.tsx`** — deux ajouts, dans le prolongement du switch déjà posé en Phase 1 :
+```tsx
+import { Alert, Button, useOverlay } from '..'; // useOverlay ajouté à l'import existant
+import HeaderNotificationsOverlay from './components/HeaderNotificationsOverlay';
+// …
+export const Layout = ({ children, headless = false, ... }: LayoutProps) => {
+  const { theme } = useEdificeTheme();
+  const override = useUiOverride('layout.header');
+  const { toggleOverlay } = useOverlay();
+  const isHeaderV2 = override?.variant === 'v2';
+  // …
+  const renderHeader = !headless ? (
+    isHeaderV2 ? (
+      <Suspense fallback={null}>
+        <HeaderV2
+          src={theme?.basePath}
+          dataProduct={override?.theme}
+          onNotificationsClick={toggleOverlay}
+        />
+      </Suspense>
+    ) : (
+      <Header is1d={theme?.is1d} src={theme?.basePath} />
+    )
+  ) : null;
+
+  const renderNotificationsOverlay = !headless && isHeaderV2 && (
+    <HeaderNotificationsOverlay />
+  );
+
+  return (
+    <>
+      {renderHeader}
+      {renderNotificationsOverlay}
+      <main className={classes} {...restProps}>{children}</main>
+      {/* … reste inchangé … */}
+```
+
+**Zéro impact pour les apps qui n'activent pas l'override** : `isHeaderV2` reste `false`, donc ni l'overlay ni `NotificationListContainer` ne sont montés — le seul changement de comportement possible est pour l'app qui active `layout.header: v2` (aujourd'hui : CRNA, opt-in explicite).
+
+**Filet de sécurité explicite** : `NotificationListContainer` suppose un `QueryClientProvider` déjà monté (vrai pour toute app React moderne, cf. CLAUDE.md — pas de vérification supplémentaire à coder, ce serait de la défense contre un cas qui ne devrait pas arriver). Si la recette CRNA (point 3) révèle un problème bloquant sur ce panneau, le point de repli le plus simple est de ne pas passer `onNotificationsClick`/de ne pas monter `HeaderNotificationsOverlay` — la cloche du Header reste alors visuellement présente mais inactive, sans aucune régression sur l'existant. Pas de code défensif à écrire pour ce cas tant qu'il ne s'est pas produit.
+
+## D. Tests
+
+**Phase 1** — nouveau fichier `packages/react/src/hooks/useUiOverride/useUiOverride.spec.tsx`, suivant la convention établie (mémoire `project_react_hooks_test_pattern`) :
+- `renderHook` depuis `~/setup`, avec `{ wrapper }` (le hook lit un contexte).
+- Mocker `@edifice.io/client` (`vi.hoisted` + `vi.mock('@edifice.io/client', ...)`) pour contrôler `odeServices.conf().getConf(...)` → `theme.uiOverrides`.
+- Cas à couvrir : clé absente → `undefined` ; valeur `string` → `{ variant: string }` ; valeur objet `{ variant, theme }` → passthrough identique.
+
+Pas de nouveau test pour `Layout`/`Header` en Phase 1 (aucun fichier de spec n'existe aujourd'hui pour ces composants, et on ne touche pas à `Header.tsx`) — la vérification du switch visuel est différée en recette (point 3 acté).
+
+**Phase 2** — nouveau fichier `packages/react/src/components/Layout/components/HeaderNotificationsOverlay.spec.tsx` :
+- `isOverlayOpen: false` (store mocké) → `NotificationListContainer` n'est pas monté (pas de requête déclenchée).
+- `isOverlayOpen: true` → `NotificationListContainer` est monté et rendu.
+- Clic sur le bouton de fermeture (`PageLayoutOverlay`) ou `onCloseNotifications` → `updateOverlayOpen(false)` appelé.
+
+Pas de nouveau test pour `Header.tsx`, `PageLayoutOverlay` ni `NotificationListContainer` : ces composants ne sont pas modifiés, leur couverture existante (le cas échéant) reste valable telle quelle.
+
+## Hors scope de ce ticket (explicitement acté avec l'utilisateur)
+
+- La variante "historique Flash" du panneau notifications (`with-flash-history`, plan §6) — arbitrage produit non tranché.
+- Toute restructuration de `Header.tsx` en compound component (`withUiOverride`, `Header.Notifications`) — écartée, cf. point 4 du Contexte.
+- Modification du `theme-conf.js` springboard CRNA — côté Intégration, hors de ce repo.
+- Vérification manuelle du theming scopé sur une vieille app CRNA (plan §10, étape 6) — différée en recette.
+
+## Vérification
+
+1. `pnpm lint` et `pnpm format` à la racine (pré-commit Husky : lint + format + test).
+2. `pnpm test --filter=./packages/react` (specs `useUiOverride` et `HeaderNotificationsOverlay`, suite existante non cassée).
+3. `pnpm build --filter=./packages/client` puis `--filter=./packages/react` (le build doit passer avec les nouveaux champs de types ; l'ordre respecte le graphe de dépendances Turbo).
+4. Test manuel en recette différé (point acté avec l'utilisateur) : activer `uiOverrides: { 'layout.header': { variant: 'v2', theme: 'crna' } }` dans un `theme-conf.js` de test et vérifier (a) le rendu du Header v2 scopé et (b) l'ouverture/fermeture fonctionnelle du panneau de notifications, dans une app encore sur `Layout`.

--- a/UI-OVERRIDES-PLAN.md
+++ b/UI-OVERRIDES-PLAN.md
@@ -1,0 +1,256 @@
+# Plan — Overrides de composants pilotés par le theme-conf
+
+> Objectif : permettre à Intégration d'activer le nouveau Header (et d'autres variantes de composants) **par plateforme**, sans `if CRNA` dans le code, sans modification de controllers, sans nouvelle API publique sur les composants.
+> Principe directeur : **on active par capacité, jamais par identité client** — et le theme-conf de la plateforme est la source unique de vérité.
+
+---
+
+## 1. Contexte
+
+- La généralisation du nouveau Header sur les anciennes apps React est **en roadmap IMPULSION (fin d'année)**, mais Intégration doit livrer CRNA **pour la rentrée** → conflit de **timing**, pas de divergence produit.
+- CRNA consomme **les mêmes versions npm publiques** `@edifice.io/*` que tout le monde → tout code Intégration finit dans `develop` et sur le registre public.
+- Un `if crna` dans `Layout` est refusé : non scalable, non maintenable, nom de client dans un repo public.
+- Le pattern va se reproduire avec d'autres clients → il faut un mécanisme pérenne.
+
+## 2. Constat technique (vérifié dans le code)
+
+- Chaque plateforme sert un asset statique **`/assets/theme-conf.js`** (source : le springboard de la plateforme). Vérifié en prod CRNA : `https://mon.lyceeconnecte.fr/assets/theme-conf.js` (entrée `child: "na"`).
+- `@edifice.io/client` le charge via `odeServices.conf().getConf(appCode)` (`configure/Service.ts` → `getThemeConf()`), et construit `IOdeTheme` exposé par `EdificeThemeProvider` / `useEdificeTheme()` — **déjà monté à la racine de toutes les apps React** (dont `timeline/frontend` et `timeline/frontend-crna`).
+- **L'entrée `overriding` est résolue par utilisateur, pas par plateforme** : `getTheme()` fait `conf.overriding.find(e => e.child === theme.themeName)` où `/theme` reflète la préférence/le degré de l'utilisateur. Une plateforme mixte a deux entrées (1D + 2D), la préférence tranche ; une plateforme mono-degré n'en a qu'une. → le cas « 1D/2D paramétré par l'utilisateur » est déjà géré, tout champ ajouté à l'entrée en hérite gratuitement.
+- Le conf prod CRNA contient déjà un champ ad-hoc hors typage (`legacyVersion: "na"`) → étendre une entrée est une pratique établie et sans risque.
+- Précédent historique : le système d'overrides de templates par skin d'entcore (`Theme.templateOverrides`). Ce plan en est le successeur React.
+- `data-product` est aujourd'hui posé à **deux endroits** : dynamiquement sur `<html>` par `EdificeThemeProvider` (dérivé du dernier segment de `bootstrapVersion` → `"neo"` sur CRNA prod), et **forcé en dur** sur `<body>` dans `timeline/frontend/homepage.html` (`edifice2d`) et `timeline/frontend-crna/homepage-crna.html` (`crna`). Fragile → à unifier via la conf.
+
+## 3. La mécanique de theming existante (package bootstrap)
+
+Tout ce dont on a besoin côté CSS existe déjà dans `packages/bootstrap/src/themes/` :
+
+| Attribut DOM | Rôle | Source (conf) | Exemples |
+| --- | --- | --- | --- |
+| `data-product` | **Le thème** (scope de variables CSS émis par `theme-vars()`) | `bootstrapVersion` (dernier segment) | `neo`, `one`, `edifice1d`, `edifice2d`, `crna` |
+| `data-theme` | **La variation / le sous-thème** au sein d'un thème | `npmTheme ?? themeName` | `na`, `cg77`, `monlycee` |
+| `data-skin` | Le skin choisi par l'utilisateur | `skinName` | `default`, `dyslexic`, `desert`… |
+
+Faits structurants (`_theme-api.scss`) :
+
+- **Tous les thèmes sont égaux** : `edifice2d`, `edifice1d` et `crna` sont déclarés à l'identique (`theme-vars('<name>', $config)` → variables sous `[data-product='<name>']`). Il n'y a pas de différence de nature entre un thème produit et un thème client — `neo` et `one` sont des portages transitoires des anciens thèmes, voués à disparaître.
+- **Les sous-thèmes existent** : `theme-variant($product, $variant, $config)` → `[data-product='X'][data-theme='Y']`. Pas encore utilisé (exemples commentés dans les `_variants.scss`), mais le contrat est prêt.
+- **La variation client par `data-theme` est déjà pratiquée** sur les anciens thèmes : `_overrides.scss` contient `[data-product='neo'][data-theme='na']` (branding CRNA actuel), `[data-theme='cg77']`, `[data-theme='monlycee']`…
+- **Un thème se scope spatialement** : un thème n'étant qu'un scope de custom properties, poser `data-product="crna"` sur la racine d'un sous-arbre applique le thème à ce sous-arbre seulement (les variables cascadent), pendant que le reste de la page reste résolu par le `data-product` du `<html>`. C'est ce que font déjà — en dur — les `<body data-product>` des templates timeline.
+
+→ Conséquence : **aucun nouvel attribut ni champ de conf n'est nécessaire pour le CSS.** Le besoin « header stylisé `crna` dans une app stylisée `neo` » = du theming scopé par sous-arbre, piloté par la conf (§4/§6).
+
+## 4. Exemple de conf finale (entrée CRNA dans `theme-conf.js`)
+
+```js
+exports.conf = {
+  overriding: [
+    {
+      parent: 'theme-open-ent',
+      child: 'na',
+      skins: ['default', 'dyslexic'],
+      bootstrapVersion: 'ode-bootstrap-neo', // inchangé : l'app reste en neo (+ branding [data-theme='na'] existant)
+      help: '/help-2d',
+      edumedia: { /* … */ },
+
+      // NOUVEAU — variantes de composants activées sur cette plateforme.
+      // Clés = capacités définies par le framework. Valeurs = variantes PRODUIT
+      // (string), ou objet enrichi si le sous-arbre doit porter un thème scopé.
+      // Aucun nom de client dans le code : la "crna-itude" ne vit qu'ici.
+      uiOverrides: {
+        'layout.header': { variant: 'v2', theme: 'crna' },
+        'notifications.panel': 'with-flash-history',
+      },
+    },
+    // Plateforme mixte : une 2e entrée (parent: 'panda', …) sélectionnée par la
+    // préférence utilisateur — chaque entrée peut avoir ses propres uiOverrides.
+  ],
+};
+```
+
+## 5. Changements par brique
+
+### `@edifice.io/client` (PR 1 — additive, pas de breaking change)
+
+```ts
+// interfaces.ts
+export type UiOverride = string | { variant: string; theme?: string };
+
+export interface IThemeConfOverriding {
+  // … champs existants …
+  uiOverrides?: Record<string, UiOverride>;
+}
+```
+
+```ts
+// Service.ts — getTheme() fait déjà le lookup de l'entrée courante (par utilisateur)
+return {
+  // … champs existants …
+  uiOverrides: themeOverride?.uiOverrides,
+};
+```
+
+### `@edifice.io/react` (PR 2)
+
+Hook de confort qui normalise la valeur :
+
+```ts
+export function useUiOverride(key: string) {
+  const { theme } = useEdificeTheme();
+  const raw = theme?.uiOverrides?.[key];
+  return typeof raw === 'string' ? { variant: raw } : raw; // { variant, theme? } | undefined
+}
+```
+
+### Springboard CRNA (Intégration)
+
+Une ligne dans `assets/theme-conf.js` de la plateforme. Activation/rollback = édition d'un asset, sans release ni redéploiement d'apps.
+
+## 6. Usage dans les composants (illustratif)
+
+### `Layout` — switch interne, API publique inchangée
+
+```tsx
+const HeaderV2 = lazy(() => import('./components/HeaderV2'));
+
+export const Layout = ({ children, headless = false, ...props }: LayoutProps) => {
+  const { theme } = useEdificeTheme();
+  const override = useUiOverride('layout.header');
+
+  const renderHeader = !headless ? (
+    override?.variant === 'v2' ? (
+      <Suspense fallback={null}>
+        <HeaderV2 />
+      </Suspense>
+    ) : (
+      <Header is1d={theme?.is1d} src={theme?.basePath} />
+    )
+  ) : null;
+
+  return (
+    <>
+      {renderHeader}
+      <main>{children}</main>
+    </>
+  );
+};
+```
+
+### Thème scopé au sous-arbre — le header en `crna` dans une app en `neo`
+
+```tsx
+export const HeaderV2 = () => {
+  const override = useUiOverride('layout.header');
+
+  return (
+    // Si la conf fournit un thème, le sous-arbre le porte ; sinon il hérite
+    // du data-product de la page. Valeur issue de la conf, jamais en dur.
+    <header data-product={override?.theme}>
+      {/* … */}
+    </header>
+  );
+};
+```
+
+### `Notifications` — même mécanisme pour l'historique Flash
+
+```tsx
+export const NotificationsPanel = () => {
+  const override = useUiOverride('notifications.panel');
+
+  return (
+    <Panel>
+      <NotificationsList />
+      {override?.variant === 'with-flash-history' && <FlashMessagesHistory />}
+    </Panel>
+  );
+};
+```
+
+> ⚠️ Prérequis : `FlashMessagesHistory` doit être du **code produit** (PR reviewée dans `packages/react`). Si le produit refuse la feature, l'override ne peut rien — il faudra un vrai slot + code externe. → arbitrage produit à lancer.
+
+## 7. Overrides complets ou partiels via compound components
+
+Le switch de variante (§6) remplace un composant **en entier**. Pour les besoins plus fins — remplacer *une partie* d'un composant sans dupliquer le reste — la mécanique **compound** s'articule naturellement avec `uiOverrides` :
+
+### Principe
+
+Un composant compound expose ses sous-parties ; chaque sous-partie peut résoudre sa propre clé d'override. La granularité des clés suit la structure compound :
+
+```js
+uiOverrides: {
+  'layout.header': { variant: 'v2', theme: 'crna' },   // override COMPLET : tout le Header
+  'header.notifications': 'with-flash-history',        // override PARTIEL : seulement la cloche
+}
+```
+
+Convention de résolution : **la clé la plus fine gagne** (une variante partielle s'applique à l'intérieur de la variante complète active).
+
+### Illustration
+
+```tsx
+// Assemblage compound par défaut (interne au framework)
+export const HeaderV2 = () => (
+  <HeaderV2.Root>
+    <HeaderV2.Logo />
+    <HeaderV2.Search />
+    <HeaderV2.Notifications />   {/* résout sa propre clé */}
+    <HeaderV2.UserMenu />
+  </HeaderV2.Root>
+);
+
+// Helper générique : une sous-partie déclare ses variantes produit
+HeaderV2.Notifications = withUiOverride('header.notifications', {
+  default: NotificationsBell,
+  'with-flash-history': NotificationsBellWithFlash,
+});
+```
+
+```tsx
+// Le helper (illustratif)
+export function withUiOverride(
+  key: string,
+  variants: Record<string, ComponentType>,
+) {
+  return function Overridable(props) {
+    const override = useUiOverride(key);
+    const Component = variants[override?.variant ?? 'default'] ?? variants.default;
+    return <Component {...props} />;
+  };
+}
+```
+
+Bénéfice : `NotificationsBellWithFlash` peut lui-même réutiliser les sous-parties par défaut et ne réécrire que ce qui change — pas de fork du composant entier.
+
+### Quand rendre un composant compound ?
+
+- **Pas d'anticipation systématique** (YAGNI) : on découpe en compound quand un besoin réel d'override partiel se présente. Le refactoring est non-breaking tant que l'export par défaut garde la même API.
+- Les nouveaux composants structurants (Header v2, panneau Notifications) ont vocation à naître compound — c'est le bon moment puisqu'ils sont en cours de développement.
+- Chaque sous-partie overridable = une clé documentée, même gouvernance qu'au §8 (créée par l'équipe framework, variantes produit uniquement, durée de vie déclarée).
+
+## 8. Garde-fous
+
+- **Seule l'équipe framework crée des clés d'override** ; une clé ne référence que du code produit (roadmap ou généralisé) présent dans le package.
+- Chaque clé a une **durée de vie déclarée** : `layout.header` meurt quand le Header v2 devient le défaut. C'est un mécanisme de **transition/rollout**, pas de customisation permanente.
+- Les variantes ont leurs **stories Storybook** (→ Chromatic).
+- Frontière visuel/comportement : le **CSS** client passe par les thèmes bootstrap (`data-product`/`data-theme`, y compris scopés à un sous-arbre), le **comportement** passe par les variantes produit + `uiOverrides`. Jamais de nom de client dans le TS/TSX.
+- (Plus tard) lint CI : grep des noms de clients dans le code TS/TSX du framework.
+
+## 9. Points de vigilance
+
+- **Theming scopé et sélecteurs descendants** : les variables cascadent proprement dans le sous-arbre, mais les règles du type `[data-product='crna'] .xxx { … }` matchent aussi tous les descendants du scope. Les overrides « composant » d'un thème destiné au scoping (dossier `crna/overrides/`) doivent rester ciblés — c'est déjà leur style d'écriture, à maintenir.
+- **Modélisation du thème `crna` à terme** (équipe bootstrap, non urgent) : quand CRNA migrera sur le nouveau DS, garder `crna` en thème complet, ou le redéclarer en **sous-thème** d'`edifice2d` via `theme-variant('edifice2d', 'crna', …)` (partage des tokens, seules les couleurs surchargées, sélecteur `[data-product='edifice2d'][data-theme='crna']`). Les deux sont supportés par l'API telle quelle.
+- **Accès public** : `getTheme()` a un cas particulier (fix WB2-2660) qui force le thème neo hors connexion → vérifier le comportement attendu des overrides sur les pages publiques.
+- **Déploiement** : les apps doivent monter sur une version du FF contenant le mécanisme (simple bump de dépendance, pas de modif de code app).
+- **Nettoyage (dette)** : supprimer à terme les `<body data-product>` en dur dans `homepage.html` / `homepage-crna.html` — le theming scopé piloté par la conf les remplace.
+- **`develop-integration`** (FF et entcore) : mêmes versions npm ⇒ ces branches doivent converger ; le travail de découplage du Header (panneau Notifications notamment) se fait en PRs sur `develop`, sous review framework/IMPULSION.
+
+## 10. Plan d'action
+
+1. [ ] PR `@edifice.io/client` : type `UiOverride` + champ `uiOverrides` (types + passthrough `getTheme()`).
+2. [ ] PR `@edifice.io/react` : hook `useUiOverride` (+ helper `withUiOverride`) + switch lazy dans `Layout` + thème scopé sur la racine de `HeaderV2`.
+3. [ ] Chantier Intégration (PRs produit sur `develop`, sous review) : découpler `HeaderV2` de la homepage (panneau Notifications accessible partout), en le faisant naître **compound** (§7).
+4. [ ] Intégration : `uiOverrides` dans le theme-conf du springboard CRNA ; CRNA = première plateforme opt-in.
+5. [ ] Arbitrage produit : historique des messages Flash (variante produit vs refus → slot).
+6. [ ] Vérifier le rendu du theming scopé (header `crna` / app `neo`) sur 1–2 vieilles apps CRNA, y compris le cas accès public (WB2-2660).
+7. [ ] Fin d'année : IMPULSION réutilise le même mécanisme pour son rollout progressif ; bascule du défaut, mort de la clé `layout.header` ; décision thème complet vs sous-thème pour `crna` sur le nouveau DS.

--- a/packages/client/src/ts/configure/Service.ts
+++ b/packages/client/src/ts/configure/Service.ts
@@ -165,6 +165,7 @@ export class ConfService {
       themeName: themeOverride?.child,
       themeUrl,
       npmTheme: themeOverride?.npmTheme ?? undefined,
+      uiOverrides: themeOverride?.uiOverrides,
     };
   }
 

--- a/packages/client/src/ts/configure/interfaces.ts
+++ b/packages/client/src/ts/configure/interfaces.ts
@@ -176,6 +176,9 @@ export interface IThemeConf {
   overriding: Array<IThemeConfOverriding>;
 }
 
+/** A UI override is either a plain variant name, or an object enriching it with a scoped theme. */
+export type UiOverride = string | { variant: string; theme?: string };
+
 //-------------------------------------
 export interface IThemeConfOverriding {
   //-------------------------------------
@@ -190,6 +193,7 @@ export interface IThemeConfOverriding {
     pattern: string;
     ignoreSubjects?: Array<string>;
   };
+  uiOverrides?: Record<string, UiOverride>;
 }
 
 export type IThemeOverrides = {
@@ -243,6 +247,7 @@ export interface IOdeTheme {
   themeName: string;
   themeUrl: string;
   npmTheme: string | undefined;
+  uiOverrides?: Record<string, UiOverride>;
 }
 
 export interface IGetConf {

--- a/packages/react/src/components/Layout/Layout.stories.tsx
+++ b/packages/react/src/components/Layout/Layout.stories.tsx
@@ -1,0 +1,86 @@
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { http, HttpResponse } from 'msw';
+
+import Layout from './Layout';
+
+const meta: Meta<typeof Layout> = {
+  title: 'Layout/Layout',
+  component: Layout,
+  args: {
+    children: <div className="p-24">Page content</div>,
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Legacy portal layout: renders the header, main content area, cookies banner and toaster. Which header it renders is driven by the `uiOverrides` mechanism from the platform theme-conf — see the `HeaderV2` story.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Layout>;
+
+/**
+ * Default legacy header (`components/Layout/components/Header`).
+ */
+export const Default: Story = {};
+
+/**
+ * `theme-conf.js` registers `uiOverrides: { 'layout.header': { variant: 'v2', theme: 'crna' } }`
+ * on the matching platform entry: `Layout` switches to the new Header
+ * (`modules/homepage/components/Header`) and mounts the Notifications overlay
+ * behind the bell icon — click it to open the panel.
+ */
+export const HeaderV2: Story = {
+  parameters: {
+    msw: {
+      // Keyed object form so Storybook deep-merges with the global handlers
+      // (see Header.stories.tsx). The `theme` key bundles BOTH the `/theme`
+      // and `/assets/theme-conf.js` routes as one array — the merge replaces
+      // the whole key, so both must be repeated here (not just the one route
+      // we actually want to change), otherwise `/theme` falls through to a 404.
+      handlers: {
+        theme: [
+          http.get('/theme', () =>
+            HttpResponse.json({
+              template: '/public/template/portal.html',
+              logoutCallback: '',
+              skin: '/assets/skins/default/',
+              themeName: 'cg77',
+              skinName: 'default',
+            }),
+          ),
+          http.get('/assets/theme-conf.js', () =>
+            HttpResponse.json({
+              overriding: [
+                {
+                  parent: 'theme-open-ent',
+                  child: 'cg77',
+                  skins: ['default', 'dyslexic'],
+                  help: '/help-2d',
+                  bootstrapVersion: 'ode-bootstrap-one',
+                  edumedia: {
+                    uri: 'https://www.edumedia-sciences.com',
+                    pattern: 'uai-token-hash-[[uai]]',
+                    ignoreSubjects: ['n-92', 'n-93'],
+                  },
+                  uiOverrides: {
+                    'layout.header': { variant: 'v2', theme: 'crna' },
+                  },
+                },
+              ],
+            }),
+          ),
+        ],
+      },
+    },
+    docs: {
+      description: {
+        story:
+          'The Notifications panel uses the real `NotificationListContainer` (list content mocked via the global MSW handlers).',
+      },
+    },
+  },
+};

--- a/packages/react/src/components/Layout/Layout.tsx
+++ b/packages/react/src/components/Layout/Layout.tsx
@@ -1,14 +1,25 @@
-import { ComponentPropsWithoutRef, type ReactNode } from 'react';
+import {
+  ComponentPropsWithoutRef,
+  Suspense,
+  lazy,
+  type ReactNode,
+} from 'react';
 
 import clsx from 'clsx';
 import { Toaster } from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
 import { Alert, Button } from '..';
-import { useCantoo, useZendeskGuide } from '../../hooks';
+import { useCantoo, useUiOverride, useZendeskGuide } from '../../hooks';
 import { useCookiesConsent } from '../../hooks/useCookiesConsent';
 import { useEdificeTheme } from '../../providers/EdificeThemeProvider/EdificeThemeProvider.hook';
 import Header from './components/Header';
+import HeaderNotificationsOverlay from './components/HeaderNotificationsOverlay';
+import { useOverlay } from '../PageLayout/hook/useOverlay';
+
+const HeaderV2 = lazy(
+  () => import('../../modules/homepage/components/Header/Header'),
+);
 
 export interface LayoutProps extends ComponentPropsWithoutRef<any> {
   /**  Main content of an application */
@@ -29,6 +40,9 @@ export const Layout = ({
   ...restProps
 }: LayoutProps) => {
   const { theme } = useEdificeTheme();
+  const override = useUiOverride('layout.header');
+  const isHeaderV2 = override?.variant === 'v2';
+  const { toggleOverlay } = useOverlay();
 
   const { t } = useTranslation();
 
@@ -54,8 +68,22 @@ export const Layout = ({
   );
 
   const renderHeader = !headless ? (
-    <Header is1d={theme?.is1d} src={theme?.basePath} />
+    isHeaderV2 ? (
+      <Suspense fallback={null}>
+        <HeaderV2
+          src={theme?.basePath}
+          dataProduct={override?.theme}
+          onNotificationsClick={toggleOverlay}
+        />
+      </Suspense>
+    ) : (
+      <Header is1d={theme?.is1d} src={theme?.basePath} />
+    )
   ) : null;
+
+  const renderNotificationsOverlay = !headless && isHeaderV2 && (
+    <HeaderNotificationsOverlay />
+  );
 
   const renderCookies = showCookiesConsent && (
     <Alert
@@ -86,6 +114,7 @@ export const Layout = ({
   return (
     <>
       {renderHeader}
+      {renderNotificationsOverlay}
 
       <main className={classes} {...restProps}>
         {children}

--- a/packages/react/src/components/Layout/components/HeaderNotificationsOverlay.spec.tsx
+++ b/packages/react/src/components/Layout/components/HeaderNotificationsOverlay.spec.tsx
@@ -1,0 +1,52 @@
+import { act, render, screen } from '~/setup';
+
+import { useOverlayStore } from '../../PageLayout/store/overlayStore';
+import HeaderNotificationsOverlay from './HeaderNotificationsOverlay';
+
+vi.mock(
+  '../../../modules/homepage/components/Notifications/NotificationListContainer',
+  () => ({
+    NotificationListContainer: ({
+      onCloseNotifications,
+    }: {
+      onCloseNotifications?: () => void;
+    }) => (
+      <div data-testid="notification-list-container">
+        <button onClick={onCloseNotifications}>close-from-list</button>
+      </div>
+    ),
+  }),
+);
+
+afterEach(() => {
+  useOverlayStore.setState({ overlayOpen: false });
+});
+
+describe('HeaderNotificationsOverlay', () => {
+  it('does not mount NotificationListContainer while the overlay is closed', () => {
+    render(<HeaderNotificationsOverlay />);
+
+    expect(
+      screen.queryByTestId('notification-list-container'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('mounts NotificationListContainer once the overlay is open', () => {
+    act(() => useOverlayStore.setState({ overlayOpen: true }));
+
+    render(<HeaderNotificationsOverlay />);
+
+    expect(
+      screen.getByTestId('notification-list-container'),
+    ).toBeInTheDocument();
+  });
+
+  it('closes the overlay when NotificationListContainer requests it', async () => {
+    act(() => useOverlayStore.setState({ overlayOpen: true }));
+    const { user } = render(<HeaderNotificationsOverlay />);
+
+    await user.click(screen.getByText('close-from-list'));
+
+    expect(useOverlayStore.getState().overlayOpen).toBe(false);
+  });
+});

--- a/packages/react/src/components/Layout/components/HeaderNotificationsOverlay.tsx
+++ b/packages/react/src/components/Layout/components/HeaderNotificationsOverlay.tsx
@@ -1,0 +1,22 @@
+import { NotificationListContainer } from '../../../modules/homepage/components/Notifications/NotificationListContainer';
+import PageLayoutOverlay from '../../PageLayout/components/PageLayoutOverlay';
+import { useOverlay } from '../../PageLayout/hook/useOverlay';
+
+const HeaderNotificationsOverlay = () => {
+  const { isOverlayOpen, updateOverlayOpen } = useOverlay();
+  const handleClose = () => updateOverlayOpen(false);
+
+  return (
+    // NotificationList renders its own header with a close button, so
+    // PageLayoutOverlay's default close button would be redundant (double X).
+    <PageLayoutOverlay onClose={handleClose} closeButton={false}>
+      {isOverlayOpen && (
+        <NotificationListContainer onCloseNotifications={handleClose} />
+      )}
+    </PageLayoutOverlay>
+  );
+};
+
+HeaderNotificationsOverlay.displayName = 'Layout.HeaderNotificationsOverlay';
+
+export default HeaderNotificationsOverlay;

--- a/packages/react/src/hooks/index.ts
+++ b/packages/react/src/hooks/index.ts
@@ -30,6 +30,7 @@ export * from './useToast';
 export * from './useToggle';
 export * from './useTrapFocus';
 export * from './useTrashedResource';
+export * from './useUiOverride';
 export * from './useUpload';
 export * from './useUploadFiles';
 export * from './useUser';

--- a/packages/react/src/hooks/useUiOverride/index.ts
+++ b/packages/react/src/hooks/useUiOverride/index.ts
@@ -1,0 +1,1 @@
+export { default as useUiOverride } from './useUiOverride';

--- a/packages/react/src/hooks/useUiOverride/useUiOverride.spec.tsx
+++ b/packages/react/src/hooks/useUiOverride/useUiOverride.spec.tsx
@@ -1,0 +1,44 @@
+import { type ReactNode } from 'react';
+
+import { renderHook } from '~/setup';
+
+import { EdificeThemeContext } from '../../providers/EdificeThemeProvider/EdificeThemeProvider.context';
+import useUiOverride from './useUiOverride';
+
+const themeWrapper = (uiOverrides?: Record<string, unknown>) => {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <EdificeThemeContext.Provider value={{ theme: { uiOverrides } as any }}>
+        {children}
+      </EdificeThemeContext.Provider>
+    );
+  };
+};
+
+describe('useUiOverride', () => {
+  it('returns undefined when the key is absent from uiOverrides', () => {
+    const { result } = renderHook(() => useUiOverride('layout.header'), {
+      wrapper: themeWrapper({}),
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('normalizes a string override to { variant }', () => {
+    const { result } = renderHook(() => useUiOverride('notifications.panel'), {
+      wrapper: themeWrapper({ 'notifications.panel': 'with-flash-history' }),
+    });
+
+    expect(result.current).toEqual({ variant: 'with-flash-history' });
+  });
+
+  it('passes through an object override untouched', () => {
+    const { result } = renderHook(() => useUiOverride('layout.header'), {
+      wrapper: themeWrapper({
+        'layout.header': { variant: 'v2', theme: 'crna' },
+      }),
+    });
+
+    expect(result.current).toEqual({ variant: 'v2', theme: 'crna' });
+  });
+});

--- a/packages/react/src/hooks/useUiOverride/useUiOverride.ts
+++ b/packages/react/src/hooks/useUiOverride/useUiOverride.ts
@@ -1,0 +1,8 @@
+import { useEdificeTheme } from '../../providers/EdificeThemeProvider/EdificeThemeProvider.hook';
+
+/** Read the platform-driven UI override registered under `key` in the theme-conf, normalized to an object form. */
+export default function useUiOverride(key: string) {
+  const { theme } = useEdificeTheme();
+  const raw = theme?.uiOverrides?.[key];
+  return typeof raw === 'string' ? { variant: raw } : raw;
+}

--- a/packages/react/src/modules/homepage/components/Header/Header.tsx
+++ b/packages/react/src/modules/homepage/components/Header/Header.tsx
@@ -35,11 +35,14 @@ import {
 export interface HeaderProps {
   src: string | undefined;
   onNotificationsClick?: () => void;
+  /** Scope this header's CSS theme (`data-product`) to its own subtree, independently of the page's ambient theme. */
+  dataProduct?: string;
 }
 
 const Header = ({
   src = '',
   onNotificationsClick,
+  dataProduct,
 }: HeaderProps): JSX.Element => {
   const { t } = useTranslation();
   const { messages } = useConversation();
@@ -73,7 +76,7 @@ const Header = ({
   };
 
   return (
-    <header className={classes}>
+    <header className={classes} data-product={dataProduct}>
       <Navbar className="px-24">
         <LogoBeta src={`${src}/img/illustrations/logo.png`} />
         <ul className="navbar-nav">


### PR DESCRIPTION
# Description

Met en place le mécanisme `uiOverrides` piloté par le `theme-conf` de plateforme (cf. `UI-OVERRIDES-PLAN.md` / `UI-OVERRIDES-IMPLEMENTATION-PLAN.md`), pour permettre à une plateforme d'activer le nouveau Header (celui de `modules/homepage`) sur les anciennes apps qui utilisent encore `Layout`, sans `if <client>` dans le code et sans nouvelle API publique sur les composants.

Objectif : permettre à Intégration d'activer le nouveau Header sur CRNA pour la rentrée, en attendant la généralisation portée par IMPULSION.

(Remplace #535, fermée suite à un renommage de branche qui a cassé son lien tête/PR.)

## Changements

- **`@edifice.io/client`** : type `UiOverride` + champ `uiOverrides` sur `IThemeConfOverriding`/`IOdeTheme`, passthrough additif dans `ConfService.getTheme()`.
- **`@edifice.io/react`** :
  - Nouveau hook `useUiOverride(key)` (normalise la valeur de la conf en `{ variant, theme? }`).
  - `Layout` bascule vers le Header existant de `modules/homepage` (lazy) quand `uiOverrides['layout.header'].variant === 'v2'`, avec theming scopé via une nouvelle prop optionnelle `dataProduct` sur ce Header (additive, sans impact sur son usage actuel dans `PageLayout.Header`).
  - Nouveau `HeaderNotificationsOverlay` : rend le panneau de notifications fonctionnel sur `Layout` en réutilisant tel quel `useOverlay`, `PageLayoutOverlay` et `NotificationListContainer` (aucune modification de ces composants).
  - Story `Layout` (`Default` / `HeaderV2`) pour visualiser/tester le switch dans Storybook.

## Which Package changed?

- [x] Components
- [x] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

- [x] New feature (MINOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Test plan

- [x] `pnpm lint`, `pnpm format`, `pnpm test --filter=./packages/react` et `--filter=./packages/client` : verts.
- [x] `pnpm build --filter=./packages/client --filter=./packages/react` : passe.
- [x] Vérifié visuellement dans Storybook (`Layout/Layout` → `HeaderV2`) : switch de Header, ouverture/fermeture du panneau de notifications (bouton + Escape).
- [ ] Vérification en recette CRNA (theming scopé, cas accès public WB2-2660) — différée, hors scope de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)