### PR TITLE
fix(react): #ENABLING-1121 corrige le débordement du popover profil dans le Header v2

### DIFF
--- a/packages/bootstrap/src/components/_popover.scss
+++ b/packages/bootstrap/src/components/_popover.scss
@@ -29,6 +29,14 @@
     transform: translateX(-50%);
   }
 
+  // When aligned to the trigger's right edge, the arrow follows suit
+  // instead of centering on the whole (wider) popover box.
+  &-align-end::before {
+    left: auto;
+    right: 0;
+    transform: none;
+  }
+
   &::after {
     display: none;
   }

--- a/packages/bootstrap/src/components/homepage/_header.scss
+++ b/packages/bootstrap/src/components/homepage/_header.scss
@@ -62,6 +62,14 @@
     .popover svg {
       --navbar-nav-link-icon-size: 2.2rem;
     }
+
+    .popover {
+      box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.18);
+    }
+
+    .popover .logout {
+      color: var(--color-support-danger-700);
+    }
   }
 
   .badge {

--- a/packages/bootstrap/src/components/homepage/_header.scss
+++ b/packages/bootstrap/src/components/homepage/_header.scss
@@ -24,16 +24,17 @@
     --navbar-brand-padding-x: 0;
     --navbar-brand-margin-end: 0;
     --navbar-brand-logo-height: 30px;
+    --navbar-brand-logo-width: 150px;
 
     grid-area: logo;
 
     .logo {
       display: none;
       height: var(--navbar-brand-logo-height);
+      width: var(--navbar-brand-logo-width);
       object-fit: contain;
       object-position: left;
       max-width: 100%;
-      width: auto;
     }
   }
 
@@ -64,7 +65,7 @@
     }
 
     .popover {
-      box-shadow: 0 4px 10px 0 rgba(0, 0, 0, 0.18);
+      box-shadow: 0 4px 10px 0 rgb(0 0 0 / 18%);
     }
 
     .popover .logout {
@@ -88,7 +89,8 @@
   }
 
   .header-beta .navbar-brand {
-    --navbar-brand-logo-height: 20px;
+    --navbar-brand-logo-height: 32px;
+    --navbar-brand-logo-width: 240px;
 
     .logo {
       display: inline-block;
@@ -116,6 +118,7 @@
 
 @include medias.respond-from('desktop-small') {
   .header-beta .navbar-brand {
-    --navbar-brand-logo-height: 24px;
+    --navbar-brand-logo-height: 40px;
+    --navbar-brand-logo-width: 300px;
   }
 }

--- a/packages/react/src/components/Popover/Popover.tsx
+++ b/packages/react/src/components/Popover/Popover.tsx
@@ -13,6 +13,13 @@ export interface PopoverProps {
    */
   isVisible?: boolean;
   /**
+   * Horizontal alignment relative to the trigger.
+   * `center` (default) centers the popover under the trigger.
+   * `end` aligns the popover's right edge with the trigger's right edge,
+   * which prevents overflow when the trigger sits near the viewport's right edge.
+   */
+  align?: 'center' | 'end';
+  /**
    * React Node
    */
   children: ReactNode;
@@ -49,9 +56,15 @@ export const PopoverFooter = ({ children, className }: PopoverProps) => {
 };
 
 export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
-  ({ children, className, id, isVisible, ...restProps }, ref) => {
+  (
+    { align = 'center', children, className, id, isVisible, ...restProps },
+    ref,
+  ) => {
     const classes = clsx(
-      'popover d-block position-absolute top-100 start-50 translate-middle-x',
+      'popover d-block position-absolute top-100',
+      align === 'end'
+        ? 'end-0 popover-align-end'
+        : 'start-50 translate-middle-x',
       className,
     );
 

--- a/packages/react/src/modules/homepage/components/Header/Header.tsx
+++ b/packages/react/src/modules/homepage/components/Header/Header.tsx
@@ -173,7 +173,8 @@ const Header = ({
               />
             </NavLink>
             <Popover
-              className="top-100 widget"
+              align="end"
+              className="widget"
               id={popoverUserId}
               isVisible={isUserHovered}
             >
@@ -182,7 +183,7 @@ const Header = ({
                   href={
                     '/auth/logout?callback=' + (theme?.logoutCallback ?? '')
                   }
-                  className="nav-link d-flex align-items-center gap-8"
+                  className="nav-link logout d-flex align-items-center gap-8"
                   data-testid="header-logout-button"
                 >
                   <IconDisconnect className="icon logout" />


### PR DESCRIPTION
# Description

Le popover profil du nouveau Header v2 (`header-beta`) se centrait toujours sous son trigger (`start-50 translate-middle-x`). Comme l'icône de profil est collée au bord droit du header, le popover débordait à droite du viewport, ce qui faisait apparaître un scroll horizontal et des sauts de layout sur la page.

Ticket : [ENABLING-1121](https://edifice-community.atlassian.net/browse/ENABLING-1121)

## Changements

- Ajoute une prop `align?: 'center' | 'end'` au composant `Popover` générique (défaut `'center'`, comportement inchangé pour les autres consommateurs : widget "Mes applis" et recherche du header historique)
- Aligne le popover profil du Header v2 sur le bord droit du trigger via `align="end"`, avec repositionnement de la flèche du popover en conséquence
- Applique, scopé au Header v2 uniquement :
  - la couleur sémantique `--color-support-danger-700` sur le lien de déconnexion
  - le `box-shadow` de la maquette sur les popovers du header

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


[ENABLING-1121]: https://edifice-community.atlassian.net/browse/ENABLING-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ