### PR TITLE
test: #ENABLING-994 add unit tests to @edifice.io/react (lot 10)

### DIFF
--- a/packages/react/src/hooks/useConversation/useConversation.spec.tsx
+++ b/packages/react/src/hooks/useConversation/useConversation.spec.tsx
@@ -1,0 +1,152 @@
+import { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '~/setup';
+import useConversation from './useConversation';
+
+const { hasWorkflowRight, get } = vi.hoisted(() => ({
+  hasWorkflowRight: vi.fn(),
+  get: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    rights: () => ({ sessionHasWorkflowRight: hasWorkflowRight }),
+    http: () => ({ get }),
+  },
+}));
+
+// Each test gets its own QueryClient to avoid cache pollution from the
+// module-level singleton used by the shared MockedProvider.
+function createWrapper() {
+  const queryClient = new QueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+function mockGet(overrides: Record<string, unknown>) {
+  get.mockImplementation(async (url: string) => {
+    if (url in overrides) return overrides[url];
+    throw new Error(`unexpected url: ${url}`);
+  });
+}
+
+describe('useConversation', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts with 0 messages and resolves the count once the query settles', async () => {
+    hasWorkflowRight.mockResolvedValue(false);
+    mockGet({
+      '/conversation/api/count/inbox': { count: 3 },
+      '/userbook/preference/zimbra': { preference: null },
+    });
+
+    const { result } = renderHook(() => useConversation(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.messages).toBe(0);
+
+    await waitFor(() => expect(result.current.messages).toBe(3));
+  });
+
+  it('always fetches the count from the conversation endpoint on mount, even when zimbraWorkflow later resolves true (existing behavior)', async () => {
+    // The count query has no `enabled` gate and runs on mount, when
+    // zimbraWorkflow is still undefined (useHasWorkflow resolves
+    // asynchronously) — so it always reads the conversation endpoint on
+    // first mount. Since the queryKey never changes, React Query does not
+    // re-run it once zimbraWorkflow later resolves to true.
+    hasWorkflowRight.mockResolvedValue(true);
+    mockGet({
+      '/conversation/api/count/inbox': { count: 5 },
+      '/zimbra/count/INBOX': { count: 999 },
+      '/userbook/preference/zimbra': { preference: null },
+    });
+
+    const { result } = renderHook(() => useConversation(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.messages).toBe(5));
+    await waitFor(() => expect(result.current.zimbraWorkflow).toBe(true));
+    expect(get).not.toHaveBeenCalledWith(
+      '/zimbra/count/INBOX',
+      expect.anything(),
+    );
+  });
+
+  it('falls back to the default zimbra link when not in expert mode', async () => {
+    hasWorkflowRight.mockResolvedValue(false);
+    mockGet({
+      '/conversation/api/count/inbox': { count: 0 },
+      '/userbook/preference/zimbra': {
+        preference: JSON.stringify({ modeExpert: false }),
+      },
+    });
+
+    const { result } = renderHook(() => useConversation(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.msgLink).toBe(
+        window.location.origin + '/zimbra/zimbra',
+      ),
+    );
+  });
+
+  it('never reaches the preauth link, even in expert mode with preauth allowed (existing behavior)', async () => {
+    // goToMessagerie runs once on mount (effect with an empty dependency
+    // array) and closes over zimbraPreauth's value at that time, which is
+    // still undefined (useHasWorkflow resolves asynchronously). Because that
+    // closure is never recreated, `isExpertMode && zimbraPreauth` always
+    // reads a stale falsy zimbraPreauth, so the preauth branch is
+    // effectively unreachable regardless of what it resolves to afterwards.
+    hasWorkflowRight.mockResolvedValue(true);
+    mockGet({
+      '/conversation/api/count/inbox': { count: 0 },
+      '/zimbra/count/INBOX': { count: 0 },
+      '/userbook/preference/zimbra': {
+        preference: JSON.stringify({ modeExpert: true }),
+      },
+    });
+
+    const { result } = renderHook(() => useConversation(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.msgLink).toBe(
+        window.location.origin + '/zimbra/zimbra',
+      ),
+    );
+  });
+
+  it('falls back to the default link when the preference request fails', async () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    hasWorkflowRight.mockResolvedValue(false);
+    get.mockImplementation(async (url: string) => {
+      if (url === '/conversation/api/count/inbox') return { count: 0 };
+      throw new Error('boom');
+    });
+
+    const { result } = renderHook(() => useConversation(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.msgLink).toBe(
+        window.location.origin + '/zimbra/zimbra',
+      ),
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/packages/react/src/hooks/useConversation/useConversation.spec.tsx
+++ b/packages/react/src/hooks/useConversation/useConversation.spec.tsx
@@ -1,7 +1,4 @@
-import { ReactNode } from 'react';
-
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '~/setup';
+import { renderHook, waitFor, wrapper } from '~/setup';
 import useConversation from './useConversation';
 
 const { hasWorkflowRight, get } = vi.hoisted(() => ({
@@ -15,17 +12,6 @@ vi.mock('@edifice.io/client', () => ({
     http: () => ({ get }),
   },
 }));
-
-// Each test gets its own QueryClient to avoid cache pollution from the
-// module-level singleton used by the shared MockedProvider.
-function createWrapper() {
-  const queryClient = new QueryClient();
-  return function Wrapper({ children }: { children: ReactNode }) {
-    return (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-    );
-  };
-}
 
 function mockGet(overrides: Record<string, unknown>) {
   get.mockImplementation(async (url: string) => {
@@ -47,7 +33,7 @@ describe('useConversation', () => {
     });
 
     const { result } = renderHook(() => useConversation(), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     expect(result.current.messages).toBe(0);
@@ -69,7 +55,7 @@ describe('useConversation', () => {
     });
 
     const { result } = renderHook(() => useConversation(), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     await waitFor(() => expect(result.current.messages).toBe(5));
@@ -90,7 +76,7 @@ describe('useConversation', () => {
     });
 
     const { result } = renderHook(() => useConversation(), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     await waitFor(() =>
@@ -117,7 +103,7 @@ describe('useConversation', () => {
     });
 
     const { result } = renderHook(() => useConversation(), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     await waitFor(() =>
@@ -138,7 +124,7 @@ describe('useConversation', () => {
     });
 
     const { result } = renderHook(() => useConversation(), {
-      wrapper: createWrapper(),
+      wrapper,
     });
 
     await waitFor(() =>

--- a/packages/react/src/hooks/useWorkspaceFile/useWorkspaceFile.spec.tsx
+++ b/packages/react/src/hooks/useWorkspaceFile/useWorkspaceFile.spec.tsx
@@ -1,0 +1,149 @@
+import { renderHook } from '~/setup';
+import useWorkspaceFile from './useWorkspaceFile';
+
+const { searchDocuments, updateFile, saveFile, deleteFile } = vi.hoisted(
+  () => ({
+    searchDocuments: vi.fn(),
+    updateFile: vi.fn(),
+    saveFile: vi.fn(),
+    deleteFile: vi.fn(),
+  }),
+);
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    workspace: () => ({
+      searchDocuments,
+      updateFile,
+      saveFile,
+      deleteFile,
+    }),
+  },
+}));
+
+describe('useWorkspaceFile', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createOrUpdate', () => {
+    it('creates a new file when uri is not a workspace document URI', async () => {
+      saveFile.mockResolvedValue({ _id: 'new-id', public: false });
+      const { result } = renderHook(() => useWorkspaceFile());
+
+      const src = await result.current.createOrUpdate({
+        blob: new Blob(['x']),
+        application: 'blog',
+        parentId: 'folder-1',
+      });
+
+      expect(saveFile).toHaveBeenCalledWith(expect.any(Blob), {
+        application: 'blog',
+        parentId: 'folder-1',
+        visibility: undefined,
+      });
+      expect(src).toBe('/workspace/document/new-id');
+    });
+
+    it('uses the public path when the created file is public', async () => {
+      saveFile.mockResolvedValue({ _id: 'new-id', public: true });
+      const { result } = renderHook(() => useWorkspaceFile());
+
+      const src = await result.current.createOrUpdate({
+        blob: new Blob(['x']),
+      });
+
+      expect(src).toBe('/workspace/pub/document/new-id');
+    });
+
+    it('updates the existing file when uri points to a workspace document', async () => {
+      searchDocuments
+        .mockResolvedValueOnce([{ _id: 'abc-123', name: 'old-name.png' }])
+        .mockResolvedValueOnce([
+          { _id: 'abc-123', name: 'old-name.png', public: false },
+        ]);
+      updateFile.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useWorkspaceFile());
+
+      const updated = await result.current.createOrUpdate({
+        blob: new Blob(['x']),
+        uri: '/workspace/document/abc-123',
+        alt: 'new alt',
+        legend: 'new legend',
+      });
+
+      expect(updateFile).toHaveBeenCalledWith('abc-123', expect.any(Blob), {
+        alt: 'new alt',
+        legend: 'new legend',
+        name: 'old-name.png',
+      });
+      expect(updated).toEqual({
+        file: { _id: 'abc-123', name: 'old-name.png', public: false },
+        src: '/workspace/document/abc-123',
+      });
+    });
+
+    it('uses the public path when the updated file is public', async () => {
+      searchDocuments
+        .mockResolvedValueOnce([{ _id: 'abc-123', name: 'old-name.png' }])
+        .mockResolvedValueOnce([
+          { _id: 'abc-123', name: 'old-name.png', public: true },
+        ]);
+      updateFile.mockResolvedValue(undefined);
+      const { result } = renderHook(() => useWorkspaceFile());
+
+      const updated = await result.current.createOrUpdate({
+        blob: new Blob(['x']),
+        uri: '/workspace/document/abc-123',
+      });
+
+      expect(updated.src).toBe('/workspace/pub/document/abc-123');
+    });
+  });
+
+  describe('create', () => {
+    it('saves a file through the workspace service', async () => {
+      const resource = { _id: 'res-1' };
+      saveFile.mockResolvedValue(resource);
+      const { result } = renderHook(() => useWorkspaceFile());
+      const file = new File(['x'], 'a.png', { type: 'image/png' });
+
+      const saved = await result.current.create(file, {
+        application: 'media-library',
+      });
+
+      expect(saveFile).toHaveBeenCalledWith(file, {
+        application: 'media-library',
+      });
+      expect(saved).toBe(resource);
+    });
+  });
+
+  describe('remove', () => {
+    it('deletes a single file wrapped in an array', async () => {
+      const { result } = renderHook(() => useWorkspaceFile());
+      const file = { _id: 'f-1' } as any;
+
+      await result.current.remove(file);
+
+      expect(deleteFile).toHaveBeenCalledWith([file]);
+    });
+
+    it('deletes an array of files as-is', async () => {
+      const { result } = renderHook(() => useWorkspaceFile());
+      const files = [{ _id: 'f-1' }, { _id: 'f-2' }] as any;
+
+      await result.current.remove(files);
+
+      expect(deleteFile).toHaveBeenCalledWith(files);
+    });
+
+    it('is a no-op for an empty array', async () => {
+      const { result } = renderHook(() => useWorkspaceFile());
+
+      await result.current.remove([]);
+
+      expect(deleteFile).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.spec.tsx
+++ b/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.spec.tsx
@@ -1,0 +1,199 @@
+import { ReactNode } from 'react';
+
+import { IUserInfo } from '@edifice.io/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '~/setup';
+import { EdificeClientContext } from '../../providers/EdificeClientProvider/EdificeClientProvider.context';
+import useWorkspaceFolders from './useWorkspaceFolders';
+
+const { listOwnerFolders, listSharedFolders, createFolder } = vi.hoisted(
+  () => ({
+    listOwnerFolders: vi.fn(),
+    listSharedFolders: vi.fn(),
+    createFolder: vi.fn(),
+  }),
+);
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    workspace: () => ({ listOwnerFolders, listSharedFolders, createFolder }),
+  },
+}));
+
+const { toastCustom } = vi.hoisted(() => ({ toastCustom: vi.fn() }));
+vi.mock('react-hot-toast', () => ({
+  default: { custom: toastCustom },
+}));
+
+const user = { userId: 'user-1', groupsIds: ['group-1'] } as IUserInfo;
+
+// Each test gets its own QueryClient + EdificeClientContext to avoid cache
+// pollution from the module-level singleton used by the shared MockedProvider.
+function createWrapper(currentUser: IUserInfo | undefined = user) {
+  const queryClient = new QueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <EdificeClientContext.Provider value={{ user: currentUser } as any}>
+          {children}
+        </EdificeClientContext.Provider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useWorkspaceFolders', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is loading until both owner and shared folders resolve, then merges them', async () => {
+    listOwnerFolders.mockResolvedValue([{ _id: 'owner-1', name: 'Owner 1' }]);
+    listSharedFolders.mockResolvedValue([
+      { _id: 'shared-1', name: 'Shared 1' },
+    ]);
+
+    const { result } = renderHook(() => useWorkspaceFolders(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.folders).toEqual([
+      { _id: 'owner-1', name: 'Owner 1' },
+      { _id: 'shared-1', name: 'Shared 1' },
+    ]);
+  });
+
+  it('adds a newly created owner folder to the folders list', async () => {
+    listOwnerFolders.mockResolvedValue([]);
+    listSharedFolders.mockResolvedValue([]);
+    const newFolder = { _id: 'new-1', name: 'New Folder', isShared: false };
+    createFolder.mockResolvedValue(newFolder);
+
+    const { result } = renderHook(() => useWorkspaceFolders(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.createFolderMutation.mutate({ folderName: 'New Folder' });
+    });
+
+    await waitFor(() =>
+      expect(result.current.createFolderMutation.isSuccess).toBe(true),
+    );
+    expect(result.current.folders).toContainEqual(newFolder);
+  });
+
+  it('adds a newly created shared folder under the shared list', async () => {
+    listOwnerFolders.mockResolvedValue([]);
+    listSharedFolders.mockResolvedValue([]);
+    const newFolder = { _id: 'new-2', name: 'Shared New', isShared: true };
+    createFolder.mockResolvedValue(newFolder);
+
+    const { result } = renderHook(() => useWorkspaceFolders(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.createFolderMutation.mutate({
+        folderName: 'Shared New',
+        folderParentId: 'parent-1',
+      });
+    });
+
+    await waitFor(() =>
+      expect(result.current.createFolderMutation.isSuccess).toBe(true),
+    );
+    expect(result.current.folders).toContainEqual(newFolder);
+    expect(createFolder).toHaveBeenCalledWith('Shared New', 'parent-1');
+  });
+
+  it('shows an error toast when folder creation fails', async () => {
+    listOwnerFolders.mockResolvedValue([]);
+    listSharedFolders.mockResolvedValue([]);
+    createFolder.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useWorkspaceFolders(), {
+      wrapper: createWrapper(),
+    });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.createFolderMutation.mutate({ folderName: 'x' });
+    });
+
+    await waitFor(() =>
+      expect(result.current.createFolderMutation.isError).toBe(true),
+    );
+    expect(toastCustom).toHaveBeenCalled();
+  });
+
+  describe('canCopyFileIntoFolder', () => {
+    it('returns true when the current user owns the folder', async () => {
+      listOwnerFolders.mockResolvedValue([
+        { _id: 'f-1', owner: 'user-1', inheritedShares: [] },
+      ]);
+      listSharedFolders.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useWorkspaceFolders(), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.canCopyFileIntoFolder('f-1')).toBe(true);
+    });
+
+    it('returns true when an inherited share grants the update-document right', async () => {
+      listOwnerFolders.mockResolvedValue([]);
+      listSharedFolders.mockResolvedValue([
+        {
+          _id: 'f-2',
+          owner: 'someone-else',
+          inheritedShares: [
+            {
+              'userId': 'user-1',
+              'org-entcore-workspace-controllers-WorkspaceController|updateDocument': true,
+            },
+          ],
+        },
+      ]);
+
+      const { result } = renderHook(() => useWorkspaceFolders(), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.canCopyFileIntoFolder('f-2')).toBe(true);
+    });
+
+    it('returns false when the user has no matching right or ownership', async () => {
+      listOwnerFolders.mockResolvedValue([]);
+      listSharedFolders.mockResolvedValue([
+        { _id: 'f-3', owner: 'someone-else', inheritedShares: [] },
+      ]);
+
+      const { result } = renderHook(() => useWorkspaceFolders(), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.canCopyFileIntoFolder('f-3')).toBe(false);
+    });
+
+    it('returns false for an unknown folder id', async () => {
+      listOwnerFolders.mockResolvedValue([]);
+      listSharedFolders.mockResolvedValue([]);
+
+      const { result } = renderHook(() => useWorkspaceFolders(), {
+        wrapper: createWrapper(),
+      });
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+      expect(result.current.canCopyFileIntoFolder('missing')).toBe(false);
+    });
+  });
+});

--- a/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.spec.tsx
+++ b/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.spec.tsx
@@ -1,8 +1,7 @@
 import { ReactNode } from 'react';
 
 import { IUserInfo } from '@edifice.io/client';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, renderHook, waitFor } from '~/setup';
+import { renderHook, wrapper as sharedWrapper, act, waitFor } from '~/setup';
 import { EdificeClientContext } from '../../providers/EdificeClientProvider/EdificeClientProvider.context';
 import useWorkspaceFolders from './useWorkspaceFolders';
 
@@ -27,17 +26,17 @@ vi.mock('react-hot-toast', () => ({
 
 const user = { userId: 'user-1', groupsIds: ['group-1'] } as IUserInfo;
 
-// Each test gets its own QueryClient + EdificeClientContext to avoid cache
-// pollution from the module-level singleton used by the shared MockedProvider.
+// Overrides the shared MockedProvider's default user with a controlled one,
+// nested inside it so the QueryClientProvider it already sets up is reused.
 function createWrapper(currentUser: IUserInfo | undefined = user) {
-  const queryClient = new QueryClient();
+  const SharedWrapper = sharedWrapper;
   return function Wrapper({ children }: { children: ReactNode }) {
     return (
-      <QueryClientProvider client={queryClient}>
+      <SharedWrapper>
         <EdificeClientContext.Provider value={{ user: currentUser } as any}>
           {children}
         </EdificeClientContext.Provider>
-      </QueryClientProvider>
+      </SharedWrapper>
     );
   };
 }

--- a/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFoldersTree.spec.tsx
+++ b/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFoldersTree.spec.tsx
@@ -1,0 +1,98 @@
+import { ReactNode } from 'react';
+
+import { IUserInfo, WorkspaceElement } from '@edifice.io/client';
+import { act, renderHook } from '~/setup';
+import { EdificeClientContext } from '../../providers/EdificeClientProvider/EdificeClientProvider.context';
+import useWorkspaceFoldersTree, {
+  WORKSPACE_SHARED_FOLDER_ID,
+  WORKSPACE_USER_FOLDER_ID,
+} from './useWorkspaceFoldersTree';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <EdificeClientContext.Provider
+      value={{ user: { userId: 'user-1' } as IUserInfo } as any}
+    >
+      {children}
+    </EdificeClientContext.Provider>
+  );
+}
+
+const folders = [
+  { _id: 'owner-1', name: 'Owner Folder', isShared: false },
+  { _id: 'owner-2', name: 'Owner Child', isShared: false, eParent: 'owner-1' },
+  { _id: 'shared-1', name: 'Shared Folder', isShared: true },
+] as WorkspaceElement[];
+
+describe('useWorkspaceFoldersTree', () => {
+  it('builds a user root and a shared root, each with its own children', () => {
+    const { result } = renderHook(() => useWorkspaceFoldersTree(folders), {
+      wrapper,
+    });
+
+    const [userRoot, sharedRoot] = result.current.foldersTree;
+    expect(userRoot.id).toBe(WORKSPACE_USER_FOLDER_ID);
+    expect(sharedRoot.id).toBe(WORKSPACE_SHARED_FOLDER_ID);
+    expect(userRoot.children).toHaveLength(1);
+    expect(userRoot.children?.[0]).toEqual(
+      expect.objectContaining({ id: 'owner-1', name: 'Owner Folder' }),
+    );
+    expect(sharedRoot.children).toEqual([
+      expect.objectContaining({ id: 'shared-1', name: 'Shared Folder' }),
+    ]);
+  });
+
+  it('nests a folder under its parent via eParent', () => {
+    const { result } = renderHook(() => useWorkspaceFoldersTree(folders), {
+      wrapper,
+    });
+
+    const [userRoot] = result.current.foldersTree;
+    expect(userRoot.children?.[0].children).toEqual([
+      expect.objectContaining({ id: 'owner-2', name: 'Owner Child' }),
+    ]);
+  });
+
+  it('builds empty roots when no folders are given', () => {
+    const { result } = renderHook(() => useWorkspaceFoldersTree(undefined), {
+      wrapper,
+    });
+
+    const [userRoot, sharedRoot] = result.current.foldersTree;
+    expect(userRoot.children).toEqual([]);
+    expect(sharedRoot.children).toEqual([]);
+  });
+
+  it('filters the tree by name, keeping ancestors of matching descendants', () => {
+    const { result, rerender } = renderHook(
+      () => useWorkspaceFoldersTree(folders),
+      { wrapper },
+    );
+
+    act(() => result.current.filterTree('child'));
+    rerender();
+
+    const [userRoot] = result.current.foldersTree;
+    expect(userRoot.children).toHaveLength(1);
+    expect(userRoot.children?.[0].id).toBe('owner-1');
+    expect(userRoot.children?.[0].children).toEqual([
+      expect.objectContaining({ id: 'owner-2' }),
+    ]);
+  });
+
+  it('returns the full tree again once the search query is cleared', () => {
+    const { result, rerender } = renderHook(
+      () => useWorkspaceFoldersTree(folders),
+      { wrapper },
+    );
+
+    act(() => result.current.filterTree('child'));
+    rerender();
+    act(() => result.current.filterTree(''));
+    rerender();
+
+    const [userRoot, sharedRoot] = result.current.foldersTree;
+    expect(userRoot.children).toHaveLength(1);
+    expect(sharedRoot.children).toHaveLength(1);
+  });
+});

--- a/packages/react/src/hooks/useWorkspaceSearch/useWorkspaceSearch.spec.tsx
+++ b/packages/react/src/hooks/useWorkspaceSearch/useWorkspaceSearch.spec.tsx
@@ -1,0 +1,182 @@
+import { act, renderHook, waitFor } from '~/setup';
+import useWorkspaceSearch from './useWorkspaceSearch';
+
+const { hasWorkflowRight, listDocuments } = vi.hoisted(() => ({
+  hasWorkflowRight: vi.fn(),
+  listDocuments: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    odeServices: {
+      rights: () => ({ sessionHasWorkflowRight: hasWorkflowRight }),
+      workspace: () => ({ listDocuments }),
+    },
+  };
+});
+
+function image(id: string, name: string) {
+  return {
+    _id: id,
+    name,
+    eType: 'file',
+    metadata: { 'content-type': 'image/png' },
+  };
+}
+
+function pdf(id: string, name: string) {
+  return {
+    _id: id,
+    name,
+    eType: 'file',
+    metadata: { 'content-type': 'application/pdf' },
+  };
+}
+
+function folder(id: string, name: string) {
+  return { _id: id, name, eType: 'folder' };
+}
+
+async function renderReady(format: any = null) {
+  hasWorkflowRight.mockResolvedValue(true);
+  const utils = renderHook(() =>
+    useWorkspaceSearch('root-id', 'Root', 'all' as any, format),
+  );
+  await waitFor(() => expect(hasWorkflowRight).toHaveBeenCalledTimes(2));
+  return utils;
+}
+
+describe('useWorkspaceSearch', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does nothing while the workflow rights have not resolved yet', async () => {
+    hasWorkflowRight.mockReturnValue(new Promise(() => {}));
+    listDocuments.mockResolvedValue([folder('f-1', 'Folder 1')]);
+
+    const { result } = renderHook(() =>
+      useWorkspaceSearch('root-id', 'Root', 'all' as any, null),
+    );
+
+    act(() => {
+      result.current.loadContent('root-id');
+    });
+
+    expect(listDocuments).not.toHaveBeenCalled();
+    expect(result.current.root.children).toBeUndefined();
+  });
+
+  it('does nothing when one of the two workflow rights resolves false', async () => {
+    hasWorkflowRight.mockImplementation((workflow: string) =>
+      Promise.resolve(workflow.endsWith('listDocuments')),
+    );
+    listDocuments.mockResolvedValue([folder('f-1', 'Folder 1')]);
+
+    const { result } = renderHook(() =>
+      useWorkspaceSearch('root-id', 'Root', 'all' as any, null),
+    );
+    await waitFor(() => expect(hasWorkflowRight).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      result.current.loadContent('root-id');
+    });
+
+    expect(listDocuments).not.toHaveBeenCalled();
+  });
+
+  it('loads the root content, splitting subfolders and files', async () => {
+    listDocuments.mockResolvedValue([
+      folder('folder-1', 'Folder 1'),
+      pdf('file-1', 'report.pdf'),
+    ]);
+
+    const { result } = await renderReady();
+
+    await act(async () => {
+      await result.current.loadContent('root-id');
+    });
+
+    expect(listDocuments).toHaveBeenCalledWith('all', '');
+    expect(result.current.root.children).toEqual([
+      { id: 'folder-1', name: 'Folder 1' },
+    ]);
+    expect(result.current.root.files).toEqual([pdf('file-1', 'report.pdf')]);
+  });
+
+  it('loads a nested folder content under the matching tree node', async () => {
+    listDocuments
+      .mockResolvedValueOnce([folder('folder-1', 'Folder 1')])
+      .mockResolvedValueOnce([pdf('file-2', 'nested.pdf')]);
+
+    const { result } = await renderReady();
+
+    await act(async () => {
+      await result.current.loadContent('root-id');
+    });
+    await act(async () => {
+      await result.current.loadContent('folder-1');
+    });
+
+    expect(listDocuments).toHaveBeenLastCalledWith('all', 'folder-1');
+    expect(result.current.root.children?.[0]).toEqual({
+      id: 'folder-1',
+      name: 'Folder 1',
+      children: [],
+      files: [pdf('file-2', 'nested.pdf')],
+    });
+  });
+
+  it('always keeps folders regardless of the format filter', async () => {
+    listDocuments.mockResolvedValue([
+      folder('folder-1', 'Folder 1'),
+      image('img-1', 'photo.png'),
+    ]);
+
+    const { result } = await renderReady('pdf');
+
+    await act(async () => {
+      await result.current.loadContent('root-id');
+    });
+
+    expect(result.current.root.children).toEqual([
+      { id: 'folder-1', name: 'Folder 1' },
+    ]);
+    expect(result.current.root.files).toEqual([]);
+  });
+
+  it('keeps only files matching a single format role', async () => {
+    listDocuments.mockResolvedValue([
+      image('img-1', 'photo.png'),
+      pdf('pdf-1', 'report.pdf'),
+    ]);
+
+    const { result } = await renderReady('img');
+
+    await act(async () => {
+      await result.current.loadContent('root-id');
+    });
+
+    expect(result.current.root.files).toEqual([image('img-1', 'photo.png')]);
+  });
+
+  it('keeps files matching any role in a format array', async () => {
+    listDocuments.mockResolvedValue([
+      image('img-1', 'photo.png'),
+      pdf('pdf-1', 'report.pdf'),
+    ]);
+
+    const { result } = await renderReady(['img', 'pdf']);
+
+    await act(async () => {
+      await result.current.loadContent('root-id');
+    });
+
+    expect(result.current.root.files).toEqual([
+      image('img-1', 'photo.png'),
+      pdf('pdf-1', 'report.pdf'),
+    ]);
+  });
+});

--- a/packages/react/src/providers/MockedProvider/MockedProvider.tsx
+++ b/packages/react/src/providers/MockedProvider/MockedProvider.tsx
@@ -1,12 +1,15 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactNode } from 'react';
+import { ReactNode, useState } from 'react';
 import { EdificeClientContext } from '../EdificeClientProvider/EdificeClientProvider.context';
 import { EdificeThemeContext } from '../EdificeThemeProvider/EdificeThemeProvider.context';
 import { mockConf, mockQueryResult, mockSession } from './MockedProvider.mocks';
 
-const queryClient = new QueryClient();
-
 export const MockedProvider = ({ children }: { children: ReactNode }) => {
+  // One QueryClient per mount (not a module-level singleton), so each
+  // render() call in a test gets its own isolated query cache instead of
+  // leaking cached data into other tests in the same file.
+  const [queryClient] = useState(() => new QueryClient());
+
   const themeContextValue = {
     theme: 'default',
     setTheme: vi.fn(),


### PR DESCRIPTION
## Contexte

[ENABLING-994](https://edifice-community.atlassian.net/browse/ENABLING-994) — Lot 10 de l'amorçage de couverture de tests du package `@edifice.io/react` (suite de ENABLING-931 à 992). Complémentaire : aucune cible ne recouvre celles des autres lots.

Ce lot cible les **hooks de données workspace et conversation** — l'audit signale 4 hooks workspace dont la cohérence d'orchestration reste à vérifier ; ce sont des données très consommées par les apps (Explorer, Workspace).

## Changements

5 fichiers de specs, **33 tests**.

| Cible | Tests |
|---|---|
| `useWorkspaceFile` | 8 |
| `useWorkspaceFolders` + `useWorkspaceFoldersTree` | 13 |
| `useWorkspaceSearch` | 7 |
| `useConversation` | 5 |

Plus un **correctif d'infrastructure de test** (`MockedProvider.tsx`) découvert en écrivant ces tests.

## Choix techniques

- `useWorkspaceFile` : chemin création vs mise à jour (détecté via l'URI `/workspace/document/:id`), suppression no-op sur tableau vide.
- `useWorkspaceFolders` : fusion des listes owner/shared, `isLoading` combiné, mutation de création avec patch direct du cache (`queryClient.setQueryData`), toast d'erreur, permissions `canCopyFileIntoFolder` (propriétaire vs droit hérité).
- `useWorkspaceFoldersTree` : construction de l'arbre (racines "mes documents"/"partagés", imbrication via `eParent`), filtrage par recherche en conservant les ancêtres des correspondances.
- `useWorkspaceSearch` : gating sur les deux droits (`listDocuments`/`listFolders`) avant tout chargement, chargement racine vs dossier imbriqué (recherche du nœud via `findNodeById`), filtrage par rôle de document (`format` string/array/null).
- `useConversation` : les tests documentent **deux comportements existants surprenants**, volontairement non corrigés (hors périmètre tests-uniquement) :
  - le choix d'endpoint de comptage (`/zimbra/count/INBOX` vs `/conversation/api/count/inbox`) et le lien « preauth » sont tous deux figés sur une valeur de fermeture capturée **au montage**, avant que `useHasWorkflow` ne se résolve (effet à dépendances vides) — ils ne reflètent donc jamais la valeur réellement résolue des droits, même une fois ceux-ci disponibles.

### Correctif d'infrastructure : `QueryClient` de `MockedProvider` isolé par test

En écrivant les premiers tests de hooks `useQuery`/`useMutation` de ce package, j'ai découvert que `MockedProvider.tsx` créait son `QueryClient` en singleton **module-level**, jamais recréé ni nettoyé entre tests (l'`afterEach` de `vitest.setup.ts` vide une `QueryCache` totalement distincte, sans effet sur celui-ci) — un vrai risque de fuite de cache entre tests pour tout hook React Query rendu via le `render()`/wrapper partagé.

Vérifié avant correction : pas de mention « DO NOT MODIFY » sur ce fichier (contrairement à `vitest.setup.ts`), exporté publiquement mais utilisé par personne d'autre dans le repo, et surtout **aucun test existant ne combinait jusqu'ici des hooks React Query avec le wrapper partagé** — le correctif est donc totalement inerte pour l'existant (suite complète revérifiée verte) et ne profite qu'aux tests React Query, actuels et futurs.

Corrigé via `useState(() => new QueryClient())` (un client isolé par montage, pattern recommandé par TanStack Query pour les tests). `useConversation.spec.tsx` et `useWorkspaceFolders.spec.tsx` en profitent directement : plus besoin de leur `QueryClient` local de contournement.

## Recette / Risque

Risque faible côté tests. Le correctif `MockedProvider` touche un fichier de test uniquement (pas de code de production, pas de changement d'API publique). Suite complète du package verte (55 fichiers / 329 tests). Lint et format conformes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ENABLING-994]: https://edifice-community.atlassian.net/browse/ENABLING-994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ