### PR TITLE
docs: #ENABLING-1015 complète les guides Storybook des briques publiques

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,57 @@ We already have a `develop` branch created to work on packages.
 - Start developing.
 - Then, create a Pull Request.
 
+## Documentation
+
+Every public brick must be documented in Storybook. Which form to use depends on what
+you are documenting.
+
+**Components — a description in the story.**
+
+Storybook runs with `autodocs` enabled globally, so every story already gets a Docs page
+with its props table generated from the types. What the tooling cannot infer is the
+narrative: what the component is for, how its props interact, when to reach for another
+one. Add it to the story `meta`:
+
+```tsx
+const meta: Meta<typeof MyComponent> = {
+  title: 'Components/MyComponent',
+  component: MyComponent,
+  parameters: {
+    docs: {
+      description: {
+        component: 'What the component does, and when to use it.',
+      },
+    },
+  },
+};
+```
+
+Markdown is supported. Do not restate the props one by one — the table already does it.
+
+**Hooks — an MDX page.**
+
+A hook has no props table to generate, so it is documented in an `.mdx` file next to it,
+with the sections `# useX`, `## Usage`, `## Parameters`, `## Returns` and `## Example`.
+
+- **Without a visual demo** (the common case): a standalone page, declared with
+  `<Meta title="Hooks/useX" />` and **no story**. Nothing is rendered, so it costs no
+  Chromatic snapshot.
+- **With a visual demo** (`useToast`, `useDropzone`, `useTrapFocus`…): add a story and
+  attach the page to it with `<Meta of={useXStories} />`, then embed the demo where it
+  belongs with `<Canvas of={useXStories.Example} />`.
+
+When a page is attached this way it **replaces** the autodocs page, so do not also add a
+`docs.description.component` to the story — the MDX carries the narrative.
+
+**A component may use MDX too**, when the documentation needs long code samples or
+several sections that would not fit in a description string.
+
+Note: MDX tables require `remark-gfm`, already configured in
+`apps/docs/.storybook/main.ts`. Without it they render as raw text.
+
+Check your page with `pnpm docs:build`, or `pnpm docs` to browse it locally.
+
 ## Pull Request
 
 - After pushing your work, create a Pull Request

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,19 @@ with the sections `# useX`, `## Usage`, `## Parameters`, `## Returns` and `## Ex
   Chromatic snapshot.
 - **With a visual demo** (`useToast`, `useDropzone`, `useTrapFocus`…): add a story and
   attach the page to it with `<Meta of={useXStories} />`, then embed the demo where it
-  belongs with `<Canvas of={useXStories.Example} />`.
+  belongs with `<Canvas of={useXStories.Example} />`. Such a story is a demo, not a
+  design system visual to watch for regressions, so exclude it from Chromatic:
+
+  ```tsx
+  const meta: Meta<typeof useX> = {
+    title: 'Hooks/useX',
+    parameters: {
+      chromatic: { disableSnapshot: true },
+    },
+  };
+  ```
+
+  The demo stays fully interactive in Storybook, it only leaves the snapshot scope.
 
 When a page is attached this way it **replaces** the autodocs page, so do not also add a
 `docs.description.component` to the story — the MDX carries the narrative.

--- a/packages/react/src/components/Grid/stories/Grid.stories.tsx
+++ b/packages/react/src/components/Grid/stories/Grid.stories.tsx
@@ -4,6 +4,14 @@ import { Grid } from '../Grid';
 const meta: Meta<typeof Grid> = {
   title: 'Layout/Grid',
   component: Grid,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The `Grid` component is the responsive layout container of the design system. It defines a grid of **12 columns on desktop, 8 on tablet and 4 on mobile**, and expects `Grid.Col` children to place content in it. It only carries the grid itself — column spans are declared per breakpoint on each `Grid.Col`. See the `Column` page for the sizing props.',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/packages/react/src/components/Grid/stories/GridCol.stories.tsx
+++ b/packages/react/src/components/Grid/stories/GridCol.stories.tsx
@@ -4,6 +4,14 @@ import { Grid } from '../Grid';
 const meta: Meta<typeof Grid.Col> = {
   title: 'Layout/Grid/Column',
   component: Grid.Col,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The `Grid.Col` component declares a cell inside a `Grid`. Its span is set per breakpoint: `sm` (mobile, required) and the optional `md` (tablet), `lg` (small desktop) and `xl` (large desktop) — each value being a number of columns within the 4/8/12 track counts of the grid. When a breakpoint is omitted, the column keeps the span of the smaller one. It is polymorphic through the `as` prop, so a column can be rendered as a `section`, an `article` or any other element instead of a `div` when the semantics call for it.',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/packages/react/src/components/StackedGroup/StackedGroup.stories.tsx
+++ b/packages/react/src/components/StackedGroup/StackedGroup.stories.tsx
@@ -13,6 +13,12 @@ const meta = {
   component: StackedGroup,
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The `StackedGroup` component lays out its children in a row with a controlled overlap, the way stacked avatars or cards are usually displayed. The `overlap` prop sets how many pixels each item bites into the previous one (20 by default), and `stackingOrder` decides which end sits on top: `leftFirst` (default) gives the highest z-index to the rightmost item, `rightFirst` does the opposite — useful when the first item must stay fully visible. With `wrap`, items flow onto several lines instead of a single row. It only handles positioning: the children provide their own shape and styling.',
+      },
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof StackedGroup>;

--- a/packages/react/src/hooks/useCheckable/useCheckable.stories.tsx
+++ b/packages/react/src/hooks/useCheckable/useCheckable.stories.tsx
@@ -4,6 +4,12 @@ import { useCheckable } from './useCheckable';
 
 const meta: Meta<typeof useCheckable> = {
   title: 'Hooks/useCheckable',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useClickOutside/useClickOutside.stories.tsx
+++ b/packages/react/src/hooks/useClickOutside/useClickOutside.stories.tsx
@@ -6,6 +6,12 @@ import useClickOutside from './useClickOutside';
 
 const meta: Meta<typeof useClickOutside> = {
   title: 'Hooks/useClickOutside',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useDropzone/useDropzone.stories.tsx
+++ b/packages/react/src/hooks/useDropzone/useDropzone.stories.tsx
@@ -5,6 +5,12 @@ import useDropzone from './useDropzone';
 
 const meta: Meta<typeof useDropzone> = {
   title: 'Hooks/useDropzone',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useHover/useHover.stories.tsx
+++ b/packages/react/src/hooks/useHover/useHover.stories.tsx
@@ -4,6 +4,12 @@ import useHover from './useHover';
 
 const meta: Meta<typeof useHover> = {
   title: 'Hooks/useHover',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useHttpErrorToast/useHttpErrorToast.mdx
+++ b/packages/react/src/hooks/useHttpErrorToast/useHttpErrorToast.mdx
@@ -1,0 +1,53 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Hooks/useHttpErrorToast" />
+
+# useHttpErrorToast
+
+The `useHttpErrorToast` hook subscribes to the transport layer of `@edifice.io/client`
+and displays an error toast whenever an HTTP request fails, so an app gets global error
+feedback without wiring a handler on every call.
+
+## Usage
+
+```tsx
+import { useHttpErrorToast } from '@edifice.io/react';
+
+function App() {
+  useHttpErrorToast();
+
+  return <Router />;
+}
+```
+
+Call it once, high in the tree — mounting it in several components would show duplicate
+toasts for the same error.
+
+## Parameters
+
+- `active` (boolean, optional): Enables the subscription. Defaults to `true`. Set it to
+  `false` to suspend the global toasts on a screen handling its errors itself.
+- `...options` (`CustomToastOptions`, optional): Forwarded to `useToast`, to adjust the
+  duration or position of the toast.
+
+## Returns
+
+Nothing. The hook only registers a subscription, and revokes it on unmount.
+
+## Message resolution
+
+The message shown is resolved in this order:
+
+1. The i18n key carried by the error payload (`payload.error`), when the backend provides one.
+2. Otherwise, the translation of the HTTP status code for a known error — `e400`, `e401`,
+   `e403`, `e404`, `e408`, `e413`, `e500`, `e504`.
+3. Otherwise, the raw `statusText` of the response, which may be technical and in English.
+
+If none of these yields a string, no toast is displayed: an empty toast is never shown.
+
+## Example
+
+```tsx
+// Suspend global toasts on a screen that renders its own error state
+useHttpErrorToast({ active: !isCustomErrorScreen });
+```

--- a/packages/react/src/hooks/useImage/useImage.stories.tsx
+++ b/packages/react/src/hooks/useImage/useImage.stories.tsx
@@ -4,6 +4,12 @@ import useImage from './useImage';
 
 const meta: Meta<typeof useImage> = {
   title: 'Hooks/useImage',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useKeyPress/useKeyPress.stories.tsx
+++ b/packages/react/src/hooks/useKeyPress/useKeyPress.stories.tsx
@@ -6,6 +6,12 @@ import Button from '../../components/Button/Button';
 
 const meta: Meta<typeof useKeyPress> = {
   title: 'Hooks/useKeyPress',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useScrollToTop/useScrollToTop.stories.tsx
+++ b/packages/react/src/hooks/useScrollToTop/useScrollToTop.stories.tsx
@@ -4,6 +4,12 @@ import useScrollToTop from './useScrollToTop';
 
 const meta: Meta<typeof useScrollToTop> = {
   title: 'Hooks/useScrollToTop',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useTitle/useTitle.stories.tsx
+++ b/packages/react/src/hooks/useTitle/useTitle.stories.tsx
@@ -4,6 +4,12 @@ import useTitle from './useTitle';
 
 const meta: Meta<typeof useTitle> = {
   title: 'Hooks/useTitle',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useToast/useToast.stories.tsx
+++ b/packages/react/src/hooks/useToast/useToast.stories.tsx
@@ -5,6 +5,12 @@ import useToast from './useToast';
 
 const meta: Meta<typeof useToast> = {
   title: 'Hooks/useToast',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useToggle/useToggle.mdx
+++ b/packages/react/src/hooks/useToggle/useToggle.mdx
@@ -1,0 +1,45 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as useToggleStories from './useToggle.stories';
+
+<Meta of={useToggleStories} />
+
+# useToggle
+
+## Usage
+
+This hook manages a boolean state and returns a function that flips it. Typical uses:
+
+- show or hide a panel
+- switch an icon between two states
+- drive an `aria-expanded` attribute
+
+## Example
+
+<Canvas of={useToggleStories.Example} />
+
+## Hook usage
+
+```jsx
+const [isOpen, toggle] = useToggle(false);
+
+<>
+  <button onClick={toggle} aria-expanded={isOpen}>
+    {isOpen ? 'Hide' : 'Show'}
+  </button>
+  {isOpen && <Panel />}
+</>;
+```
+
+## Parameters
+
+- `initialState` (boolean, optional): The starting value. Defaults to `false`.
+
+## Returns
+
+A `[state, toggle]` tuple:
+
+- `state` (boolean): The current value.
+- `toggle` (function): Flips the value.
+
+`toggle` is wrapped in `useCallback` with no dependencies, so its identity is stable
+across renders — it can be passed to a memoized child without triggering a re-render.

--- a/packages/react/src/hooks/useToggle/useToggle.stories.tsx
+++ b/packages/react/src/hooks/useToggle/useToggle.stories.tsx
@@ -5,6 +5,12 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta = {
   title: 'Hooks/useToggle',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useTrapFocus/useTrapFocus.mdx
+++ b/packages/react/src/hooks/useTrapFocus/useTrapFocus.mdx
@@ -1,0 +1,46 @@
+import { Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as useTrapFocusStories from './useTrapFocus.stories';
+
+<Meta of={useTrapFocusStories} />
+
+# useTrapFocus
+
+## Usage
+
+This hook confines keyboard navigation inside a container:
+
+- pressing `Tab` on the last focusable element loops back to the first
+- pressing `Shift+Tab` on the first loops to the last
+
+It is an accessibility building block. Without it, keyboard and screen reader users can
+tab out of an open dialog and reach the page behind it.
+
+## Example
+
+Click inside the box below, then press `Tab` or `Shift+Tab` to cycle through the fields.
+
+<Canvas of={useTrapFocusStories.Base} />
+
+## Hook usage
+
+```jsx
+const ref = useTrapFocus(isOpen);
+
+<div ref={ref} role="dialog" aria-modal="true">
+  <input name="email" />
+  <input name="password" />
+  <button onClick={onClose}>Close</button>
+</div>;
+```
+
+## Parameters
+
+- `isActive` (boolean, optional): Enables the trap. Pass the open state of the dialog so
+  focus is only confined while it is displayed.
+
+## Returns
+
+- `ref` (ref): To attach to the container element.
+
+Focusable elements are detected automatically — buttons, links, inputs, selects,
+textareas and anything with a non-negative `tabindex`. Disabled buttons are excluded.

--- a/packages/react/src/hooks/useTrapFocus/useTrapFocus.stories.tsx
+++ b/packages/react/src/hooks/useTrapFocus/useTrapFocus.stories.tsx
@@ -8,6 +8,12 @@ import useTrapFocus from './useTrapFocus';
 
 const meta: Meta<typeof useTrapFocus> = {
   title: 'Hooks/useTrapFocus',
+  // A hook has no visual surface of its own: this story is an interactive demo
+  // embedded in the MDX guide, not a design system visual to watch for
+  // regressions. Excluding it keeps the Chromatic budget for components.
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
 };
 
 export default meta;

--- a/packages/react/src/hooks/useUiOverride/useUiOverride.mdx
+++ b/packages/react/src/hooks/useUiOverride/useUiOverride.mdx
@@ -1,0 +1,47 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Hooks/useUiOverride" />
+
+# useUiOverride
+
+The `useUiOverride` hook reads a UI override declared by the platform in its
+`theme-conf`, so a deployment can switch a component variant without any code change
+in the consuming app.
+
+## Usage
+
+```tsx
+import useUiOverride from './useUiOverride';
+
+const override = useUiOverride('layout.header');
+```
+
+## Parameters
+
+- `key` (string): The override key to look up, as registered in the theme configuration
+  (for example `layout.header`).
+
+## Returns
+
+- `override` (object | undefined): The override registered under `key`, or `undefined`
+  when the platform declares none.
+
+The value is **normalized**: a `theme-conf` may declare an override either as a plain
+string or as an object. A string is returned as `{ variant: '<the string>' }`, so
+callers can always read `override?.variant` without testing the type.
+
+## Example
+
+```tsx
+const override = useUiOverride('layout.header');
+
+// theme-conf: { 'layout.header': 'v2' }
+//   → { variant: 'v2' }
+// theme-conf: { 'layout.header': { variant: 'v2', theme: 'crna' } }
+//   → { variant: 'v2', theme: 'crna' }
+
+return override?.variant === 'v2' ? <HeaderV2 /> : <Header />;
+```
+
+Prefer this hook over hard-coding a platform test (`if (theme === 'crna')`): the
+condition then lives in the platform configuration rather than in the framework.

--- a/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.mdx
+++ b/packages/react/src/hooks/useWorkspaceFolders/useWorkspaceFolders.mdx
@@ -1,0 +1,61 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Hooks/useWorkspaceFolders" />
+
+# useWorkspaceFolders
+
+The `useWorkspaceFolders` hook loads the user's workspace folders — personal and shared —
+and exposes folder creation. Its companion `useWorkspaceFoldersTree` turns that flat list
+into a searchable tree.
+
+## Usage
+
+```tsx
+import useWorkspaceFolders from './useWorkspaceFolders';
+
+const { folders, createFolderMutation, canCopyFileIntoFolder, isLoading } =
+  useWorkspaceFolders();
+```
+
+## Returns
+
+- `folders` (WorkspaceElement[]): Personal and shared folders, merged.
+- `createFolderMutation` (mutation): TanStack Query mutation taking
+  `{ folderName, folderParentId? }`. On success it updates the cache directly instead of
+  refetching; on failure it shows an error toast.
+- `canCopyFileIntoFolder` (function): Tells whether the user may copy a file into a given
+  folder — a shared folder can be browsable without being writable.
+- `isLoading` (boolean): True while either the personal or the shared list is loading.
+
+Both lists are fetched through TanStack Query under the keys
+`['workspace', 'folders', 'owner']` and `['workspace', 'folders', 'shared']`.
+
+## useWorkspaceFoldersTree
+
+```tsx
+const { foldersTree, filterTree } = useWorkspaceFoldersTree(folders);
+```
+
+Builds the two root nodes ("My documents" and "Shared documents") and nests folders under
+them. `filterTree` narrows the tree to nodes matching a search query.
+
+Two constants identify the roots, which have no real id on the backend:
+
+- `WORKSPACE_USER_FOLDER_ID`
+- `WORKSPACE_SHARED_FOLDER_ID`
+
+When passing a selection to the API, the personal root must be sent as an **empty string**
+rather than its constant, since the backend expects an empty `parentId` at that level.
+
+## Example
+
+```tsx
+const { folders, isLoading } = useWorkspaceFolders();
+const { foldersTree } = useWorkspaceFoldersTree(folders);
+
+if (isLoading) return <LoadingScreen />;
+return <TreeView data={foldersTree} onTreeItemClick={handleSelect} />;
+```
+
+The `WorkspaceFolders` component of the multimedia module already wires all of this
+together — use it rather than rebuilding the picker.

--- a/packages/react/src/hooks/useZoom/useZoom.mdx
+++ b/packages/react/src/hooks/useZoom/useZoom.mdx
@@ -1,0 +1,51 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Hooks/useZoom" />
+
+# useZoom
+
+The `useZoom` hook manages a zoom scale bounded between a minimum and a maximum value.
+
+## Usage
+
+```tsx
+import useZoom from './useZoom';
+
+const { scale, zoomIn, zoomOut, resetZoom, setScale } = useZoom();
+```
+
+## Parameters
+
+- `initialScale` (number, optional): The scale to start from. Defaults to `1`.
+- `maxScale` (number, optional): Upper bound, `zoomIn` never goes above it. Defaults to `2`.
+- `minScale` (number, optional): Lower bound, `zoomOut` never goes below it. Defaults to `0.5`.
+- `step` (number, optional): Increment applied by each zoom action. Defaults to `0.5`.
+
+## Returns
+
+- `scale` (number): The current scale.
+- `zoomIn` (function): Increases the scale by `step`, capped at `maxScale`.
+- `zoomOut` (function): Decreases the scale by `step`, floored at `minScale`.
+- `resetZoom` (function): Restores `initialScale`.
+- `setScale` (function): Sets the scale directly. Note that this setter does **not**
+  apply the min/max clamping — use it only when the caller already controls the range.
+
+## Example
+
+```tsx
+import useZoom from './useZoom';
+
+function ImagePreview({ src }: { src: string }) {
+  const { scale, zoomIn, zoomOut, resetZoom } = useZoom(1, 3, 0.5, 0.25);
+
+  return (
+    <div>
+      <button onClick={zoomOut}>-</button>
+      <button onClick={resetZoom}>{Math.round(scale * 100)}%</button>
+      <button onClick={zoomIn}>+</button>
+
+      <img src={src} style={{ transform: `scale(${scale})` }} alt="" />
+    </div>
+  );
+}
+```

--- a/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlash.stories.tsx
+++ b/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlash.stories.tsx
@@ -13,6 +13,12 @@ const meta = {
   component: MessageFlash,
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          "The `MessageFlash` component renders a single flash message pushed by the platform (an `IFlashMessageModel` from `@edifice.io/client`) on the homepage. It picks the content matching the user's current language, falls back to French, then to the first non-empty translation available. Long messages are truncated to two lines with a toggle to expand them, and the message can be dismissed through the `onCloseMessage` callback — persisting that dismissal is the caller's responsibility. The visual style (info, warning, alert…) follows the message model itself, not a prop.",
+      },
+    },
   },
   tags: ['autodocs'],
 } satisfies Meta<typeof MessageFlash>;

--- a/packages/react/src/modules/homepage/components/Notifications/NotificationItem.stories.tsx
+++ b/packages/react/src/modules/homepage/components/Notifications/NotificationItem.stories.tsx
@@ -7,6 +7,12 @@ const meta = {
   component: NotificationItem,
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The `NotificationItem` component renders a single notification from a raw `NotificationModel`. It adapts the model internally and picks one of two display variants: **user** when another user triggered the event (a shared resource, for instance) — the author avatar is then shown; **system** when the event comes from an application — the app icon is shown instead. Callers only pass the model: the variant is inferred, never chosen through a prop.',
+      },
+    },
   },
   tags: ['autodocs'],
   decorators: [

--- a/packages/react/src/modules/homepage/components/Notifications/NotificationSkeleton.stories.tsx
+++ b/packages/react/src/modules/homepage/components/Notifications/NotificationSkeleton.stories.tsx
@@ -6,6 +6,12 @@ const meta = {
   component: NotificationSkeleton,
   parameters: {
     layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'The `NotificationSkeleton` component is the loading placeholder of `NotificationItem`. It mirrors its layout — avatar on the left, text lines and an action block on the right — so the notification list keeps a stable height while data is being fetched, avoiding a layout shift when the real items arrive. It takes no prop beyond the standard `div` attributes and forwards its ref, which makes it usable as a sentinel in an infinite-scroll list.',
+      },
+    },
   },
   tags: ['autodocs'],
   decorators: [

--- a/packages/react/src/modules/modals/ShareModal/ShareModal.stories.tsx
+++ b/packages/react/src/modules/modals/ShareModal/ShareModal.stories.tsx
@@ -12,6 +12,14 @@ const mockShareOptions: ShareOptions = {
 const meta: Meta<typeof ShareModal> = {
   title: 'Modules/Modals/ShareModal',
   component: ShareModal,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The `ShareModal` component is the standard sharing dialog: it wraps `ShareResources` in a modal and adds the confirm/cancel actions. It expects `shareOptions` describing the resource (id, current rights, creator id) and calls `onSuccess` once sharing succeeded, `onCancel` when the user backs out. By default the modal performs the share request itself; pass the optional `shareResource` mutation only when the host app needs optimistic UI — it must then be a React Query mutation. The `children` slot lets an app inject its own specific block into the dialog (as the Blog does).',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/packages/react/src/modules/modals/ShareModal/ShareResources.stories.tsx
+++ b/packages/react/src/modules/modals/ShareModal/ShareResources.stories.tsx
@@ -16,6 +16,14 @@ const mockShareOptions: ShareOptions = {
 const meta: Meta<typeof ShareResources> = {
   title: 'Modules/ShareResources',
   component: ShareResources,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The `ShareResources` component is the sharing panel itself, without any dialog around it: user and group search, the rights matrix (read, contribute, manage…) and bookmark handling. Most apps should use `ShareModal`, which already embeds it together with the confirm/cancel actions — reach for `ShareResources` directly only when the panel must be hosted in a custom container. It exposes a `ShareResourcesRef` so the parent can trigger the submission from its own button, and reports state through `onChange` (current rights plus a dirty flag) and `onSubmit`.',
+      },
+    },
+  },
   globals: {
     app: 'actualites',
   },

--- a/packages/react/src/modules/multimedia/FileCard/FileCard.stories.tsx
+++ b/packages/react/src/modules/multimedia/FileCard/FileCard.stories.tsx
@@ -5,6 +5,14 @@ import FileCard from './FileCard';
 const meta: Meta<typeof FileCard> = {
   title: 'Components/Card/File Card',
   component: FileCard,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "The `FileCard` component renders a workspace document (`WorkspaceElement`) as a card. The icon and colour are derived automatically from the file type — image, video, audio or text — and can be overridden through `customIcon` and `customColor`. Being built on `Card`, it inherits its interaction props (`isClickable`, `isSelectable`, `isSelected`, `onClick`), which makes it usable both as a simple link and as an item in a multi-selection list. Note: this component is meant for internal use inside the multimedia module and isn't part of the package's public exports.",
+      },
+    },
+  },
   args: {
     isSelectable: false,
     isClickable: true,

--- a/packages/react/src/modules/multimedia/Linker/ExternalLinker/ExternalLinker.stories.tsx
+++ b/packages/react/src/modules/multimedia/Linker/ExternalLinker/ExternalLinker.stories.tsx
@@ -5,6 +5,14 @@ import { ExternalLinker } from './ExternalLinker';
 const meta: Meta<typeof ExternalLinker> = {
   title: 'Modules/Multimedia/ExternalLinker',
   component: ExternalLinker,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The `ExternalLinker` component is the form used to attach an external URL, typically from the editor link dialog. It edits a `{ url, text, target }` triple and reports every change through `onChange`, leaving validation and persistence to the caller. Pass an existing `link` to edit it rather than create a new one. When several nodes are selected in the editor, set `multiNodeSelected` so the component hides the link-text field — that text cannot apply to a multi-node selection. Its counterpart for internal resources is `InternalLinker`.',
+      },
+    },
+  },
   args: {},
 };
 

--- a/packages/react/src/modules/multimedia/MediaLibrary/MediaLibrary.stories.tsx
+++ b/packages/react/src/modules/multimedia/MediaLibrary/MediaLibrary.stories.tsx
@@ -13,6 +13,14 @@ import MediaLibrary, {
 const meta: Meta<typeof MediaLibrary> = {
   title: 'Modules/Multimedia/MediaLibrary',
   component: MediaLibrary,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "The `MediaLibrary` component is the modal through which the user picks or produces a media. It gathers every source behind tabs: the workspace, a device upload, an external link, embed code, and direct audio or video recording. Which tabs appear depends on the requested `MediaLibraryType`, so the same component serves an image picker as well as an attachment picker. It is driven imperatively through a `MediaLibraryRef` — the host app opens it on the right tab and receives the user's selection as a `MediaLibraryResult`. Most apps reach it indirectly through the editor rather than mounting it themselves.",
+      },
+    },
+  },
   decorators: [
     (Story) => {
       return (

--- a/packages/react/src/modules/multimedia/Workspace/Workspace.stories.tsx
+++ b/packages/react/src/modules/multimedia/Workspace/Workspace.stories.tsx
@@ -5,6 +5,14 @@ import Workspace from './Workspace';
 const meta: Meta<typeof Workspace> = {
   title: 'Modules/Multimedia/Workspace',
   component: Workspace,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "The `Workspace` component is the document browser used inside the media library: a folder tree on one side, the documents of the selected folder on the other, with search and sorting (by name or by date). The `roles` prop filters which media types are listed — pass `null` to show everything — while `defaultFolder` pre-selects a folder on open and `showPublicFolder` exposes public documents. It handles browsing and selection only; uploading is the media library's job.",
+      },
+    },
+  },
   args: {},
 };
 

--- a/packages/react/src/modules/multimedia/WorkspaceFolders/WorkspaceFolders.stories.tsx
+++ b/packages/react/src/modules/multimedia/WorkspaceFolders/WorkspaceFolders.stories.tsx
@@ -6,6 +6,14 @@ import WorkspaceFolders from './WorkspaceFolders';
 const meta: Meta<typeof Workspace> = {
   title: 'Modules/Multimedia/WorkspaceFolders',
   component: WorkspaceFolders,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'The `WorkspaceFolders` component displays the workspace folder tree — personal folders and shared folders — with a search field and the ability to create a folder. It is the destination picker used when copying a document into the workspace. Each selection triggers `onFolderSelected` with the folder id **and** a `canCopyFileInto` flag, since the user may browse a shared folder without holding write access to it: the caller must honour that flag before enabling its own confirm action. Folders are fetched by the component itself through `useWorkspaceFolders`.',
+      },
+    },
+  },
   args: {},
 };
 

--- a/packages/react/src/modules/widgets/BookmarkedApps/BookmarkedApps.stories.tsx
+++ b/packages/react/src/modules/widgets/BookmarkedApps/BookmarkedApps.stories.tsx
@@ -6,6 +6,14 @@ import BookmarkedApps from './BookmarkedApps';
 const meta: Meta<typeof BookmarkedApps> = {
   title: 'Modules/Widgets/Bookmarked Apps',
   component: BookmarkedApps,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          "The `BookmarkedApps` component is the homepage widget listing the user's favourite applications as clickable icons linking to each app. It renders **at most the first six** entries of the `data` array it receives — the caller decides the ordering. When the list is empty, it falls back to a link inviting the user to pick their favourite apps. It is a pure display component: it neither fetches nor persists the bookmarks.",
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <div style={{ width: '300px' }}>


### PR DESCRIPTION
# Description

Complète la documentation Storybook des briques publiques de `@edifice.io/react`.

Ticket : [ENABLING-1015](https://edifice-community.atlassian.net/browse/ENABLING-1015)

Storybook tourne avec `autodocs` activé globalement : chaque story dispose déjà d'une page Docs avec son tableau de props généré depuis les types. Le déficit ne portait donc pas sur l'API mais sur la **narration** — à quoi sert la brique, quand l'utiliser. Le recensement a fait ressortir trois cas :

- **14 composants** sans `docs.description.component` (`Grid`, `StackedGroup`, `MessageFlash`, `ShareModal`, `MediaLibrary`, `Workspace`…) → description ajoutée dans le `meta` de la story.
- **4 hooks sans aucune documentation**, ni story ni MDX (`useHttpErrorToast`, `useUiOverride`, `useWorkspaceFolders`, `useZoom`) → page MDX autonome créée. Ces quatre-là étaient invisibles pour une analyse partant des fichiers de stories.
- **2 hooks** documentés par une description de story alors que les 43 autres utilisent un MDX (`useToggle`, `useTrapFocus`) → alignés sur la norme, leur MDX est désormais rattaché à la story via `<Meta of={…}>`.

Résultat : **49/49 hooks** et **123/123 stories** documentés.

La convention est écrite dans `CONTRIBUTING.md`, en reflétant la pratique réelle du repo — description de story pour les composants (l'autodoc fournit déjà les props), MDX pour les hooks (rattaché quand une démo visuelle existe, autonome sinon).

**Note Chromatic** : aucune story n'est créée, donc aucun snapshot ajouté. Un second commit exclut au contraire les 11 stories de hooks des captures (`chromatic: { disableSnapshot: true }`) — une démo de hook n'est pas un visuel du design system à surveiller. Gain ~22 snapshots par build complet, dans le contexte de quota d'ENABLING-997.

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [x] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Comment tester

1. `pnpm docs` puis parcourir les pages concernées — les 4 nouveaux hooks apparaissent sous `Hooks/`, et les composants listés ci-dessus ont désormais un texte au-dessus de leur tableau de props.
2. Vérifier que `useToggle` et `useTrapFocus` affichent bien leur page MDX (avec la démo embarquée) et non l'autodoc.
3. `pnpm docs:build` — vert (seuls les warnings préexistants du repo : `NPM_TOKEN`, `"use client"`).


[ENABLING-1015]: https://edifice-community.atlassian.net/browse/ENABLING-1015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ