### PR TITLE
fix(release): #ENABLING-1118 restreint git describe aux tags semver dans publish.sh

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -59,7 +59,6 @@ publish () {
   # unrelated release trains sharing this repo's tag namespace (e.g.
   # impact-analyzer-viewer-v*.*.*) can never be picked as the nearest tag.
   LATEST_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "1.0.0")
-  LATEST_TAG=${LATEST_TAG#v}
 
   # Définition du tag de la branche
   if [ "$LOCAL_BRANCH" = "main" ]; then

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -55,7 +55,10 @@ publish () {
   # Récupération de la date et du timestamp
   TIMESTAMP=`date +%Y%m%d%H%M%S`
   # Récupération du dernier tag stable
-  LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "1.0.0")
+  # --match restricts candidates to bare semver tags (2.6.0-style), so
+  # unrelated release trains sharing this repo's tag namespace (e.g.
+  # impact-analyzer-viewer-v*.*.*) can never be picked as the nearest tag.
+  LATEST_TAG=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' 2>/dev/null || echo "1.0.0")
   LATEST_TAG=${LATEST_TAG#v}
 
   # Définition du tag de la branche


### PR DESCRIPTION
# Description

Le pipeline Jenkins de publish (`scripts/publish.sh`, stage *Publish* du `Jenkinsfile`) calcule la version à publier via `git describe --tags --abbrev=0`. Ce repo héberge aussi les tags `impact-analyzer-viewer-v*.*.*` (release Docker du viewer impact-analyzer, sur les mêmes commits que `develop-enabling`). Une fois un tel tag poussé, il devient le tag le plus proche par ancestry et supplante le vrai dernier tag semver de package (ex. `2.6.0`).

Résultat observé : `LATEST_TAG` valait `impact-analyzer-viewer-v0.1.3` au lieu de `2.6.0`, `NEW_VERSION` devenait une chaîne invalide, et `npm version` la rejetait (`Invalid version`) — ce qui faisait échouer tout le stage Publish pour `develop-enabling` et toute branche descendante.

Le fix restreint `git describe` aux tags semver bruts via `--match '[0-9]*.[0-9]*.[0-9]*'`, même filtre que celui déjà utilisé dans `.github/workflows/impact-analyzer-generate.yml` pour la même raison.

Ticket : [ENABLING-1118](https://edifice-community.atlassian.net/browse/ENABLING-1118)

## Which Package changed?

Ni un package `@edifice.io/*` ni Storybook — script de build/release (`scripts/publish.sh`, utilisé par le `Jenkinsfile`).

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Comment tester

1. `git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*' origin/develop-enabling` doit retourner `2.6.0` (pas `impact-analyzer-viewer-v0.1.3`).
2. Un `npm version "2.6.0-develop-enabling.<timestamp>" --no-git-tag-version` sur un package quelconque doit réussir (pas de "Invalid version").

[ENABLING-1118]: https://edifice-community.atlassian.net/browse/ENABLING-1118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ