### PR TITLE
test: #ENABLING-991 add unit tests to @edifice.io/react (lot 8)

### DIFF
--- a/packages/react/src/components/Combobox/Combobox.spec.tsx
+++ b/packages/react/src/components/Combobox/Combobox.spec.tsx
@@ -1,0 +1,149 @@
+import { ChangeEvent, useState } from 'react';
+
+import { createRef } from 'react';
+import { render, screen, waitFor } from '~/setup';
+import Combobox, { ComboboxRef, OptionListItemType } from './Combobox';
+
+const allOptions: OptionListItemType[] = [
+  { value: 'first', label: 'First Item' },
+  { value: 'second', label: 'Second Item' },
+  { value: 'third', label: 'Third Item' },
+];
+
+function getInput() {
+  return screen.getByTestId('combobox-search-input');
+}
+
+function ControlledCombobox({
+  onSearchResultsChange,
+  comboboxRef,
+}: {
+  onSearchResultsChange?: (model: (string | number)[]) => void;
+  comboboxRef?: React.Ref<ComboboxRef>;
+}) {
+  const [value, setValue] = useState('');
+  const [options, setOptions] = useState<OptionListItemType[]>([]);
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setValue(event.target.value);
+    setOptions(
+      allOptions.filter((option) =>
+        (option.label ?? '')
+          .toLowerCase()
+          .includes(event.target.value.toLowerCase()),
+      ),
+    );
+  };
+
+  return (
+    <Combobox
+      ref={comboboxRef}
+      value={value}
+      options={options}
+      isLoading={false}
+      noResult={value.length >= 3 && options.length === 0}
+      onSearchInputChange={handleChange}
+      onSearchResultsChange={onSearchResultsChange}
+      placeholder="Rechercher…"
+    />
+  );
+}
+
+describe('Combobox', () => {
+  it('displays the placeholder', () => {
+    render(<ControlledCombobox />);
+
+    expect(getInput()).toHaveAttribute('placeholder', 'Rechercher…');
+  });
+
+  it('shows the loading indicator when isLoading is true', () => {
+    render(
+      <Combobox
+        value="abc"
+        options={[]}
+        isLoading
+        noResult={false}
+        onSearchInputChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('explorer.search.pending')).toBeInTheDocument();
+  });
+
+  it('shows the default no-result message', async () => {
+    const { user } = render(<ControlledCombobox />);
+
+    await user.type(getInput(), 'zzz');
+
+    await waitFor(() => {
+      expect(screen.getByText('portal.no.result')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a custom no-result message via renderNoResult', () => {
+    render(
+      <Combobox
+        value="zzz"
+        options={[]}
+        isLoading={false}
+        noResult
+        onSearchInputChange={vi.fn()}
+        renderNoResult={<div>Aucun résultat personnalisé</div>}
+      />,
+    );
+
+    expect(screen.getByText('Aucun résultat personnalisé')).toBeInTheDocument();
+  });
+
+  it('filters and displays matching options as the user types', async () => {
+    const { user } = render(<ControlledCombobox />);
+
+    await user.type(getInput(), 'sec');
+
+    await waitFor(() => {
+      expect(screen.getByText('Second Item')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('First Item')).not.toBeInTheDocument();
+  });
+
+  it('selects an option on click and reports it via onSearchResultsChange', async () => {
+    const onSearchResultsChange = vi.fn();
+    const { user } = render(
+      <ControlledCombobox onSearchResultsChange={onSearchResultsChange} />,
+    );
+
+    await user.type(getInput(), 'First');
+    await waitFor(() => {
+      expect(screen.getByText('First Item')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('First Item'));
+
+    expect(onSearchResultsChange).toHaveBeenCalledWith(['first']);
+  });
+
+  it('clears the input value when the dropdown closes', async () => {
+    const { user } = render(<ControlledCombobox />);
+
+    const input = getInput();
+    await user.type(input, 'sec');
+    await waitFor(() => {
+      expect(screen.getByText('Second Item')).toBeInTheDocument();
+    });
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() => {
+      expect(input).toHaveValue('');
+    });
+  });
+
+  it('exposes an imperative focus() via ComboboxRef', () => {
+    const ref = createRef<ComboboxRef>();
+    render(<ControlledCombobox comboboxRef={ref} />);
+
+    ref.current?.focus();
+
+    expect(getInput()).toHaveFocus();
+  });
+});

--- a/packages/react/src/components/Dropdown/Dropdown.spec.tsx
+++ b/packages/react/src/components/Dropdown/Dropdown.spec.tsx
@@ -1,0 +1,143 @@
+import { createRef } from 'react';
+import { act, render, screen } from '~/setup';
+import Dropdown, { DropdownApi } from './Dropdown';
+
+function getTrigger() {
+  return screen.getByRole('button', { name: /menu/i });
+}
+
+function BasicDropdown({
+  onToggle,
+  refDropdown,
+  onItemClick,
+}: {
+  onToggle?: (visible: boolean) => void;
+  refDropdown?: React.Ref<DropdownApi>;
+  onItemClick?: (item: string) => void;
+} = {}) {
+  return (
+    <Dropdown ref={refDropdown} onToggle={onToggle}>
+      <Dropdown.Trigger label="Menu" />
+      <Dropdown.Menu>
+        <Dropdown.Item type="action" onClick={() => onItemClick?.('Item 1')}>
+          Item 1
+        </Dropdown.Item>
+        <Dropdown.Item type="action" onClick={() => onItemClick?.('Item 2')}>
+          Item 2
+        </Dropdown.Item>
+        <Dropdown.Item type="action" onClick={() => onItemClick?.('Item 3')}>
+          Item 3
+        </Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}
+
+describe('Dropdown', () => {
+  it('renders the menu closed by default', () => {
+    render(<BasicDropdown />);
+
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  it('opens the menu on trigger click', async () => {
+    const { user } = render(<BasicDropdown />);
+
+    await user.click(getTrigger());
+
+    expect(screen.getAllByRole('menuitem')).toHaveLength(3);
+  });
+
+  it('closes the menu when clicking outside', async () => {
+    const { user } = render(
+      <div>
+        <BasicDropdown />
+        <button>Outside</button>
+      </div>,
+    );
+
+    await user.click(getTrigger());
+    expect(screen.getAllByRole('menuitem')).toHaveLength(3);
+
+    await user.click(screen.getByRole('button', { name: 'Outside' }));
+
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  it('opens on ArrowDown and moves focus between items with the arrow keys', async () => {
+    const { user } = render(<BasicDropdown />);
+    getTrigger().focus();
+
+    await user.keyboard('{ArrowDown}');
+    const items = screen.getAllByRole('menuitem');
+    expect(items[0]).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(items[1]).toHaveFocus();
+
+    await user.keyboard('{ArrowUp}');
+    expect(items[0]).toHaveFocus();
+  });
+
+  it('jumps to the first/last item with Home/End', async () => {
+    const { user } = render(<BasicDropdown />);
+    getTrigger().focus();
+    await user.keyboard('{ArrowDown}');
+    const items = screen.getAllByRole('menuitem');
+
+    await user.keyboard('{End}');
+    expect(items[2]).toHaveFocus();
+
+    await user.keyboard('{Home}');
+    expect(items[0]).toHaveFocus();
+  });
+
+  it('activates the focused item on Enter, closing the dropdown and refocusing the trigger', async () => {
+    const onItemClick = vi.fn();
+    const { user } = render(<BasicDropdown onItemClick={onItemClick} />);
+    const trigger = getTrigger();
+    trigger.focus();
+
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+
+    expect(onItemClick).toHaveBeenCalledWith('Item 1');
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('closes on Escape and refocuses the trigger', async () => {
+    const { user } = render(<BasicDropdown />);
+    const trigger = getTrigger();
+
+    await user.click(trigger);
+    expect(screen.getAllByRole('menuitem')).toHaveLength(3);
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('calls onToggle whenever visibility changes', async () => {
+    const onToggle = vi.fn();
+    const { user } = render(<BasicDropdown onToggle={onToggle} />);
+
+    await user.click(getTrigger());
+
+    expect(onToggle).toHaveBeenCalledWith(true);
+  });
+
+  it('exposes an imperative API via ref', () => {
+    const ref = createRef<DropdownApi>();
+    render(<BasicDropdown refDropdown={ref} />);
+
+    expect(ref.current?.visible).toBe(false);
+
+    act(() => ref.current?.openDropdown());
+    expect(ref.current?.visible).toBe(true);
+
+    act(() => ref.current?.closeDropdown());
+    expect(ref.current?.visible).toBe(false);
+  });
+});

--- a/packages/react/src/components/Menu/Menu.spec.tsx
+++ b/packages/react/src/components/Menu/Menu.spec.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '~/setup';
+import { Menu } from './components/Menu';
+
+function BasicMenu({ onClick }: { onClick?: (item: string) => void } = {}) {
+  return (
+    <Menu label="Navigation">
+      <Menu.Item>
+        <Menu.Button selected={false} onClick={() => onClick?.('Item 1')}>
+          Item 1
+        </Menu.Button>
+      </Menu.Item>
+      <Menu.Item>
+        <Menu.Button selected={false} onClick={() => onClick?.('Item 2')}>
+          Item 2
+        </Menu.Button>
+      </Menu.Item>
+      <Menu.Item>
+        <Menu.Button selected={false} onClick={() => onClick?.('Item 3')}>
+          Item 3
+        </Menu.Button>
+      </Menu.Item>
+    </Menu>
+  );
+}
+
+describe('Menu', () => {
+  it('renders a labelled nav with a menubar and its items', () => {
+    render(<BasicMenu />);
+
+    expect(
+      screen.getByRole('navigation', { name: 'Navigation' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menubar', { name: 'Navigation' }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByRole('menuitem')).toHaveLength(3);
+  });
+
+  it('calls onClick when a menu button is clicked', async () => {
+    const onClick = vi.fn();
+    const { user } = render(<BasicMenu onClick={onClick} />);
+
+    await user.click(screen.getByRole('menuitem', { name: 'Item 2' }));
+
+    expect(onClick).toHaveBeenCalledWith('Item 2');
+  });
+
+  it('marks a selected item with the selected class', () => {
+    render(
+      <Menu label="Navigation">
+        <Menu.Item>
+          <Menu.Button selected>Active</Menu.Button>
+        </Menu.Item>
+      </Menu>,
+    );
+
+    expect(screen.getByRole('menuitem', { name: 'Active' })).toHaveClass(
+      'selected',
+    );
+  });
+
+  it('moves focus to the next item on ArrowDown, wrapping after the last', async () => {
+    const { user } = render(<BasicMenu />);
+    const items = screen.getAllByRole('menuitem');
+
+    items[0].focus();
+    await user.keyboard('{ArrowDown}');
+    expect(items[1]).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(items[2]).toHaveFocus();
+
+    await user.keyboard('{ArrowDown}');
+    expect(items[0]).toHaveFocus();
+  });
+
+  it('moves focus to the previous item on ArrowUp, wrapping before the first', async () => {
+    const { user } = render(<BasicMenu />);
+    const items = screen.getAllByRole('menuitem');
+
+    items[0].focus();
+    await user.keyboard('{ArrowUp}');
+    expect(items[2]).toHaveFocus();
+
+    await user.keyboard('{ArrowUp}');
+    expect(items[1]).toHaveFocus();
+  });
+
+  it('jumps to the first/last item with Home/End', async () => {
+    const { user } = render(<BasicMenu />);
+    const items = screen.getAllByRole('menuitem');
+
+    items[0].focus();
+    await user.keyboard('{End}');
+    expect(items[2]).toHaveFocus();
+
+    await user.keyboard('{Home}');
+    expect(items[0]).toHaveFocus();
+  });
+});

--- a/packages/react/src/components/Modal/Modal.spec.tsx
+++ b/packages/react/src/components/Modal/Modal.spec.tsx
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+
+import { fireEvent, render, screen } from '~/setup';
+import Modal from './Modal';
+
+function OpenableModal({
+  focusId,
+  onClose,
+}: {
+  focusId?: string;
+  onClose?: () => void;
+} = {}) {
+  const [isOpen, setIsOpen] = useState(true);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    onClose?.();
+  };
+
+  return (
+    <>
+      {isOpen && (
+        <Modal
+          id="test-modal"
+          isOpen={isOpen}
+          onModalClose={handleClose}
+          focusId={focusId}
+        >
+          <Modal.Header onModalClose={handleClose}>Modal title</Modal.Header>
+          <Modal.Body>
+            <button id="action-button">Action</button>
+          </Modal.Body>
+        </Modal>
+      )}
+    </>
+  );
+}
+
+function getCloseButton() {
+  return document.querySelector('.btn-close') as HTMLElement;
+}
+
+describe('Modal', () => {
+  it('does not render when isOpen is false', () => {
+    render(
+      <Modal id="closed-modal" isOpen={false} onModalClose={vi.fn()}>
+        <Modal.Body>Content</Modal.Body>
+      </Modal>,
+    );
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('renders the dialog with its content when isOpen is true', () => {
+    render(<OpenableModal />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(screen.getByText('Modal title')).toBeInTheDocument();
+  });
+
+  it('focuses the close button by default', () => {
+    render(<OpenableModal />);
+
+    expect(document.activeElement).toBe(getCloseButton());
+  });
+
+  it('focuses the element referenced by focusId instead of the close button', () => {
+    render(<OpenableModal focusId="action-button" />);
+
+    expect(document.activeElement).toHaveAttribute('id', 'action-button');
+  });
+
+  it('calls onModalClose when the header close button is clicked', async () => {
+    const onClose = vi.fn();
+    const { user } = render(<OpenableModal onClose={onClose} />);
+
+    await user.click(getCloseButton());
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onModalClose on Escape', () => {
+    const onClose = vi.fn();
+    render(<OpenableModal onClose={onClose} />);
+
+    fireEvent.keyDown(window, { key: 'Escape', code: 'Escape' });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onModalClose when clicking outside the dialog', () => {
+    const onClose = vi.fn();
+    render(<OpenableModal onClose={onClose} />);
+
+    fireEvent.mouseDown(document.body);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('traps focus inside the dialog, wrapping Tab/Shift+Tab between first and last elements', () => {
+    render(<OpenableModal />);
+
+    const dialogContent = document.getElementById(
+      'test-modal_ref',
+    ) as HTMLElement;
+    const closeButton = getCloseButton();
+    const actionButton = screen.getByText('Action');
+
+    expect(document.activeElement).toBe(closeButton);
+
+    fireEvent.keyDown(dialogContent, { key: 'Tab', shiftKey: true });
+    expect(document.activeElement).toBe(actionButton);
+
+    fireEvent.keyDown(dialogContent, { key: 'Tab' });
+    expect(document.activeElement).toBe(closeButton);
+  });
+});

--- a/packages/react/src/components/Popover/Popover.spec.tsx
+++ b/packages/react/src/components/Popover/Popover.spec.tsx
@@ -1,0 +1,66 @@
+import { createRef } from 'react';
+import { render, screen } from '~/setup';
+import { Popover, PopoverBody, PopoverFooter, PopoverHeader } from './Popover';
+
+describe('Popover', () => {
+  it('does not render when isVisible is false', () => {
+    render(
+      <Popover id="popover" isVisible={false}>
+        Content
+      </Popover>,
+    );
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('does not render when isVisible is omitted', () => {
+    render(<Popover id="popover">Content</Popover>);
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('renders its content when isVisible is true', () => {
+    render(
+      <Popover id="popover" isVisible>
+        Content
+      </Popover>,
+    );
+
+    const popover = screen.getByRole('tooltip');
+    expect(popover).toBeInTheDocument();
+    expect(popover).toHaveAttribute('aria-labelledby', 'popover');
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('renders Header, Body and Footer subcomponents', () => {
+    render(
+      <Popover id="popover" isVisible>
+        <PopoverHeader>Title</PopoverHeader>
+        <PopoverBody>Body text</PopoverBody>
+        <PopoverFooter>Footer text</PopoverFooter>
+      </Popover>,
+    );
+
+    expect(screen.getByText('Title').closest('div')).toHaveClass(
+      'popover-header',
+    );
+    expect(screen.getByText('Body text').closest('div')).toHaveClass(
+      'popover-body',
+    );
+    expect(screen.getByText('Footer text').closest('div')).toHaveClass(
+      'popover-footer',
+    );
+  });
+
+  it('forwards a ref to the root element', () => {
+    const ref = createRef<HTMLDivElement>();
+    render(
+      <Popover id="popover" isVisible ref={ref}>
+        Content
+      </Popover>,
+    );
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current).toHaveAttribute('role', 'tooltip');
+  });
+});

--- a/packages/react/src/components/Select/Select.spec.tsx
+++ b/packages/react/src/components/Select/Select.spec.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '~/setup';
+import Select, { OptionsType } from './Select';
+
+const options: OptionsType[] = [
+  { value: 'artActivity', label: 'Activités artistiques' },
+  { value: 'chemistry', label: 'Chimie' },
+  { value: 'law', label: 'Droit' },
+];
+
+function getTrigger() {
+  return screen.getByRole('combobox');
+}
+
+describe('Select', () => {
+  it('displays the placeholder option when nothing is selected', () => {
+    render(<Select options={options} placeholderOption="Choisir…" />);
+
+    expect(getTrigger()).toHaveTextContent('Choisir…');
+  });
+
+  it('opens the menu and lists every option on trigger click', async () => {
+    const { user } = render(
+      <Select options={options} placeholderOption="Choisir…" />,
+    );
+
+    await user.click(getTrigger());
+
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+    options.forEach((option) => {
+      expect(screen.getByText(option.label)).toBeInTheDocument();
+    });
+  });
+
+  it('selects an option on click, updates the trigger label and closes the menu', async () => {
+    const onValueChange = vi.fn();
+    const { user } = render(
+      <Select
+        options={options}
+        placeholderOption="Choisir…"
+        onValueChange={onValueChange}
+      />,
+    );
+
+    await user.click(getTrigger());
+    await user.click(screen.getByText('Chimie'));
+
+    expect(onValueChange).toHaveBeenCalledWith('chemistry');
+    expect(getTrigger()).toHaveTextContent('Chimie');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('opens the menu on ArrowDown and selects the focused option on Enter', async () => {
+    const onValueChange = vi.fn();
+    const { user } = render(
+      <Select
+        options={options}
+        placeholderOption="Choisir…"
+        onValueChange={onValueChange}
+      />,
+    );
+
+    getTrigger().focus();
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Enter}');
+
+    expect(onValueChange).toHaveBeenCalledWith('chemistry');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('closes the menu on Escape and refocuses the trigger', async () => {
+    const { user } = render(
+      <Select options={options} placeholderOption="Choisir…" />,
+    );
+
+    await user.click(getTrigger());
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    expect(getTrigger()).toHaveFocus();
+  });
+
+  it('respects the controlled selectedValue prop', () => {
+    render(
+      <Select
+        options={options}
+        placeholderOption="Choisir…"
+        selectedValue={options[2]}
+      />,
+    );
+
+    expect(getTrigger()).toHaveTextContent('Droit');
+  });
+
+  it('preselects the option matching defaultValue', () => {
+    render(
+      <Select
+        options={options}
+        placeholderOption="Choisir…"
+        defaultValue="law"
+      />,
+    );
+
+    expect(getTrigger()).toHaveTextContent('Droit');
+  });
+});

--- a/packages/react/src/components/Stepper/Stepper.spec.tsx
+++ b/packages/react/src/components/Stepper/Stepper.spec.tsx
@@ -1,0 +1,37 @@
+import { render } from '~/setup';
+import Stepper from './Stepper';
+
+describe('Stepper', () => {
+  it('renders one step element per nbSteps', () => {
+    const { container } = render(<Stepper currentStep={0} nbSteps={4} />);
+
+    expect(container.querySelectorAll('.step')).toHaveLength(4);
+  });
+
+  it('marks the currentStep as active', () => {
+    const { container } = render(<Stepper currentStep={2} nbSteps={4} />);
+
+    const steps = container.querySelectorAll('.step');
+    expect(steps[2]).toHaveClass('step-active', 'bg-secondary');
+    expect(steps[0]).not.toHaveClass('step-active');
+    expect(steps[0]).toHaveClass('bg-secondary-300');
+  });
+
+  it('applies the color prop to the active step', () => {
+    const { container } = render(
+      <Stepper currentStep={0} nbSteps={2} color="primary" />,
+    );
+
+    const steps = container.querySelectorAll('.step');
+    expect(steps[0]).toHaveClass('bg-primary', 'step-active');
+    expect(steps[1]).toHaveClass('bg-primary-300');
+  });
+
+  it('forwards a ref to the underlying container', () => {
+    const ref = { current: null } as React.RefObject<HTMLDivElement>;
+    render(<Stepper ref={ref} currentStep={0} nbSteps={3} />);
+
+    expect(ref.current).not.toBeNull();
+    expect(ref.current?.querySelectorAll('.step')).toHaveLength(3);
+  });
+});

--- a/packages/react/src/components/Tabs/Tabs.spec.tsx
+++ b/packages/react/src/components/Tabs/Tabs.spec.tsx
@@ -1,0 +1,77 @@
+import { render, screen } from '~/setup';
+import Tabs from './components/Tabs';
+import { TabsItemProps } from './components/TabsItem';
+
+const items: TabsItemProps[] = [
+  { id: 'one', icon: null, label: 'One', content: <div>Content one</div> },
+  { id: 'two', icon: null, label: 'Two', content: <div>Content two</div> },
+  {
+    id: 'three',
+    icon: null,
+    label: 'Three',
+    content: <div>Content three</div>,
+  },
+];
+
+function getTab(name: string) {
+  return screen.getByRole('tab', { name });
+}
+
+describe('Tabs', () => {
+  it('renders the tab list and the default panel content', () => {
+    render(<Tabs defaultId="one" items={items} />);
+
+    expect(screen.getByRole('tablist')).toBeInTheDocument();
+    expect(getTab('One')).toHaveAttribute('aria-selected', 'true');
+    expect(getTab('Two')).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByText('Content one')).toBeInTheDocument();
+  });
+
+  it('only gives tabIndex 0 to the active tab (roving tabindex)', () => {
+    render(<Tabs defaultId="one" items={items} />);
+
+    expect(getTab('One')).toHaveAttribute('tabindex', '0');
+    expect(getTab('Two')).toHaveAttribute('tabindex', '-1');
+    expect(getTab('Three')).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('switches tab and calls onChange when clicking another tab', async () => {
+    const onChange = vi.fn();
+    const { user } = render(
+      <Tabs defaultId="one" items={items} onChange={onChange} />,
+    );
+
+    await user.click(getTab('Two'));
+
+    expect(getTab('Two')).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByText('Content two')).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'two' }),
+    );
+  });
+
+  it('moves to the next/previous tab with ArrowRight/ArrowLeft, wrapping at the ends', async () => {
+    const { user } = render(<Tabs defaultId="one" items={items} />);
+
+    getTab('One').focus();
+    await user.keyboard('{ArrowLeft}');
+    expect(getTab('Three')).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{ArrowRight}');
+    expect(getTab('One')).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{ArrowRight}');
+    expect(getTab('Two')).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('jumps to the first/last tab with Home/End', async () => {
+    const { user } = render(<Tabs defaultId="two" items={items} />);
+
+    getTab('Two').focus();
+    await user.keyboard('{End}');
+    expect(getTab('Three')).toHaveAttribute('aria-selected', 'true');
+
+    await user.keyboard('{Home}');
+    expect(getTab('One')).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/packages/react/src/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/react/src/components/Tooltip/Tooltip.spec.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '~/setup';
+import Tooltip from './Tooltip';
+
+describe('Tooltip', () => {
+  it('always renders the trigger children', () => {
+    render(
+      <Tooltip message="Some help text">
+        <button>Trigger</button>
+      </Tooltip>,
+    );
+
+    expect(screen.getByText('Trigger')).toBeInTheDocument();
+  });
+
+  it('does not show the message before hovering', () => {
+    render(
+      <Tooltip message="Some help text">
+        <button>Trigger</button>
+      </Tooltip>,
+    );
+
+    expect(screen.queryByText('Some help text')).not.toBeInTheDocument();
+  });
+
+  it('shows the message on hover and hides it when the pointer leaves', async () => {
+    const { user } = render(
+      <Tooltip message="Some help text">
+        <button>Trigger</button>
+      </Tooltip>,
+    );
+
+    await user.hover(screen.getByText('Trigger'));
+    expect(screen.getByText('Some help text')).toBeInTheDocument();
+
+    await user.unhover(screen.getByText('Trigger'));
+    expect(screen.queryByText('Some help text')).not.toBeInTheDocument();
+  });
+
+  it('renders the icon next to the message when visible', async () => {
+    const { user } = render(
+      <Tooltip message="Some help text" icon={<span>icon</span>}>
+        <button>Trigger</button>
+      </Tooltip>,
+    );
+
+    await user.hover(screen.getByText('Trigger'));
+
+    expect(screen.getByText('icon')).toBeInTheDocument();
+    expect(screen.getByText('Some help text')).toBeInTheDocument();
+  });
+
+  it('never displays a tooltip body when message is undefined', async () => {
+    const { user, container } = render(
+      <Tooltip message={undefined}>
+        <button>Trigger</button>
+      </Tooltip>,
+    );
+
+    await user.hover(screen.getByText('Trigger'));
+
+    expect(container.querySelector('.tooltip-inner')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Contexte

[ENABLING-991](https://edifice-community.atlassian.net/browse/ENABLING-991) — Lot 8 de l'amorçage de couverture de tests du package `@edifice.io/react` (suite de ENABLING-931 à 990). Complémentaire : aucune cible ne recouvre celles des autres lots.

Ce lot cible les **composants interactifs et overlays**, dont les cibles explicitement nommées par l'audit (finding 5.1) : interactions clavier de `Select`/`Combobox`/`Dropdown`. Tous les candidats prioritaires du ticket ont été traités.

## Changements

9 fichiers de specs, **57 tests** — aucune modification de code de prod.

| Catégorie | Cibles | Tests |
|---|---|---|
| Sélection & combobox (audit 5.1) | `Select`, `Combobox`, `Dropdown` | 24 |
| Menus & onglets | `Menu`, `Tabs`, `Stepper` | 15 |
| Overlays | `Tooltip`, `Popover`, `Modal` | 18 |

## Choix techniques

- Interactions via `userEvent` (`const { user } = render(...)` depuis `~/setup`), assertions comportementales plutôt que markup exact.
- `Select`/`Combobox`/`Dropdown` : ouverture/fermeture (clic, clavier), navigation clavier (flèches, Home/End, Enter, Échap), clic extérieur, refocus du trigger à la fermeture ; `ComboboxRef.focus()` et `DropdownApi` (ref impérative) couverts.
- `Modal` : Échap et clic extérieur ferment la modale, trap focus (Tab/Shift+Tab boucle entre premier et dernier élément focusable), focus par défaut sur le bouton de fermeture ou sur `focusId`.
- `Menu` : navigation clavier à tabindex roulant (roving tabindex — flèches avec wrap, Home/End).
- `Tabs` : changement d'onglet au clic et au clavier (flèches avec wrap, Home/End), roving tabindex, callback `onChange`.
- `Tooltip`/`Popover` : rendu conditionnel (survol pour `Tooltip`, prop `isVisible` pour `Popover`), pas de mock nécessaire (jsdom gère `@floating-ui`/`react-popper`/`react-spring` sans polyfill supplémentaire ici).
- `Stepper` : composant purement présentationnel, tests sur le rendu des steps et l'état actif.

## Recette / Risque

Risque faible — ajout de tests uniquement, pas de changement d'API publique. Tests déterministes : pas de timers réels, pas de dépendance réseau non mockée. Suite complète du package verte (59 fichiers / 353 tests). Lint et format conformes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENABLING-991]: https://edifice-community.atlassian.net/browse/ENABLING-991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ