### PR TITLE
ci: #ENABLING-997 réactive Chromatic sur push/PR avec TurboSnap ciblé

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,17 +1,32 @@
 name: "Chromatic"
 
 on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - develop
+      - develop*
+      - epic-*
   workflow_dispatch:
 
 jobs:
   chromatic:
     name: Run Chromatic
     runs-on: ubuntu-latest
+    env:
+      # Required for TurboSnap to correctly detect changed files on pull_request events.
+      # See https://www.chromatic.com/docs/github-actions/
+      CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      CHROMATIC_SLUG: ${{ github.repository }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.ref }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -27,7 +42,7 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Run Chromatic
-        uses: chromaui/action@latest
+        uses: chromaui/action@v18
         with:
           # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/apps/docs/chromatic.config.json
+++ b/apps/docs/chromatic.config.json
@@ -1,5 +1,6 @@
 {
   "onlyChanged": true,
+  "untraced": ["**/package.json"],
   "projectId": "6717abe597612cd54fd9ea66",
   "storybookBaseDir": "apps/docs",
   "buildScriptName": "build",

--- a/packages/react/src/components/Button/stories/Button.stories.tsx
+++ b/packages/react/src/components/Button/stories/Button.stories.tsx
@@ -55,7 +55,7 @@ export const Base: Story = {
   args: {
     color: 'primary',
     variant: 'filled',
-    children: 'Label',
+    children: 'Label TurboSnap test',
     type: 'button',
     disabled: false,
   },

--- a/packages/react/src/components/Button/stories/Button.stories.tsx
+++ b/packages/react/src/components/Button/stories/Button.stories.tsx
@@ -55,7 +55,7 @@ export const Base: Story = {
   args: {
     color: 'primary',
     variant: 'filled',
-    children: 'Label TurboSnap test',
+    children: 'Label',
     type: 'button',
     disabled: false,
   },


### PR DESCRIPTION
## Résumé
Réactive Chromatic automatique sur push/PR (retiré en avril) avec TurboSnap ciblé. Validé en conditions réelles sur `develop-enabling` avant merge.

## Contexte
Ticket : [ENABLING-997](https://edifice-community.atlassian.net/browse/ENABLING-997)

Chromatic tournait auparavant sur chaque push/PR mais re-snapshotait toutes les stories, épuisant le quota gratuit mensuel en 2 jours → passé en déclenchement manuel. Storybook est passé en v10 depuis. Cause confirmée en logs réels : sans lockfile versionné (`pnpm-lock.yaml` volontairement non commité dans ce repo), Chromatic ne peut pas résoudre les changements de dépendances et bascule en full-rebuild dès qu'un `package.json` du monorepo diffère de la dernière baseline.

## Changements
- Réactive `push` (main) + `pull_request` (develop, develop*, epic-*), en gardant `workflow_dispatch`
- Ajoute le contournement documenté par Chromatic (`ref` + `CHROMATIC_BRANCH`/`CHROMATIC_SHA`/`CHROMATIC_SLUG`) pour que TurboSnap fonctionne sur `pull_request`
- Ajoute `untraced: ["**/package.json"]` pour éviter les full-rebuild déclenchés par un bump de dépendance
- Épingle `chromaui/action@v18` au lieu de `@latest`

## Validation effectuée
- ✅ TurboSnap confirmé fonctionnel sur `pull_request` : un changement ciblé sur `Button.stories.tsx` n'a re-testé que les 13 stories du fichier modifié (26 snapshots), pas les ~500 autres
- ✅ Baselines rafraîchies et acceptées sur les 6 branches concernées : `main`, `develop`, `develop-enabling`, `develop-b2school`, `develop-integration`, `develop-pedago`
- ✅ Ruleset GitHub ajouté sur `develop-enabling` rendant `UI Tests`/`UI Review` obligatoires avant merge (aucun contournement possible)

## Volume estimé / soutenabilité du quota

Basé sur l'activité réelle des 30 derniers jours (10 push sur `main` + commits poussés sur des PR ouvertes ciblant develop/develop-enabling/develop-b2school/develop-pedago), en excluant une PR exceptionnelle à 66 commits (un outil créé de zéro sur la période, cas non représentatif de l'activité normale) : ~78 déclenchements de build/mois.

- Chaque build a un plancher incompressible : TurboSnap facture les stories inchangées "copiées" à 20% du prix d'un snapshot (confirmé empiriquement : 488 copies ≈ 98 snapshots facturés). Avec ~501 stories et les tests d'accessibilité actifs (qui doublent le coût par story), le **plancher est d'environ 100 snapshots par build, même sans aucune modification de composant**.
- **~78 builds × ~100 ≈ 7 800 snapshots/mois** rien que pour ce plancher incompressible, soit ~1,6× le quota gratuit (5000/mois) — avant même de compter le coût des vraies modifications de composants.

**Conclusion : le quota gratuit ne suffira probablement pas au rythme actuel de commits**, indépendamment de TurboSnap (déjà optimisé dans cette PR). Pistes non tranchées à ce stade, à discuter séparément :
1. Filtrer le trigger `pull_request` par `paths:` (stories/composants/`.storybook` uniquement)
2. Ne déclencher que sur `opened`/`ready_for_review`, pas sur chaque `synchronize`
3. Plan payant (Starter 149$/mois, 35 000 snapshots)

## Risque connu, non résolu
Le comportement de `UI Tests`/`UI Review` quand le quota est épuisé en pleine review n'a pas été testé en conditions réelles — à surveiller lors du premier dépassement de quota une fois en production.


[ENABLING-997]: https://edifice-community.atlassian.net/browse/ENABLING-997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
