### PR TITLE
ci: #ENABLING-1128 rend tests.yml et icons-check.yml éligibles comme required checks

### DIFF
--- a/.github/workflows/icons-check.yml
+++ b/.github/workflows/icons-check.yml
@@ -2,10 +2,6 @@ name: "Icons check"
 
 on:
   pull_request:
-    paths:
-      - "packages/react/src/modules/icons/**"
-      - "packages/react/svgr.config.cjs"
-      - ".github/workflows/icons-check.yml"
 
 jobs:
   icons-check:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,35 +2,47 @@ name: 'Tests'
 
 on:
   pull_request:
-    paths:
-      - 'packages/react/**'
-      - 'packages/client/**'
-      - 'pnpm-lock.yaml'
-      - '.github/workflows/tests.yml'
 
 jobs:
+  changes:
+    name: Detect relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      react: ${{ steps.filter.outputs.react }}
+      client: ${{ steps.filter.outputs.client }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            react:
+              - 'packages/react/**'
+              - '.github/workflows/tests.yml'
+            client:
+              - 'packages/client/**'
+              - '.github/workflows/tests.yml'
+
   test-react:
     name: '@edifice.io/react — lint, format, test (coverage)'
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
-      - name: Install dependencies
-        run: pnpm install
-      - name: Build workspace dependencies
-        run: pnpm run build
-      - name: Lint
-        run: pnpm --filter @edifice.io/react lint
-      - name: Format
-        run: pnpm --filter @edifice.io/react format
-      - name: Test with coverage
-        run: pnpm --filter @edifice.io/react test:coverage
+      - name: Install, lint, format, test (coverage)
+        if: needs.changes.outputs.react == 'true'
+        run: |
+          pnpm install
+          pnpm run build
+          pnpm --filter @edifice.io/react lint
+          pnpm --filter @edifice.io/react format
+          pnpm --filter @edifice.io/react test:coverage
       - name: Upload coverage report
-        if: always()
+        if: needs.changes.outputs.react == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-react
@@ -39,26 +51,24 @@ jobs:
 
   test-client:
     name: '@edifice.io/client — lint, format, test (coverage)'
+    needs: changes
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20
       - uses: pnpm/action-setup@v4
-      - name: Install dependencies
-        run: pnpm install
-      - name: Build workspace dependencies
-        run: pnpm run build
-      - name: Lint
-        run: pnpm --filter @edifice.io/client lint
-      - name: Format
-        run: pnpm --filter @edifice.io/client format
-      - name: Test with coverage
-        run: pnpm --filter @edifice.io/client test:coverage
+      - name: Install, lint, format, test (coverage)
+        if: needs.changes.outputs.client == 'true'
+        run: |
+          pnpm install
+          pnpm run build
+          pnpm --filter @edifice.io/client lint
+          pnpm --filter @edifice.io/client format
+          pnpm --filter @edifice.io/client test:coverage
       - name: Upload coverage report
-        if: always()
+        if: needs.changes.outputs.client == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: coverage-client

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -17,5 +17,3 @@ This package contains shared utility functions and helpers used across multiple 
 ```bash
 pnpm add @edifice.io/utilities
 ```
-
-<!-- ci test: validating tests.yml paths-filter fast-skip, will revert -->

--- a/packages/utilities/README.md
+++ b/packages/utilities/README.md
@@ -17,3 +17,5 @@ This package contains shared utility functions and helpers used across multiple 
 ```bash
 pnpm add @edifice.io/utilities
 ```
+
+<!-- ci test: validating tests.yml paths-filter fast-skip, will revert -->


### PR DESCRIPTION
## Résumé
Corrige `tests.yml` et `icons-check.yml` pour qu'ils puissent être rendus "required" dans un GitHub Ruleset sans bloquer indéfiniment les PR qui ne touchent pas leurs chemins habituels.

## Contexte
Ticket : [ENABLING-1128](https://edifice-community.atlassian.net/browse/ENABLING-1128)

Les deux workflows étaient filtrés par `paths:`, donc jamais déclenchés sur une PR qui ne touche pas ces chemins précis. Les rendre "required" tel quel bloquerait ces PR indéfiniment (le check n'existerait jamais) — constaté concrètement lors d'ENABLING-997.

## Changements
- `icons-check.yml` : retire le filtre `paths:` du trigger (job léger, coût négligeable de le faire tourner partout)
- `tests.yml` : retire le filtre au niveau du trigger, ajoute un job `changes` (`dorny/paths-filter@v3`) et conditionne l'étape lourde (install/build/lint/format/test:coverage) de `test-react`/`test-client` via `if:` — le job existe toujours et poste un statut, trivial si rien de pertinent n'a changé

## Comment tester
1. Vérifier que cette PR (qui ne touche ni `packages/react` ni `packages/client`) déclenche bien `test-react`/`test-client` avec un succès rapide (étapes lourdes skippées)
2. Ouvrir une PR touchant `packages/react` ou `packages/client` et vérifier que le job complet tourne comme avant
3. Vérifier qu'`icons-check` se déclenche sur cette PR même si elle ne touche pas les icônes

[ENABLING-1128]: https://edifice-community.atlassian.net/browse/ENABLING-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ