### PR TITLE
feat(react): #IMPULS-6138 add disabled prop to DatePicker

### DIFF
--- a/packages/react/src/components/DatePicker/DatePicker.spec.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.spec.tsx
@@ -79,4 +79,24 @@ describe('DatePicker', () => {
 
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
+
+  it('disables the input and does not open the calendar when disabled', async () => {
+    const onChange = vi.fn();
+    const { user } = render(
+      <DatePicker
+        value={new Date(2026, 0, 15)}
+        onChange={onChange}
+        disabled
+        data-testid="date-picker"
+      />,
+    );
+
+    const input = screen.getByTestId('date-picker');
+    expect(input).toBeDisabled();
+
+    await user.click(input);
+
+    expect(screen.queryByText('20')).not.toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/packages/react/src/components/DatePicker/DatePicker.stories.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.stories.tsx
@@ -12,6 +12,11 @@ const meta: Meta<typeof DatePicker> = {
       control: { type: 'date' },
       description: 'Selected date value',
     },
+    disabled: {
+      control: { type: 'boolean' },
+      description:
+        'Disables the input and prevents the calendar popup from opening',
+    },
   },
   parameters: {
     docs: {
@@ -37,6 +42,7 @@ export const Default: Story = {
       today.getMonth(),
       today.getDate() + 3,
     ),
+    disabled: false,
     onChange: (date) => {
       console.log('Selected date:', date);
     },
@@ -48,6 +54,7 @@ export const Default: Story = {
         maxDate={args.maxDate}
         minDate={args.minDate}
         value={date}
+        disabled={args.disabled}
         data-testid="date-picker-default"
         dateFormat={args.dateFormat}
         onChange={(newDate) => {
@@ -58,4 +65,20 @@ export const Default: Story = {
       />
     );
   },
+};
+
+export const Disabled: Story = {
+  args: {
+    value: new Date(),
+    dateFormat: 'DD / MM / YYYY',
+    disabled: true,
+  },
+  render: (args) => (
+    <DatePicker
+      value={args.value}
+      disabled={args.disabled}
+      dateFormat={args.dateFormat}
+      data-testid="date-picker-disabled"
+    />
+  ),
 };

--- a/packages/react/src/components/DatePicker/DatePicker.tsx
+++ b/packages/react/src/components/DatePicker/DatePicker.tsx
@@ -52,6 +52,12 @@ export interface DatePickerProps extends Omit<
    * Maximum selectable date
    */
   maxDate?: Date;
+
+  /**
+   * Disables the input and prevents the calendar popup from opening.
+   * @default false
+   */
+  disabled?: boolean;
 }
 
 /**
@@ -87,6 +93,7 @@ const DatePicker = forwardRef<HTMLElement, DatePickerProps>(
       dateFormat = 'DD / MM / YYYY',
       minDate,
       maxDate,
+      disabled,
       ...htmlProps
     },
     ref,
@@ -101,6 +108,7 @@ const DatePicker = forwardRef<HTMLElement, DatePickerProps>(
       format: dateFormat,
       minDate: minDate ? dayjs(minDate) : undefined,
       maxDate: maxDate ? dayjs(maxDate) : undefined,
+      disabled,
       ref: ref as any, // Cast necessary because AntDatePicker expects a specific type, but our API exposes only HTMLElement to avoid dependency on Ant Design-specific features.
       ...htmlProps,
     };


### PR DESCRIPTION
## Résumé
Ajoute une prop `disabled` au composant `DatePicker` : elle désactive l'input et empêche l'ouverture du calendrier.

## Contexte
Ticket : [IMPULS-6138](https://edifice-community.atlassian.net/browse/IMPULS-6138)

## Changements
- Ajout de la prop `disabled?: boolean` sur `DatePickerProps`, transmise à l'input Ant Design sous-jacent
- Nouvelle story `Disabled` dans `DatePicker.stories.tsx` et control `disabled` sur la story par défaut
- Nouveau test : input désactivé et calendrier qui ne s'ouvre pas au clic quand `disabled` est actif

## Comment tester
1. `pnpm --filter @edifice.io/react test` (les 6 tests de `DatePicker.spec.tsx` passent, dont le nouveau cas `disabled`)
2. `pnpm docs` puis ouvrir la story `DatePicker > Disabled` pour vérifier visuellement que l'input est désactivé et que le calendrier ne s'ouvre pas au clic

[IMPULS-6138]: https://edifice-community.atlassian.net/browse/IMPULS-6138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ