### PR TITLE
feat: #ENABLING-932, add new tests for components, hooks and utilities

### DIFF
--- a/packages/react/src/components/Badge/Badge.spec.tsx
+++ b/packages/react/src/components/Badge/Badge.spec.tsx
@@ -1,0 +1,88 @@
+import type { IWebApp } from '@edifice.io/client';
+import { render, screen } from '~/setup';
+import Badge from './Badge';
+
+const iconHelpers = {
+  getIconClass: vi.fn(() => 'color-app-demo'),
+  getBackgroundLightIconClass: vi.fn(() => 'bg-light-demo'),
+  getBorderIconClass: vi.fn(() => 'border-app-demo'),
+};
+
+vi.mock('../../hooks/useEdificeIcons', () => ({
+  useEdificeIcons: () => iconHelpers,
+}));
+
+describe('Badge', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the default notification badge variant', () => {
+    render(<Badge>Notification</Badge>);
+
+    expect(screen.getByText('Notification')).toHaveClass(
+      'badge',
+      'rounded-pill',
+      'badge-notification',
+      'bg-info',
+      'text-light',
+      'border',
+      'border-0',
+    );
+  });
+
+  it('renders content badges with the expected background classes', () => {
+    render(
+      <Badge variant={{ type: 'content', level: 'warning', background: true }}>
+        Content
+      </Badge>,
+    );
+
+    expect(screen.getByText('Content')).toHaveClass(
+      'badge',
+      'rounded-pill',
+      'bg-gray-200',
+      'text-warning',
+    );
+  });
+
+  it('renders chip badges inside the chip container', () => {
+    const { container } = render(
+      <Badge variant={{ type: 'chip' }}>Chip label</Badge>,
+    );
+
+    expect(screen.getByText('Chip label')).toBeInTheDocument();
+    expect(container.querySelector('div')).toHaveClass(
+      'd-flex',
+      'fw-800',
+      'align-items-center',
+    );
+  });
+
+  it('renders beta badges with the default label and app color classes', () => {
+    const app = { icon: 'demo' } as IWebApp;
+
+    render(<Badge variant={{ type: 'beta', app }} />);
+
+    expect(screen.getByText('BÊTA')).toHaveClass(
+      'badge',
+      'rounded-pill',
+      'color-app-demo',
+      'bg-light-demo',
+      'border-app-demo',
+    );
+    expect(iconHelpers.getIconClass).toHaveBeenCalled();
+    expect(iconHelpers.getBackgroundLightIconClass).toHaveBeenCalled();
+    expect(iconHelpers.getBorderIconClass).toHaveBeenCalled();
+  });
+
+  it('renders profile badges with the profile class', () => {
+    render(
+      <Badge variant={{ type: 'user', profile: 'Teacher' as never }}>
+        Teacher
+      </Badge>,
+    );
+
+    expect(screen.getByText('Teacher')).toHaveClass('badge-profile-teacher');
+  });
+});

--- a/packages/react/src/components/Pagination/Pagination.spec.tsx
+++ b/packages/react/src/components/Pagination/Pagination.spec.tsx
@@ -1,0 +1,55 @@
+import { render } from '~/setup';
+import { Pagination } from './Pagination';
+
+describe('Pagination', () => {
+  beforeAll(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: (query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => {},
+        removeListener: () => {},
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        dispatchEvent: () => false,
+      }),
+    });
+  });
+
+  it('renders Ant Design pagination with expected classes', () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <Pagination
+        current={2}
+        total={120}
+        pageSize={20}
+        onChange={onChange}
+        className="custom-pagination"
+      />,
+    );
+
+    expect(container.querySelector('.ant-pagination')).toBeInTheDocument();
+    expect(
+      container.querySelector('.ant-pagination.custom-pagination'),
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector('.ant-pagination-item-active'),
+    ).toHaveTextContent('2');
+  });
+
+  it('calls onChange when user changes page', async () => {
+    const onChange = vi.fn();
+    const { container, user } = render(
+      <Pagination current={1} total={40} pageSize={10} onChange={onChange} />,
+    );
+
+    const page2 = container.querySelector('.ant-pagination-item-2');
+    expect(page2).toBeInTheDocument();
+    await user.click(page2 as HTMLElement);
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toBe(2);
+  });
+});

--- a/packages/react/src/components/PreventPropagation/PreventPropagation.spec.tsx
+++ b/packages/react/src/components/PreventPropagation/PreventPropagation.spec.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '~/setup';
+import PreventPropagation from './PreventPropagation';
+
+describe('PreventPropagation', () => {
+  it('renders children', () => {
+    render(
+      <PreventPropagation>
+        <span>Inner content</span>
+      </PreventPropagation>,
+    );
+
+    expect(screen.getByText('Inner content')).toBeInTheDocument();
+  });
+
+  it('stops click event propagation', async () => {
+    const parentClick = vi.fn();
+    const { user } = render(
+      <div onClick={parentClick}>
+        <PreventPropagation>
+          <button type="button">Child action</button>
+        </PreventPropagation>
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Child action' }));
+
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/components/VisuallyHidden/VisuallyHidden.spec.tsx
+++ b/packages/react/src/components/VisuallyHidden/VisuallyHidden.spec.tsx
@@ -1,0 +1,26 @@
+import { createRef } from 'react';
+import { render, screen } from '~/setup';
+import VisuallyHidden from './VisuallyHidden';
+
+describe('VisuallyHidden', () => {
+  it('renders children content', () => {
+    render(<VisuallyHidden>Accessible text</VisuallyHidden>);
+
+    expect(screen.getByText('Accessible text')).toBeInTheDocument();
+  });
+
+  it('applies the visually-hidden class on the span', () => {
+    render(<VisuallyHidden>Hidden label</VisuallyHidden>);
+
+    expect(screen.getByText('Hidden label')).toHaveClass('visually-hidden');
+  });
+
+  it('forwards the ref to the underlying span element', () => {
+    const ref = createRef<HTMLSpanElement>();
+
+    render(<VisuallyHidden ref={ref}>Ref target</VisuallyHidden>);
+
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+    expect(ref.current).toBe(screen.getByText('Ref target'));
+  });
+});

--- a/packages/react/src/hooks/useBreakpoint/useBreakPoint.spec.tsx
+++ b/packages/react/src/hooks/useBreakpoint/useBreakPoint.spec.tsx
@@ -1,0 +1,80 @@
+import { useMediaQuery } from '@uidotdev/usehooks';
+import { render, screen } from '~/setup';
+import useBreakpoint from './useBreakpoint';
+
+vi.mock('@uidotdev/usehooks', () => ({
+  useMediaQuery: vi.fn(),
+}));
+
+function HookHost() {
+  const breakpoint = useBreakpoint();
+
+  return (
+    <>
+      <span data-testid="xs">{String(breakpoint.xs)}</span>
+      <span data-testid="sm">{String(breakpoint.sm)}</span>
+      <span data-testid="md">{String(breakpoint.md)}</span>
+      <span data-testid="lg">{String(breakpoint.lg)}</span>
+      <span data-testid="xl">{String(breakpoint.xl)}</span>
+      <span data-testid="xxl">{String(breakpoint.xxl)}</span>
+    </>
+  );
+}
+
+describe('useBreakpoint', () => {
+  const mockedUseMediaQuery = vi.mocked(useMediaQuery);
+
+  afterEach(() => {
+    mockedUseMediaQuery.mockReset();
+  });
+
+  it('detects responsive breakpoints from media query matches', () => {
+    mockedUseMediaQuery.mockImplementation(
+      (query) =>
+        query === 'only screen and (min-width: 0)' ||
+        query === 'only screen and (min-width: 375px)' ||
+        query === 'only screen and (min-width: 768px)',
+    );
+
+    render(<HookHost />);
+
+    expect(screen.getByTestId('xs')).toHaveTextContent('true');
+    expect(screen.getByTestId('sm')).toHaveTextContent('true');
+    expect(screen.getByTestId('md')).toHaveTextContent('true');
+    expect(screen.getByTestId('lg')).toHaveTextContent('false');
+    expect(screen.getByTestId('xl')).toHaveTextContent('false');
+    expect(screen.getByTestId('xxl')).toHaveTextContent('false');
+  });
+
+  it('uses browser media queries for all bootstrap breakpoints', () => {
+    mockedUseMediaQuery.mockReturnValue(false);
+
+    render(<HookHost />);
+
+    expect(mockedUseMediaQuery).toHaveBeenCalledTimes(6);
+    expect(mockedUseMediaQuery).toHaveBeenNthCalledWith(
+      1,
+      'only screen and (min-width: 0)',
+    );
+    expect(mockedUseMediaQuery).toHaveBeenNthCalledWith(
+      2,
+      'only screen and (min-width: 375px)',
+    );
+    expect(mockedUseMediaQuery).toHaveBeenNthCalledWith(
+      3,
+      'only screen and (min-width: 768px)',
+    );
+    expect(mockedUseMediaQuery).toHaveBeenNthCalledWith(
+      4,
+      'only screen and (min-width: 1024px)',
+    );
+    expect(mockedUseMediaQuery).toHaveBeenNthCalledWith(
+      5,
+      'only screen and (min-width: 1280px)',
+    );
+    expect(mockedUseMediaQuery).toHaveBeenNthCalledWith(
+      6,
+      'only screen and (min-width: 1400px)',
+    );
+  });
+});

--- a/packages/react/src/hooks/useBrowserInfo/useBrowserInfo.spec.tsx
+++ b/packages/react/src/hooks/useBrowserInfo/useBrowserInfo.spec.tsx
@@ -1,0 +1,65 @@
+import useBrowserInfo from './useBrowserInfo';
+
+describe('useBrowserInfo', () => {
+  it('detects an iPhone user agent', () => {
+    const userAgent =
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1';
+
+    const { os, device, browser, isIphone, isIpod, isIpad } =
+      useBrowserInfo(userAgent);
+
+    expect(os.name).toBe('iOS');
+    expect(device.model).toContain('iPhone');
+    expect(browser.name).toBeTruthy();
+    expect(isIphone).toBe(true);
+    expect(isIpod).toBe(false);
+    expect(isIpad).toBe(false);
+  });
+
+  it('detects an iPad user agent', () => {
+    const userAgent =
+      'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Mobile/15E148 Safari/604.1';
+
+    const { device, isIphone, isIpod, isIpad } = useBrowserInfo(userAgent);
+
+    expect(device.model).toContain('iPad');
+    expect(isIphone).toBe(false);
+    expect(isIpod).toBe(false);
+    expect(isIpad).toBe(true);
+  });
+
+  it('detects an iPod user agent', () => {
+    const userAgent =
+      'Mozilla/5.0 (iPod touch; CPU iPhone OS 12_5_7 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1';
+
+    const { device, isIphone, isIpod, isIpad } = useBrowserInfo(userAgent);
+
+    expect(device.model).toContain('iPod');
+    expect(isIphone).toBe(false);
+    expect(isIpod).toBe(true);
+    expect(isIpad).toBe(false);
+  });
+
+  it('returns all iOS flags as false for a desktop browser user agent', () => {
+    const userAgent =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Safari/537.36';
+
+    const { os, device, browser, isIphone, isIpod, isIpad } =
+      useBrowserInfo(userAgent);
+
+    expect(os.name).toBe('Windows');
+    expect(device.model).toBeUndefined();
+    expect(browser.name).toBe('Chrome');
+    expect(isIphone).toBe(false);
+    expect(isIpod).toBe(false);
+    expect(isIpad).toBe(false);
+  });
+
+  it('returns parsed structures when no userAgent is provided', () => {
+    const { os, device, browser } = useBrowserInfo();
+
+    expect(os).toBeDefined();
+    expect(device).toBeDefined();
+    expect(browser).toBeDefined();
+  });
+});

--- a/packages/react/src/hooks/useBrowserInfo/useBrowserInfo.ts
+++ b/packages/react/src/hooks/useBrowserInfo/useBrowserInfo.ts
@@ -7,9 +7,10 @@ export default function useBrowserInfo(userAgent?: string) {
   const device: UAParser.IDevice = uaParser.getDevice();
   const browser: UAParser.IBrowser = uaParser.getBrowser();
 
-  const isIphone = device.model?.indexOf('iPhone') != -1;
-  const isIpod = device.model?.indexOf('iPod') != -1;
-  const isIpad = device.model?.indexOf('iPad') != -1;
+  const deviceModel = device.model ?? '';
+  const isIphone = deviceModel.includes('iPhone');
+  const isIpod = deviceModel.includes('iPod');
+  const isIpad = deviceModel.includes('iPad');
 
   return { os, device, browser, isIphone, isIpod, isIpad };
 }

--- a/packages/react/src/hooks/useHover/useHover.spec.tsx
+++ b/packages/react/src/hooks/useHover/useHover.spec.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from '~/setup';
+import useHover from './useHover';
+
+function HookHost() {
+  const [ref, isHovered] = useHover<HTMLButtonElement>();
+
+  return (
+    <>
+      <button ref={ref} data-testid="hover-target" type="button">
+        Hover me
+      </button>
+      <span>{isHovered ? 'hovered' : 'not-hovered'}</span>
+    </>
+  );
+}
+
+describe('useHover', () => {
+  it('sets hovered state to true on mouseover and false on mouseout', () => {
+    render(<HookHost />);
+    const target = screen.getByTestId('hover-target');
+
+    fireEvent.mouseOver(target);
+    expect(screen.getByText('hovered')).toBeInTheDocument();
+
+    fireEvent.mouseOut(target);
+    expect(screen.getByText('not-hovered')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/hooks/useScrollToTop/useScrollToTop.spec.tsx
+++ b/packages/react/src/hooks/useScrollToTop/useScrollToTop.spec.tsx
@@ -1,0 +1,30 @@
+import { fireEvent, render, screen } from '~/setup';
+import useScrollToTop from './useScrollToTop';
+
+function HookHost() {
+  const scrollToTop = useScrollToTop();
+
+  return (
+    <button type="button" onClick={scrollToTop} data-testid="scroll-btn">
+      Scroll to top
+    </button>
+  );
+}
+
+describe('useScrollToTop', () => {
+  it('returns a function', () => {
+    render(<HookHost />);
+    expect(screen.getByTestId('scroll-btn')).toBeInTheDocument();
+  });
+
+  it('calls scrollIntoView on the html element when invoked', () => {
+    const scrollIntoViewMock = vi.fn();
+    const htmlElement = document.querySelector('html')!;
+    htmlElement.scrollIntoView = scrollIntoViewMock;
+
+    render(<HookHost />);
+    fireEvent.click(screen.getByTestId('scroll-btn'));
+
+    expect(scrollIntoViewMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/hooks/useTitle/useTitle.spec.tsx
+++ b/packages/react/src/hooks/useTitle/useTitle.spec.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '~/setup';
+import useTitle from './useTitle';
+
+function HookHost() {
+  const title = useTitle();
+
+  return <span>{title}</span>;
+}
+
+describe('useTitle', () => {
+  let initialTitle = '';
+
+  beforeEach(() => {
+    initialTitle = document.title;
+  });
+
+  afterEach(() => {
+    document.title = initialTitle;
+  });
+
+  it('returns the current document.title', () => {
+    document.title = 'My first title';
+
+    render(<HookHost />);
+
+    expect(screen.getByText('My first title')).toBeInTheDocument();
+  });
+
+  it('syncs with the latest document.title on a new mount', () => {
+    document.title = 'Title A';
+    const { unmount } = render(<HookHost />);
+
+    expect(screen.getByText('Title A')).toBeInTheDocument();
+
+    unmount();
+    document.title = 'Title B';
+
+    render(<HookHost />);
+
+    expect(screen.getByText('Title B')).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/utilities/check-user-rights/check-user-rights.spec.tsx
+++ b/packages/react/src/utilities/check-user-rights/check-user-rights.spec.tsx
@@ -1,0 +1,120 @@
+import { checkUserRight } from './check-user-rights';
+
+const rightsMethods = vi.hoisted(() => ({
+  sessionHasAtLeastOneResourceRight: vi.fn(),
+  sessionHasResourceRight: vi.fn(),
+  sessionHasAtLeastOneResourceRightForEachList: vi.fn(),
+  sessionHasResourceRightForEachList: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: {
+    rights: () => rightsMethods,
+  },
+}));
+
+describe('checkUserRight', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('checks default roles with a single right', async () => {
+    rightsMethods.sessionHasResourceRight.mockImplementation(
+      async (role: string) => role === 'read',
+    );
+
+    const result = await checkUserRight('read');
+
+    expect(rightsMethods.sessionHasResourceRight).toHaveBeenCalledTimes(4);
+    expect(rightsMethods.sessionHasResourceRight).toHaveBeenCalledWith(
+      'contrib',
+      ['read'],
+    );
+    expect(rightsMethods.sessionHasResourceRight).toHaveBeenCalledWith(
+      'creator',
+      ['read'],
+    );
+    expect(rightsMethods.sessionHasResourceRight).toHaveBeenCalledWith(
+      'manager',
+      ['read'],
+    );
+    expect(rightsMethods.sessionHasResourceRight).toHaveBeenCalledWith('read', [
+      'read',
+    ]);
+
+    expect(result).toEqual({
+      creator: false,
+      contrib: false,
+      manager: false,
+      read: true,
+    });
+  });
+
+  it('supports additional roles', async () => {
+    rightsMethods.sessionHasResourceRight.mockResolvedValue(true);
+
+    const result = await checkUserRight('read', 'super-admin');
+
+    expect(rightsMethods.sessionHasResourceRight).toHaveBeenCalledTimes(5);
+    expect(rightsMethods.sessionHasResourceRight).toHaveBeenCalledWith(
+      'super-admin',
+      ['read'],
+    );
+    expect((result as Record<string, boolean>)['super-admin']).toBe(true);
+  });
+
+  it('checks list of rights from object input', async () => {
+    rightsMethods.sessionHasResourceRight.mockResolvedValue(true);
+
+    const result = await checkUserRight({ rights: ['read', 'contrib'] });
+
+    expect(rightsMethods.sessionHasResourceRight).toHaveBeenCalledTimes(4);
+    expect(rightsMethods.sessionHasResourceRight).toHaveBeenCalledWith(
+      'contrib',
+      ['read', 'contrib'],
+    );
+    expect(result).toEqual({
+      creator: true,
+      contrib: true,
+      manager: true,
+      read: true,
+    });
+  });
+
+  it('checks rights for multiple resources', async () => {
+    rightsMethods.sessionHasResourceRightForEachList.mockResolvedValue(true);
+
+    const result = await checkUserRight([
+      { rights: ['read'] },
+      { rights: ['read', 'contrib'] },
+    ]);
+
+    expect(
+      rightsMethods.sessionHasResourceRightForEachList,
+    ).toHaveBeenCalledTimes(4);
+    expect(
+      rightsMethods.sessionHasResourceRightForEachList,
+    ).toHaveBeenCalledWith('read', [['read'], ['read', 'contrib']]);
+    expect(result).toEqual({
+      creator: true,
+      contrib: true,
+      manager: true,
+      read: true,
+    });
+  });
+
+  it('returns false for all roles when rights list is empty', async () => {
+    const result = await checkUserRight([]);
+
+    expect(rightsMethods.sessionHasResourceRight).not.toHaveBeenCalled();
+    expect(
+      rightsMethods.sessionHasResourceRightForEachList,
+    ).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      creator: false,
+      contrib: false,
+      manager: false,
+      read: false,
+    });
+  });
+});

--- a/packages/react/src/utilities/emptyscreen-mapping/emptyscreen-mapping.spec.tsx
+++ b/packages/react/src/utilities/emptyscreen-mapping/emptyscreen-mapping.spec.tsx
@@ -1,0 +1,30 @@
+import { emptyScreenMapping, type AppKeys } from './emptyscreen-mapping';
+
+const expectedKeys: AppKeys[] = [
+  'blog',
+  'wiki',
+  'empty',
+  'collaborative-wall',
+  'community',
+  'exercizer',
+  'formulaire',
+  'forum',
+  'homeworks',
+  'magneto',
+];
+
+describe('emptyScreenMapping', () => {
+  it('exposes the same app keys for both themes', () => {
+    expect(Object.keys(emptyScreenMapping.one).sort()).toEqual(
+      [...expectedKeys].sort(),
+    );
+    expect(Object.keys(emptyScreenMapping.neo).sort()).toEqual(
+      [...expectedKeys].sort(),
+    );
+  });
+
+  it.each(expectedKeys)('provides a mapping for %s in both themes', (key) => {
+    expect(emptyScreenMapping.one[key]).toEqual(expect.any(String));
+    expect(emptyScreenMapping.neo[key]).toEqual(expect.any(String));
+  });
+});

--- a/packages/react/src/utilities/mime-types/mime-types-utils.spec.tsx
+++ b/packages/react/src/utilities/mime-types/mime-types-utils.spec.tsx
@@ -1,0 +1,17 @@
+import { HEIC_MIME_TYPES } from './mime-types-utils';
+
+describe('HEIC_MIME_TYPES', () => {
+  it('lists the HEIC and HEIF MIME types', () => {
+    expect(HEIC_MIME_TYPES).toEqual(['image/heic', 'image/heif']);
+  });
+
+  it('matches HEIC and HEIF file types', () => {
+    expect(HEIC_MIME_TYPES.includes('image/heic')).toBe(true);
+    expect(HEIC_MIME_TYPES.includes('image/heif')).toBe(true);
+  });
+
+  it('does not match unrelated file types', () => {
+    expect(HEIC_MIME_TYPES.includes('image/png')).toBe(false);
+    expect(HEIC_MIME_TYPES.includes('image/jpeg')).toBe(false);
+  });
+});


### PR DESCRIPTION
# Description

Ajout de tests unitaires Vitest sur des composants, hooks et utilitaires du package `@edifice.io/react` (lot 2, complémentaire au lot 1 - ENABLING-931).

Couverts : `Badge`, `Pagination`, `PreventPropagation`, `VisuallyHidden` (composants) ; `useBreakpoint`, `useBrowserInfo`, `useHover`, `useScrollToTop`, `useTitle` (hooks) ; `check-user-rights`, `emptyscreen-mapping`, `mime-types-utils` (utilitaires) — soit l'intégralité des candidats listés dans le ticket.

Ticket : https://edifice-community.atlassian.net/browse/ENABLING-932

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
