### PR TITLE
fix: #PEDAGO-4020, remove old Community app from Header

### DIFF
--- a/packages/react/src/components/Layout/components/Header.stories.tsx
+++ b/packages/react/src/components/Layout/components/Header.stories.tsx
@@ -25,7 +25,7 @@ const meta: Meta<typeof Header> = {
     docs: {
       description: {
         component:
-          'Legacy portal header. It renders the main navigation (home, applications, messaging, community, help, account) and adapts its layout to the school level through the `is1d` prop: the 2nd degree (default) layout uses a single navbar, while the 1st degree layout (`is1d`) displays a dedicated secondary navbar. Messaging, community, search and help entries are gated by the user workflows.',
+          'Legacy portal header. It renders the main navigation (home, applications, messaging, communities, help, account) and adapts its layout to the school level through the `is1d` prop: the 2nd degree (default) layout uses a single navbar, while the 1st degree layout (`is1d`) displays a dedicated secondary navbar. Messaging, communities, search and help entries are gated by the user workflows.',
       },
     },
   },

--- a/packages/react/src/components/Layout/components/Header.tsx
+++ b/packages/react/src/components/Layout/components/Header.tsx
@@ -16,7 +16,6 @@ import { useEdificeTheme } from '../../../providers/EdificeThemeProvider/Edifice
 
 import { IconRafterDown } from '../../../modules/icons/components';
 import {
-  IconCommunity,
   IconCommunities,
   IconDisconnect,
   IconHome,
@@ -81,7 +80,6 @@ const Header = ({ is1d = false, src = '' }: HeaderProps): JSX.Element => {
     userAvatar,
     userName,
     welcomeUser,
-    communityWorkflow,
     communitiesWorkflow,
     conversationWorflow,
     searchWorkflow,
@@ -399,16 +397,6 @@ const Header = ({ is1d = false, src = '' }: HeaderProps): JSX.Element => {
                     }`}
                     id="dropdown-navbar"
                   >
-                    {communityWorkflow && (
-                      <NavItem>
-                        <a href="/community" className="nav-link dropdown-item">
-                          <IconCommunity className="icon community" />
-                          <span className="nav-text">
-                            {t('navbar.community')}
-                          </span>
-                        </a>
-                      </NavItem>
-                    )}
                     {communitiesWorkflow && (
                       <NavItem>
                         <a

--- a/packages/react/src/components/Layout/hooks/useHeader.ts
+++ b/packages/react/src/components/Layout/hooks/useHeader.ts
@@ -53,9 +53,6 @@ export default function useHeader({
   /**
    * Handle Header Workflows
    */
-  const communityWorkflow = useHasWorkflow(
-    'net.atos.entng.community.controllers.CommunityController|view',
-  );
   const communitiesWorkflow = useHasWorkflow('community.access');
   const conversationWorflow = useHasWorkflow(
     'org.entcore.conversation.controllers.ConversationController|view',
@@ -79,7 +76,6 @@ export default function useHeader({
       userAvatar,
       userName,
       welcomeUser,
-      communityWorkflow,
       communitiesWorkflow,
       conversationWorflow,
       searchWorkflow,
@@ -90,7 +86,6 @@ export default function useHeader({
       appsRef,
       bookmarkedApps,
       communitiesWorkflow,
-      communityWorkflow,
       conversationWorflow,
       isAppsHovered,
       isCollapsed,


### PR DESCRIPTION
# Description

Remove old Community app from Header

https://edifice-community.atlassian.net/browse/PEDAGO-4020

## Which Package changed?

Please check the name of the package you changed

- [ ] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
