### PR TITLE
feat: #PEDAGO-4086, refactor Badge Beta to handle different version l…

### DIFF
--- a/packages/react/src/components/Badge/Badge.spec.tsx
+++ b/packages/react/src/components/Badge/Badge.spec.tsx
@@ -1,0 +1,142 @@
+import { createRef } from 'react';
+
+import { render, screen } from '~/setup';
+import Badge, { BadgeRef } from './Badge';
+
+describe('Badge component', () => {
+  it('renders notification variant with default classes', () => {
+    render(<Badge data-testid="badge">Updates</Badge>);
+    const badge = screen.getByTestId('badge');
+
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent('Updates');
+    expect(badge).toHaveClass(
+      'badge',
+      'rounded-pill',
+      'badge-notification',
+      'bg-info',
+      'text-light',
+      'border',
+      'border-0',
+    );
+  });
+
+  it('renders content variant classes with and without background', () => {
+    const { rerender } = render(
+      <Badge
+        data-testid="badge"
+        variant={{ type: 'content', level: 'success' }}
+      />,
+    );
+    const badge = screen.getByTestId('badge');
+
+    expect(badge).toHaveClass('text-success', 'border', 'border-0');
+    expect(badge).not.toHaveClass('bg-gray-200');
+
+    rerender(
+      <Badge
+        data-testid="badge"
+        variant={{ type: 'content', level: 'danger', background: true }}
+      />,
+    );
+
+    expect(badge).toHaveClass('text-danger', 'bg-gray-200');
+    expect(badge).not.toHaveClass('border', 'border-0');
+  });
+
+  it('renders user variant classes with profile mapping', () => {
+    render(
+      <Badge
+        data-testid="badge"
+        variant={{ type: 'user', profile: 'Teacher', background: true }}
+      >
+        Teacher
+      </Badge>,
+    );
+
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveClass('badge-profile-teacher', 'bg-gray-200');
+    expect(badge).toHaveTextContent('Teacher');
+  });
+
+  it('renders link variant class', () => {
+    render(
+      <Badge data-testid="badge" variant={{ type: 'link' }}>
+        Docs
+      </Badge>,
+    );
+
+    expect(screen.getByTestId('badge')).toHaveClass(
+      'badge-link',
+      'border',
+      'border-0',
+    );
+  });
+
+  it('renders chip variant in its dedicated wrapper', () => {
+    const { container } = render(
+      <Badge data-testid="badge" variant={{ type: 'chip' }}>
+        Chip value
+      </Badge>,
+    );
+    const badge = screen.getByTestId('badge');
+    const chipContent = container.querySelector(
+      'div.d-flex.fw-800.align-items-center',
+    );
+
+    expect(badge).toHaveClass('bg-gray-200');
+    expect(chipContent).toBeInTheDocument();
+    expect(chipContent).toHaveTextContent('Chip value');
+  });
+
+  it('renders appVersion default label and app color classes', () => {
+    render(
+      <Badge
+        data-testid="badge"
+        variant={{
+          type: 'appVersion',
+          app: { icon: 'blog-large' } as never,
+        }}
+      />,
+    );
+
+    const badge = screen.getByTestId('badge');
+
+    expect(badge).toHaveTextContent('BÊTA');
+    expect(badge).toHaveClass(
+      'color-app-blog',
+      'bg-light-blog',
+      'border-app-blog',
+    );
+  });
+
+  it('renders appVersion children when provided', () => {
+    render(
+      <Badge data-testid="badge" variant={{ type: 'appVersion' }}>
+        NEW
+      </Badge>,
+    );
+
+    expect(screen.getByTestId('badge')).toHaveTextContent('NEW');
+  });
+
+  it('forwards className, extra props and ref', () => {
+    const ref = createRef<BadgeRef>();
+
+    render(
+      <Badge
+        ref={ref}
+        data-testid="badge"
+        className="custom-class"
+        aria-label="badge label"
+      >
+        Content
+      </Badge>,
+    );
+
+    const badge = screen.getByTestId('badge');
+    expect(badge).toHaveClass('custom-class');
+    expect(badge).toHaveAttribute('aria-label', 'badge label');
+    expect(ref.current).toBe(badge);
+  });
+});

--- a/packages/react/src/components/Badge/Badge.stories.tsx
+++ b/packages/react/src/components/Badge/Badge.stories.tsx
@@ -282,7 +282,7 @@ export const BadgeBetaCommunities: Story = {
   args: {
     children: null,
     variant: {
-      type: 'beta',
+      type: 'appVersion',
       app: {
         name: 'communities',
         address: '',
@@ -298,7 +298,7 @@ export const BadgeBetaCommunities: Story = {
     docs: {
       description: {
         story:
-          'Badge of type `beta` is used to indicate that a feature or component is in beta status. You can customize the color of the badge using the `color` property, which accepts a hex color code.',
+          'Badge of type `appVersion` is used to display the version of an app (BETA, NEW, ALPHA, custom label version). You can customize the color of the badge using the `color` property, which accepts a hex color code.',
       },
     },
   },
@@ -307,11 +307,41 @@ export const BadgeBetaCommunities: Story = {
   },
 };
 
+export const BadgeNewCommunities: Story = {
+  args: {
+    children: null,
+    variant: {
+      type: 'appVersion',
+      app: {
+        name: 'communities',
+        address: '',
+        display: false,
+        displayName: 'Communities',
+        icon: '',
+        isExternal: false,
+        scope: [],
+        version: 'NEW',
+      },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Badge of type `appVersion` is used to display the version of an app (BETA, NEW, ALPHA, custom label version). You can customize the color of the badge using the `color` property, which accepts a hex color code.',
+      },
+    },
+  },
+  render: (args) => {
+    return <Badge {...args}>{args.variant.app.version}</Badge>;
+  },
+};
+
 export const BadgeBetaBlog: Story = {
   args: {
     children: null,
     variant: {
-      type: 'beta',
+      type: 'appVersion',
       app: {
         name: 'blog',
         address: '',
@@ -327,7 +357,7 @@ export const BadgeBetaBlog: Story = {
     docs: {
       description: {
         story:
-          'Badge of type `beta` is used to indicate that a feature or component is in beta status. You can customize the color of the badge using the `color` property, which accepts a hex color code.',
+          'Badge of type `appVersion` is used to display the version of an app (BETA, NEW, ALPHA, custom label version). You can customize the color of the badge using the `color` property, which accepts a hex color code.',
       },
     },
   },

--- a/packages/react/src/components/Badge/Badge.tsx
+++ b/packages/react/src/components/Badge/Badge.tsx
@@ -43,18 +43,25 @@ export type LinkBadgeVariant = {
 };
 
 /**
- * Badge variant : beta.
- * Beta Badge is used to indicate that a feature is in beta phase.
- * The color prop allows to customize the badge color to match the app color.
- * Defaults to black if not provided.
- * Beta Badge has a fixed text 'BÊTA' unless children is provided.
- * If app is provided, the color of the Beta Badge is derived from the application colors.
- * Example:
- * <Badge variant={{ type: 'beta', color: '#823AA1', app: myApp }} />
- * where myApp is of type IWebApp.
+ * Badge variant : App Version.
+ *
+ * Displays a badge showing the app version, for example: BÊTA, ALPHA, NEW or a custom version label.
+ *
+ * Default label is BÊTA unless a label is provided as a children of the component.
+ * Example of usage:
+ * <Badge variant={{ type: 'appVersion', app: myApp }}>NEW</Badge>
+ *
+ * The color prop allows to customize the badge color to match the app color (Defaults to black if not provided).
+ * Example of usage:
+ * <Badge variant={{ type: 'appVersion', color: '#823AA1' }} />
+ *
+ * If app prop is provided, the color of the App Version Badge is derived from the application colors,
+ * for example if the app provided is Blog then the Badge will have the same color as Blog app.
+ * Example of usage:
+ * <Badge variant={{ type: 'appVersion', app: blog }} />
  */
-export type BetaBadgeVariant = {
-  type: 'beta';
+export type AppVersionBadgeVariant = {
+  type: 'appVersion';
   color?: string;
   app?: IWebApp;
 };
@@ -66,7 +73,7 @@ export type BadgeVariants =
   | ProfileBadgeVariant
   | ChipBadgeVariant
   | LinkBadgeVariant
-  | BetaBadgeVariant;
+  | AppVersionBadgeVariant;
 
 export interface BadgeProps extends React.ComponentPropsWithRef<'span'> {
   /**
@@ -76,7 +83,6 @@ export interface BadgeProps extends React.ComponentPropsWithRef<'span'> {
   variant?: BadgeVariants;
   /**
    * Text or icon (or whatever) to render as children elements.
-   * Defaults to 'BÊTA' for beta variant.
    */
   children?: ReactNode;
   /**
@@ -98,19 +104,19 @@ const Badge = forwardRef(
     }: BadgeProps,
     ref: Ref<BadgeRef>,
   ) => {
-    // Colors for the Beta Badge
+    // Colors for the App Version Badge
     const { getIconClass, getBackgroundLightIconClass, getBorderIconClass } =
       useEdificeIcons();
-    let badgeColorClassName = '';
-    if (variant.type === 'beta' && variant.app) {
+    let appVersionBadgeColorClassName = '';
+    if (variant.type === 'appVersion' && variant.app) {
       const colorAppClassName = getIconClass(variant.app);
       const backgroundLightAppClassName = getBackgroundLightIconClass(
         variant.app,
       );
       const borderAppClassName = getBorderIconClass(variant.app);
-      badgeColorClassName = `${colorAppClassName} ${backgroundLightAppClassName} ${borderAppClassName}`;
+      appVersionBadgeColorClassName = `${colorAppClassName} ${backgroundLightAppClassName} ${borderAppClassName}`;
     }
-    // End of Colors for the Beta Badge
+    // End of Colors for the App Version Badge
 
     const classes = clsx(
       'badge rounded-pill',
@@ -130,7 +136,7 @@ const Badge = forwardRef(
         `badge-profile-${variant.profile.toLowerCase()}`,
       variant.type === 'link' && 'badge-link border border-0',
       variant.type === 'chip' && 'bg-gray-200',
-      variant.type === 'beta' && badgeColorClassName,
+      variant.type === 'appVersion' && appVersionBadgeColorClassName,
       className,
     );
 
@@ -139,8 +145,8 @@ const Badge = forwardRef(
         {variant.type === 'chip' && (
           <div className="d-flex fw-800 align-items-center">{children}</div>
         )}
-        {variant.type === 'beta' && (children ?? 'BÊTA')}
-        {variant.type !== 'chip' && variant.type !== 'beta' && children}
+        {variant.type === 'appVersion' && (children ?? 'BÊTA')}
+        {variant.type !== 'chip' && variant.type !== 'appVersion' && children}
       </span>
     );
   },


### PR DESCRIPTION
# Description

Refactor Badge Beta to handle different version labels. 

Now the type of badge is `appVersion` 

Displays a badge showing the app version, for example: BÊTA, ALPHA, NEW or a custom version label.

Default label is BÊTA unless a label is provided as a children of the component.

Example of usage:
`<Badge variant={{ type: 'appVersion', app: myApp }}>NEW</Badge>`

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
