### PR TITLE
test: #ENABLING-1132 couvre les utilitaires d'arbre et trois hooks sans tests

### DIFF
--- a/packages/react/src/components/Tree/hooks/useTree.spec.tsx
+++ b/packages/react/src/components/Tree/hooks/useTree.spec.tsx
@@ -1,0 +1,275 @@
+import { act, renderHook } from '~/setup';
+import { TreeItem } from '../types';
+import { useTree } from './useTree';
+
+// a
+// └── a1
+// b
+function makeNodes(): TreeItem[] {
+  return [
+    { id: 'a', name: 'A', children: [{ id: 'a1', name: 'A1' }] },
+    { id: 'b', name: 'B' },
+  ];
+}
+
+type Callbacks = {
+  onTreeItemUnfold: ReturnType<typeof vi.fn>;
+  onTreeItemFold: ReturnType<typeof vi.fn>;
+  onTreeItemClick: ReturnType<typeof vi.fn>;
+};
+
+// The data identity must stay stable across renders: the expand-all effect
+// depends on it, so a fresh array on every render would loop forever.
+function setup(
+  props: Partial<Parameters<typeof useTree>[0]> = {},
+): { result: { current: ReturnType<typeof useTree> } } & Callbacks {
+  const callbacks: Callbacks = {
+    onTreeItemUnfold: vi.fn(),
+    onTreeItemFold: vi.fn(),
+    onTreeItemClick: vi.fn(),
+  };
+  const data = props.data ?? makeNodes();
+
+  const { result } = renderHook(() =>
+    useTree({ ...callbacks, ...props, data }),
+  );
+
+  return { result, ...callbacks };
+}
+
+const expanded = (result: { current: ReturnType<typeof useTree> }) =>
+  Array.from(result.current.expandedNodes);
+
+describe('useTree', () => {
+  it('starts with nothing selected, nothing expanded and nothing dragged', () => {
+    const { result } = setup();
+
+    expect(result.current.selectedNodeId).toBeUndefined();
+    expect(expanded(result)).toEqual([]);
+    expect(result.current.draggedNodeId).toBeUndefined();
+  });
+
+  describe('handleItemClick', () => {
+    it('selects the node, expands its path and notifies the parent', () => {
+      const { result, onTreeItemClick, onTreeItemUnfold } = setup();
+
+      act(() => result.current.handleItemClick('a1'));
+
+      expect(result.current.selectedNodeId).toBe('a1');
+      expect(expanded(result)).toEqual(['a', 'a1']);
+      expect(onTreeItemClick).toHaveBeenCalledWith('a1');
+      expect(onTreeItemUnfold).toHaveBeenCalledWith('a');
+      expect(onTreeItemUnfold).toHaveBeenCalledWith('a1');
+    });
+
+    it('keeps the selection when clicking the already selected node', () => {
+      const { result, onTreeItemClick } = setup();
+
+      act(() => result.current.handleItemClick('b'));
+      act(() => result.current.handleItemClick('b'));
+
+      expect(result.current.selectedNodeId).toBe('b');
+      expect(onTreeItemClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('expands a first-level node with its own id only', () => {
+      const { result } = setup();
+
+      act(() => result.current.handleItemClick('a'));
+
+      expect(expanded(result)).toEqual(['a']);
+    });
+  });
+
+  describe('handleFoldUnfold', () => {
+    it('expands a collapsed node', () => {
+      const { result, onTreeItemUnfold } = setup();
+
+      act(() => result.current.handleFoldUnfold('a'));
+
+      expect(expanded(result)).toEqual(['a']);
+      expect(onTreeItemUnfold).toHaveBeenCalledWith('a');
+    });
+
+    it('collapses an expanded node without touching its ancestors', () => {
+      const { result, onTreeItemFold } = setup();
+
+      act(() => result.current.handleItemClick('a1'));
+      act(() => result.current.handleFoldUnfold('a1'));
+
+      expect(expanded(result)).toEqual(['a']);
+      // The fold callback fires for the nodes that stay open.
+      expect(onTreeItemFold).toHaveBeenCalledWith('a');
+      expect(onTreeItemFold).not.toHaveBeenCalledWith('a1');
+    });
+
+    it('is a no-op on an unknown node beyond opening nothing', () => {
+      const { result } = setup();
+
+      act(() => result.current.handleFoldUnfold('ghost'));
+
+      expect(expanded(result)).toEqual([]);
+    });
+  });
+
+  describe('handleCollapseNode', () => {
+    it('removes a single node from the expanded set', () => {
+      const { result } = setup();
+
+      act(() => result.current.handleItemClick('a1'));
+      act(() => result.current.handleCollapseNode('a'));
+
+      expect(expanded(result)).toEqual(['a1']);
+    });
+  });
+
+  describe('shouldExpandAllNodes', () => {
+    it('expands every first-level node on mount', () => {
+      const { result } = setup({ shouldExpandAllNodes: true });
+
+      expect(expanded(result)).toEqual(['a', 'b']);
+    });
+
+    it('ignores the flag when the data is a single root node', () => {
+      const data: TreeItem = {
+        id: 'root',
+        name: 'Root',
+        children: makeNodes(),
+      };
+
+      const { result } = renderHook(() =>
+        useTree({ data, shouldExpandAllNodes: true }),
+      );
+
+      expect(Array.from(result.current.expandedNodes)).toEqual([]);
+    });
+  });
+
+  describe('externalSelectedNodeId', () => {
+    it('selects and expands the path of an existing node', () => {
+      const { result, onTreeItemUnfold } = setup({
+        externalSelectedNodeId: 'a1',
+      });
+
+      expect(result.current.selectedNodeId).toBe('a1');
+      expect(expanded(result)).toEqual(['a', 'a1']);
+      expect(onTreeItemUnfold).toHaveBeenCalledWith('a1');
+    });
+
+    it('still reports an unknown node as selected but expands nothing', () => {
+      const { result, onTreeItemUnfold } = setup({
+        externalSelectedNodeId: 'ghost',
+      });
+
+      expect(result.current.selectedNodeId).toBe('ghost');
+      expect(expanded(result)).toEqual([]);
+      expect(onTreeItemUnfold).not.toHaveBeenCalled();
+    });
+
+    it('does not expand the path when every node is already expanded', () => {
+      const { result } = setup({
+        externalSelectedNodeId: 'a1',
+        shouldExpandAllNodes: true,
+      });
+
+      expect(result.current.selectedNodeId).toBe('a1');
+      expect(expanded(result)).toEqual(['a', 'b']);
+    });
+
+    it('only replays the unfold callbacks for the "default" node', () => {
+      const nodes: TreeItem[] = [
+        { id: 'default', name: 'Default' },
+        ...makeNodes(),
+      ];
+      const onTreeItemUnfold = vi.fn();
+
+      const { result } = renderHook(() =>
+        useTree({
+          data: nodes,
+          externalSelectedNodeId: 'default',
+          onTreeItemUnfold,
+        }),
+      );
+
+      expect(result.current.selectedNodeId).toBe('default');
+      expect(Array.from(result.current.expandedNodes)).toEqual([]);
+      expect(onTreeItemUnfold).not.toHaveBeenCalled();
+    });
+
+    it('drops the internal selection when the prop is cleared', () => {
+      const data = makeNodes();
+
+      const { result, rerender } = renderHook(
+        ({ externalSelectedNodeId }: { externalSelectedNodeId?: string }) =>
+          useTree({ data, externalSelectedNodeId }),
+        { initialProps: { externalSelectedNodeId: 'a1' } },
+      );
+
+      expect(result.current.selectedNodeId).toBe('a1');
+
+      rerender({ externalSelectedNodeId: undefined });
+
+      expect(result.current.selectedNodeId).toBeUndefined();
+    });
+  });
+
+  describe('draggedNode', () => {
+    it('tracks the node being dragged over the tree', () => {
+      const { result } = setup({
+        externalSelectedNodeId: 'a1',
+        draggedNode: { isOver: true, overId: 'a', isTreeview: true },
+      });
+
+      expect(result.current.draggedNodeId).toBe('a');
+    });
+
+    it('clears the dragged node when the pointer leaves the tree', () => {
+      const { result } = setup({
+        externalSelectedNodeId: 'a1',
+        draggedNode: { isOver: false, overId: 'a', isTreeview: true },
+      });
+
+      expect(result.current.draggedNodeId).toBeUndefined();
+    });
+
+    it('ignores a drag coming from outside the treeview', () => {
+      const { result } = setup({
+        draggedNode: { isOver: true, overId: 'a', isTreeview: false },
+      });
+
+      expect(result.current.draggedNodeId).toBeUndefined();
+    });
+
+    // Dragging over a node collapses it here, where the TreeView flavour of the
+    // hook expands it.
+    it('collapses the hovered node when a drag enters it', () => {
+      const data = makeNodes();
+      const onTreeItemFold = vi.fn();
+      type Props = {
+        draggedNode?: Parameters<typeof useTree>[0]['draggedNode'];
+      };
+
+      const { result, rerender } = renderHook(
+        ({ draggedNode }: Props) =>
+          useTree({
+            data,
+            externalSelectedNodeId: 'a1',
+            draggedNode,
+            onTreeItemFold,
+          }),
+        { initialProps: {} as Props },
+      );
+
+      // The external selection expanded the whole path of 'a1'.
+      expect(Array.from(result.current.expandedNodes)).toEqual(['a', 'a1']);
+
+      rerender({
+        draggedNode: { isOver: true, overId: 'a1', isTreeview: true },
+      });
+
+      expect(result.current.draggedNodeId).toBe('a1');
+      expect(Array.from(result.current.expandedNodes)).toEqual(['a']);
+      expect(onTreeItemFold).toHaveBeenCalledWith('a');
+    });
+  });
+});

--- a/packages/react/src/components/Tree/hooks/useTreeSortable.spec.tsx
+++ b/packages/react/src/components/Tree/hooks/useTreeSortable.spec.tsx
@@ -1,0 +1,336 @@
+import {
+  DragEndEvent,
+  DragMoveEvent,
+  DragOverEvent,
+  DragStartEvent,
+  MeasuringStrategy,
+} from '@dnd-kit/core';
+import { act, renderHook } from '~/setup';
+import { TreeItem, UpdateTreeData } from '../types';
+import { useTreeSortable } from './useTreeSortable';
+
+// a
+// ├── a1
+// └── a2
+// b
+function makeNodes(): TreeItem[] {
+  return [
+    {
+      id: 'a',
+      name: 'A',
+      children: [
+        { id: 'a1', name: 'A1' },
+        { id: 'a2', name: 'A2' },
+      ],
+    },
+    { id: 'b', name: 'B' },
+  ];
+}
+
+function setup(nodes: TreeItem[] = makeNodes()) {
+  const onSortable = vi.fn();
+  const handleCollapseNode = vi.fn();
+
+  // Stable identity: the hook mirrors the prop into its own state on change.
+  const { result } = renderHook(() =>
+    useTreeSortable({ nodes, onSortable, handleCollapseNode }),
+  );
+
+  return { result, onSortable, handleCollapseNode };
+}
+
+const dragStart = (id: string) =>
+  ({ active: { id } }) as unknown as DragStartEvent;
+const dragOver = (id: string) => ({ over: { id } }) as unknown as DragOverEvent;
+const dragMove = (x: number) => ({ delta: { x } }) as unknown as DragMoveEvent;
+const dragEnd = (activeId: string, overId?: string) =>
+  ({
+    active: { id: activeId },
+    over: overId ? { id: overId } : null,
+  }) as unknown as DragEndEvent;
+
+const positions = (updateArray: UpdateTreeData[]) =>
+  updateArray.map(({ _id, position, parentId }) => ({
+    _id,
+    position,
+    parentId,
+  }));
+
+describe('useTreeSortable', () => {
+  describe('initial state', () => {
+    it('flattens the nodes and exposes their sorted ids', () => {
+      const { result } = setup();
+
+      expect(result.current.items).toEqual(makeNodes());
+      expect(result.current.sortedIds).toEqual(['a', 'a1', 'a2', 'b']);
+      expect(
+        result.current.flattenedTree.map(({ id, depth, parentId }) => ({
+          id,
+          depth,
+          parentId,
+        })),
+      ).toEqual([
+        { id: 'a', depth: 0, parentId: null },
+        { id: 'a1', depth: 1, parentId: 'a' },
+        { id: 'a2', depth: 1, parentId: 'a' },
+        { id: 'b', depth: 0, parentId: null },
+      ]);
+    });
+
+    it('has nothing active and no projection before a drag', () => {
+      const { result } = setup();
+
+      expect(result.current.activeId).toBeNull();
+      expect(result.current.activeItem).toBeNull();
+      expect(result.current.projected).toBeNull();
+    });
+
+    it('exposes the drag-and-drop configuration of the tree', () => {
+      const { result } = setup();
+
+      expect(result.current.indentationWidth).toBe(64);
+      expect(result.current.indicator).toBe(false);
+      expect(result.current.activationConstraint).toEqual({
+        delay: 200,
+        tolerance: 5,
+      });
+      expect(result.current.measuring.droppable.strategy).toBe(
+        MeasuringStrategy.Always,
+      );
+      expect(result.current.sensors).toHaveLength(2);
+    });
+
+    it('mirrors a new nodes prop into its items', () => {
+      const first = makeNodes();
+      const second: TreeItem[] = [{ id: 'z', name: 'Z' }];
+      const onSortable = vi.fn();
+      const handleCollapseNode = vi.fn();
+
+      const { result, rerender } = renderHook(
+        ({ nodes }: { nodes: TreeItem[] }) =>
+          useTreeSortable({ nodes, onSortable, handleCollapseNode }),
+        { initialProps: { nodes: first } },
+      );
+
+      expect(result.current.sortedIds).toEqual(['a', 'a1', 'a2', 'b']);
+
+      rerender({ nodes: second });
+
+      expect(result.current.items).toEqual(second);
+      expect(result.current.sortedIds).toEqual(['z']);
+    });
+  });
+
+  describe('handleDragStart', () => {
+    it('collapses a first-level node and marks it active', () => {
+      const { result, handleCollapseNode } = setup();
+
+      act(() => result.current.handleDragStart(dragStart('a')));
+
+      expect(handleCollapseNode).toHaveBeenCalledWith('a');
+      expect(result.current.activeId).toBe('a');
+      expect(result.current.activeItem?.id).toBe('a');
+    });
+
+    it('does not collapse a nested node', () => {
+      const { result, handleCollapseNode } = setup();
+
+      act(() => result.current.handleDragStart(dragStart('a1')));
+
+      expect(handleCollapseNode).not.toHaveBeenCalled();
+      expect(result.current.activeId).toBe('a1');
+    });
+  });
+
+  describe('projection while dragging', () => {
+    it('keeps the node at the root level without a horizontal offset', () => {
+      const { result } = setup();
+
+      act(() => result.current.handleDragStart(dragStart('a')));
+      act(() => result.current.handleDragOver(dragOver('a2')));
+
+      expect(result.current.projected).toMatchObject({
+        depth: 0,
+        parentId: null,
+      });
+    });
+
+    it('nests the node after a one-step horizontal offset', () => {
+      const { result } = setup();
+
+      act(() => result.current.handleDragStart(dragStart('a')));
+      act(() => result.current.handleDragOver(dragOver('a2')));
+      act(() => result.current.handleDragMove(dragMove(64)));
+
+      expect(result.current.projected).toMatchObject({
+        depth: 1,
+        parentId: 'a',
+      });
+    });
+  });
+
+  describe('handleDragEnd', () => {
+    it('reorders at the root level and reports every new position', () => {
+      const { result, onSortable } = setup();
+
+      act(() => result.current.handleDragStart(dragStart('b')));
+      act(() => result.current.handleDragOver(dragOver('a1')));
+      act(() => result.current.handleDragEnd(dragEnd('b', 'a1')));
+
+      expect(onSortable).toHaveBeenCalledTimes(1);
+      expect(positions(onSortable.mock.calls[0][0])).toEqual([
+        { _id: 'a', position: 0, parentId: undefined },
+        { _id: 'a1', position: 1, parentId: 'a' },
+        { _id: 'a2', position: 2, parentId: 'a' },
+        { _id: 'b', position: 3, parentId: undefined },
+      ]);
+    });
+
+    it('re-parents the dropped node when the drag projects a nesting', () => {
+      const { result, onSortable } = setup();
+
+      act(() => result.current.handleDragStart(dragStart('b')));
+      act(() => result.current.handleDragOver(dragOver('a1')));
+      act(() => result.current.handleDragMove(dragMove(64)));
+      act(() => result.current.handleDragEnd(dragEnd('b', 'a1')));
+
+      expect(positions(onSortable.mock.calls[0][0])).toEqual([
+        { _id: 'a', position: 0, parentId: undefined },
+        { _id: 'b', position: 1, parentId: 'a' },
+        { _id: 'a1', position: 2, parentId: 'a' },
+        { _id: 'a2', position: 3, parentId: 'a' },
+      ]);
+    });
+
+    it('clears the drag state once dropped', () => {
+      const { result } = setup();
+
+      act(() => result.current.handleDragStart(dragStart('b')));
+      act(() => result.current.handleDragEnd(dragEnd('b', 'a1')));
+
+      expect(result.current.activeId).toBeNull();
+      expect(result.current.activeItem).toBeNull();
+      expect(result.current.projected).toBeNull();
+    });
+  });
+
+  describe('announcements', () => {
+    it('announces the picked up node', () => {
+      const { result } = setup();
+
+      expect(
+        result.current.announcements.onDragStart?.({
+          active: { id: 'b' },
+        } as unknown as DragStartEvent),
+      ).toBe('Picked up b.');
+    });
+
+    it('announces a cancelled move', () => {
+      const { result } = setup();
+
+      expect(
+        result.current.announcements.onDragCancel?.({
+          active: { id: 'b' },
+        } as unknown as DragStartEvent),
+      ).toBe('Moving was cancelled. b was dropped in its original position.');
+    });
+
+    it('announces a nesting while moving', () => {
+      const { result } = setup();
+      let announcement: string | undefined;
+
+      act(() => result.current.handleDragStart(dragStart('b')));
+      act(() => result.current.handleDragOver(dragOver('a1')));
+      act(() => result.current.handleDragMove(dragMove(64)));
+      act(() => {
+        announcement = result.current.announcements.onDragMove?.({
+          active: { id: 'b' },
+          over: { id: 'a1' },
+        } as unknown as DragMoveEvent) as string | undefined;
+      });
+
+      expect(announcement).toBe('b was nested under a.');
+    });
+
+    it('announces a move after the previous sibling', () => {
+      const { result } = setup();
+      let announcement: string | undefined;
+
+      act(() => result.current.handleDragStart(dragStart('b')));
+      act(() => result.current.handleDragOver(dragOver('a1')));
+      act(() => {
+        announcement = result.current.announcements.onDragOver?.({
+          active: { id: 'b' },
+          over: { id: 'a1' },
+        } as unknown as DragOverEvent) as string | undefined;
+      });
+
+      expect(announcement).toBe('b was moved after a.');
+    });
+
+    it('says nothing while no node is being dragged', () => {
+      const { result } = setup();
+
+      expect(
+        result.current.announcements.onDragMove?.({
+          active: { id: 'b' },
+          over: { id: 'a1' },
+        } as unknown as DragMoveEvent),
+      ).toBeUndefined();
+    });
+
+    it('says nothing when there is no node under the pointer', () => {
+      const { result } = setup();
+
+      act(() => result.current.handleDragStart(dragStart('b')));
+
+      expect(
+        result.current.announcements.onDragOver?.({
+          active: { id: 'b' },
+          over: null,
+        } as unknown as DragOverEvent),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('drag presentation', () => {
+    it('lifts the drag overlay by 25 pixels', () => {
+      const { result } = setup();
+
+      expect(
+        result.current.adjustTranslate({
+          transform: { x: 10, y: 100, scaleX: 1, scaleY: 1 },
+        } as Parameters<typeof result.current.adjustTranslate>[0]),
+      ).toEqual({ x: 10, y: 75, scaleX: 1, scaleY: 1 });
+    });
+
+    it('fades the dropped node out and re-animates the source node', () => {
+      const { result } = setup();
+      const animate = vi.fn();
+      const transform = {
+        initial: { x: 0, y: 0, scaleX: 1, scaleY: 1 },
+        final: { x: 10, y: 20, scaleX: 1, scaleY: 1 },
+      };
+
+      const keyframes = result.current.dropAnimationConfig.keyframes?.({
+        transform,
+      } as Parameters<
+        NonNullable<typeof result.current.dropAnimationConfig.keyframes>
+      >[0]);
+
+      expect(keyframes?.[0]).toMatchObject({ opacity: 1 });
+      expect(keyframes?.[1]).toMatchObject({ opacity: 0 });
+
+      result.current.dropAnimationConfig.sideEffects?.({
+        active: { node: { animate } },
+      } as unknown as Parameters<
+        NonNullable<typeof result.current.dropAnimationConfig.sideEffects>
+      >[0]);
+
+      expect(animate).toHaveBeenCalledWith(
+        [{ opacity: 0 }, { opacity: 1 }],
+        expect.objectContaining({ duration: expect.any(Number) }),
+      );
+    });
+  });
+});

--- a/packages/react/src/components/Tree/utilities/tree-sortable.spec.ts
+++ b/packages/react/src/components/Tree/utilities/tree-sortable.spec.ts
@@ -1,0 +1,513 @@
+import { Active, Over } from '@dnd-kit/core';
+import { FlattenedItem, Projected, TreeItem } from '../types';
+import {
+  buildTree,
+  determineNewParentId,
+  findItemIndexInTree,
+  flattenNodes,
+  flattenTree,
+  generateUpdateData,
+  getActiveAndOverNodes,
+  getDragDepth,
+  getIndicesToUpdate,
+  getProjection,
+  updateParentIds,
+} from './tree-sortable';
+
+// a
+// ├── a1
+// └── a2
+// b
+function makeNodes(): TreeItem[] {
+  return [
+    {
+      id: 'a',
+      name: 'A',
+      children: [
+        { id: 'a1', name: 'A1' },
+        { id: 'a2', name: 'A2' },
+      ],
+    },
+    { id: 'b', name: 'B' },
+  ];
+}
+
+const asActive = (id: string) => ({ id }) as unknown as Active;
+const asOver = (id: string) => ({ id }) as unknown as Over;
+
+describe('Tree sortable utilities', () => {
+  describe('getDragDepth', () => {
+    it('converts a horizontal offset into a depth step', () => {
+      expect(getDragDepth(64, 64)).toBe(1);
+      expect(getDragDepth(0, 64)).toBe(0);
+    });
+
+    it('rounds to the nearest step', () => {
+      expect(getDragDepth(100, 64)).toBe(2);
+      expect(getDragDepth(20, 64)).toBe(0);
+    });
+
+    it('handles a drag back to the left', () => {
+      expect(getDragDepth(-64, 64)).toBe(-1);
+    });
+  });
+
+  describe('flattenTree', () => {
+    it('flattens depth-first with parent ids and depths', () => {
+      const flattened = flattenTree(makeNodes(), null);
+
+      expect(
+        flattened.map(({ id, parentId, depth }) => ({ id, parentId, depth })),
+      ).toEqual([
+        { id: 'a', parentId: null, depth: 0 },
+        { id: 'a1', parentId: 'a', depth: 1 },
+        { id: 'a2', parentId: 'a', depth: 1 },
+        { id: 'b', parentId: null, depth: 0 },
+      ]);
+    });
+
+    it('starts at the given depth and parent', () => {
+      const flattened = flattenTree([{ id: 'x', name: 'X' }], 'parent', 3);
+
+      expect(flattened[0]).toMatchObject({
+        id: 'x',
+        parentId: 'parent',
+        depth: 3,
+      });
+    });
+
+    it('keeps an explicit position and defaults it to undefined otherwise', () => {
+      const flattened = flattenTree(
+        [
+          { id: 'x', name: 'X', position: 7 },
+          { id: 'y', name: 'Y' },
+        ],
+        null,
+      );
+
+      expect(flattened[0].position).toBe(7);
+      expect(flattened[1].position).toBeUndefined();
+    });
+
+    it('returns an empty array for an empty tree', () => {
+      expect(flattenTree([], null)).toEqual([]);
+    });
+  });
+
+  describe('flattenNodes', () => {
+    it('includes the children of an expanded node and flags the hierarchy', () => {
+      const flattened = flattenNodes(makeNodes(), new Set(['a']));
+
+      expect(
+        flattened.map(
+          ({ id, isChild, haveChilds, expandNode, parentExpanded }) => ({
+            id,
+            isChild,
+            haveChilds,
+            expandNode,
+            parentExpanded,
+          }),
+        ),
+      ).toEqual([
+        {
+          id: 'a',
+          isChild: false,
+          haveChilds: true,
+          expandNode: true,
+          parentExpanded: true,
+        },
+        {
+          id: 'a1',
+          isChild: true,
+          haveChilds: false,
+          expandNode: false,
+          parentExpanded: true,
+        },
+        {
+          id: 'a2',
+          isChild: true,
+          haveChilds: false,
+          expandNode: false,
+          parentExpanded: true,
+        },
+        {
+          id: 'b',
+          isChild: false,
+          haveChilds: false,
+          expandNode: false,
+          parentExpanded: true,
+        },
+      ]);
+    });
+
+    it('hides the children of a collapsed node', () => {
+      const flattened = flattenNodes(makeNodes(), new Set());
+
+      expect(flattened.map(({ id }) => id)).toEqual(['a', 'b']);
+      expect(flattened[0].expandNode).toBe(false);
+    });
+
+    it('does not mark a childless node as expanded even when it is in the set', () => {
+      const flattened = flattenNodes([{ id: 'b', name: 'B' }], new Set(['b']));
+
+      expect(flattened[0].expandNode).toBe(false);
+      expect(flattened[0].haveChilds).toBe(false);
+    });
+
+    it('treats an empty children array as no children', () => {
+      const flattened = flattenNodes(
+        [{ id: 'b', name: 'B', children: [] }],
+        new Set(['b']),
+      );
+
+      expect(flattened).toHaveLength(1);
+      expect(flattened[0].expandNode).toBe(false);
+    });
+  });
+
+  describe('getActiveAndOverNodes', () => {
+    it('resolves both nodes and their indices', () => {
+      const tree = flattenTree(makeNodes(), null);
+
+      const { activeNode, activeNodeIndex, overNode, overNodeIndex } =
+        getActiveAndOverNodes(tree, 'a1', 'b');
+
+      expect(activeNode.id).toBe('a1');
+      expect(activeNodeIndex).toBe(1);
+      expect(overNode?.id).toBe('b');
+      expect(overNodeIndex).toBe(3);
+    });
+
+    it('returns a null over node when no over id is given', () => {
+      const tree = flattenTree(makeNodes(), null);
+
+      const { overNode, overNodeIndex } = getActiveAndOverNodes(tree, 'a');
+
+      expect(overNode).toBeNull();
+      expect(overNodeIndex).toBe(-1);
+    });
+
+    it('returns a null over node for an unknown over id', () => {
+      const tree = flattenTree(makeNodes(), null);
+
+      expect(getActiveAndOverNodes(tree, 'a', 'ghost').overNode).toBeNull();
+    });
+  });
+
+  describe('determineNewParentId', () => {
+    const activeNode = { id: 'a1', parentId: 'a', depth: 1 } as FlattenedItem;
+    const overNode = { id: 'b', parentId: null, depth: 0 } as FlattenedItem;
+
+    it('trusts the projection at the root depth', () => {
+      const projected = {
+        depth: 0,
+        parentId: null,
+        activeId: 'a1',
+      } as Projected;
+
+      expect(
+        determineNewParentId(
+          asActive('a1'),
+          asOver('b'),
+          activeNode,
+          overNode,
+          projected,
+        ),
+      ).toBeNull();
+    });
+
+    it('trusts the projection at the first nesting level', () => {
+      const projected = {
+        depth: 1,
+        parentId: 'a',
+        activeId: 'a1',
+      } as Projected;
+
+      expect(
+        determineNewParentId(
+          asActive('a1'),
+          asOver('b'),
+          activeNode,
+          overNode,
+          projected,
+        ),
+      ).toBe('a');
+    });
+
+    it('adopts the over node parent when the two nodes are not siblings', () => {
+      expect(
+        determineNewParentId(
+          asActive('a1'),
+          asOver('b'),
+          activeNode,
+          overNode,
+          null,
+        ),
+      ).toBeNull();
+    });
+
+    it('keeps the active parent when both nodes are siblings', () => {
+      const sibling = { id: 'a2', parentId: 'a', depth: 1 } as FlattenedItem;
+
+      expect(
+        determineNewParentId(
+          asActive('a1'),
+          asOver('a2'),
+          activeNode,
+          sibling,
+          null,
+        ),
+      ).toBe('a');
+    });
+
+    it('is undefined when the node is dropped on itself', () => {
+      expect(
+        determineNewParentId(
+          asActive('a1'),
+          asOver('a1'),
+          activeNode,
+          activeNode,
+          null,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('is undefined without a projection and without an over node', () => {
+      expect(
+        determineNewParentId(asActive('a1'), null, activeNode, null, null),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('getIndicesToUpdate', () => {
+    it('returns the whole subtree when nesting a node that has children', () => {
+      const tree = flattenTree(makeNodes(), null);
+      const projected = { depth: 1, parentId: 'a', activeId: 'a' } as Projected;
+
+      expect(getIndicesToUpdate(tree[0], 0, tree, projected)).toEqual([
+        0, 1, 2,
+      ]);
+    });
+
+    it('returns the node alone when it has no children', () => {
+      const tree = flattenTree(makeNodes(), null);
+      const projected = {
+        depth: 1,
+        parentId: null,
+        activeId: 'b',
+      } as Projected;
+
+      expect(getIndicesToUpdate(tree[3], 3, tree, projected)).toEqual([3]);
+    });
+
+    it('returns the node alone when the projected depth is not the nesting one', () => {
+      const tree = flattenTree(makeNodes(), null);
+      const projected = {
+        depth: 0,
+        parentId: null,
+        activeId: 'a',
+      } as Projected;
+
+      expect(getIndicesToUpdate(tree[0], 0, tree, projected)).toEqual([0]);
+    });
+
+    it('returns the node alone without a projection', () => {
+      const tree = flattenTree(makeNodes(), null);
+
+      expect(getIndicesToUpdate(tree[0], 0, tree, null)).toEqual([0]);
+    });
+  });
+
+  describe('updateParentIds', () => {
+    it('rewrites the parent id of the given indices only', () => {
+      const tree = flattenTree(makeNodes(), null);
+
+      updateParentIds(tree, [1, 2], 'b');
+
+      expect(tree.map(({ parentId }) => parentId)).toEqual([
+        null,
+        'b',
+        'b',
+        null,
+      ]);
+    });
+
+    it('accepts a null parent to promote a node to the root level', () => {
+      const tree = flattenTree(makeNodes(), null);
+
+      updateParentIds(tree, [1], null);
+
+      expect(tree[1].parentId).toBeNull();
+    });
+
+    it('does nothing without indices', () => {
+      const tree = flattenTree(makeNodes(), null);
+
+      updateParentIds(tree, [], 'b');
+
+      expect(tree[1].parentId).toBe('a');
+    });
+  });
+
+  describe('findItemIndexInTree', () => {
+    it('returns the index of a first-level item', () => {
+      expect(findItemIndexInTree(makeNodes(), 'b')).toBe(1);
+    });
+
+    it('returns the index of a nested item within its own siblings', () => {
+      expect(findItemIndexInTree(makeNodes(), 'a2')).toBe(1);
+    });
+
+    // A nested first child resolves to 0, which the caller cannot tell apart
+    // from "not found" — both answers collapse onto the same value.
+    it('returns 0 for a nested first child as well as for an unknown id', () => {
+      expect(findItemIndexInTree(makeNodes(), 'a1')).toBe(0);
+      expect(findItemIndexInTree(makeNodes(), 'ghost')).toBe(0);
+    });
+  });
+
+  describe('generateUpdateData', () => {
+    it('numbers the positions depth-first and carries the parent id', () => {
+      const nodes = makeNodes();
+      const flattened = flattenTree(nodes, null);
+
+      const { updateArray } = generateUpdateData(flattened, nodes);
+
+      expect(
+        updateArray.map(({ _id, position, parentId }) => ({
+          _id,
+          position,
+          parentId,
+        })),
+      ).toEqual([
+        { _id: 'a', position: 0, parentId: undefined },
+        { _id: 'a1', position: 1, parentId: 'a' },
+        { _id: 'a2', position: 2, parentId: 'a' },
+        { _id: 'b', position: 3, parentId: undefined },
+      ]);
+    });
+
+    it('writes the computed positions back into the flattened tree', () => {
+      const nodes = makeNodes();
+      const flattened = flattenTree(nodes, null);
+
+      const { updatedTreeData } = generateUpdateData(flattened, nodes);
+
+      expect(updatedTreeData.map(({ position }) => position)).toEqual([
+        0, 1, 2, 3,
+      ]);
+      expect(updatedTreeData).toBe(flattened);
+    });
+
+    it('forwards the visibility flag', () => {
+      const nodes: TreeItem[] = [{ id: 'a', name: 'A', isVisible: false }];
+
+      const { updateArray } = generateUpdateData(
+        flattenTree(nodes, null),
+        nodes,
+      );
+
+      expect(updateArray[0]).toMatchObject({ _id: 'a', isVisible: false });
+    });
+
+    it('returns an empty update array for an empty tree', () => {
+      expect(generateUpdateData([], []).updateArray).toEqual([]);
+    });
+  });
+
+  describe('buildTree', () => {
+    it('rebuilds the hierarchy from the flattened items', () => {
+      const tree = buildTree(flattenTree(makeNodes(), null));
+
+      expect(tree.map(({ id }) => id)).toEqual(['a', 'b']);
+      expect(tree[0].children?.map(({ id }) => id)).toEqual(['a1', 'a2']);
+      expect(tree[1].children).toEqual([]);
+    });
+
+    it('treats an undefined parent id as a root node', () => {
+      const tree = buildTree([
+        { id: 'a', name: 'A', depth: 0 } as unknown as FlattenedItem,
+      ]);
+
+      expect(tree.map(({ id }) => id)).toEqual(['a']);
+    });
+
+    it('drops an item whose parent is missing from the flat list', () => {
+      const tree = buildTree([
+        { id: 'a', name: 'A', parentId: null, depth: 0 } as FlattenedItem,
+        {
+          id: 'orphan',
+          name: 'Orphan',
+          parentId: 'ghost',
+          depth: 1,
+        } as FlattenedItem,
+      ]);
+
+      expect(tree.map(({ id }) => id)).toEqual(['a']);
+      expect(tree[0].children).toEqual([]);
+    });
+
+    it('keeps the position and the visibility of each item', () => {
+      const tree = buildTree([
+        {
+          id: 'a',
+          name: 'A',
+          parentId: null,
+          depth: 0,
+          position: 4,
+          isVisible: false,
+        } as FlattenedItem,
+      ]);
+
+      expect(tree[0]).toMatchObject({ position: 4, isVisible: false });
+    });
+  });
+
+  describe('getProjection', () => {
+    it('projects to the root level when the node lands first', () => {
+      const items = flattenTree(makeNodes(), null);
+
+      const projection = getProjection(items, 'b', 'a', 0, 64);
+
+      expect(projection.depth).toBe(0);
+      expect(projection.parentId).toBeNull();
+      expect(projection.activeId).toBe('b');
+      expect(projection.previousItem).toBeUndefined();
+    });
+
+    it('nests under the previous item when dragged one step to the right', () => {
+      const items = flattenTree(makeNodes(), null);
+
+      const projection = getProjection(items, 'b', 'a1', 64, 64);
+
+      expect(projection.depth).toBe(1);
+      expect(projection.parentId).toBe('a');
+    });
+
+    it('adopts the parent of the previous item when both sit at the same depth', () => {
+      const items = flattenTree(makeNodes(), null);
+
+      const projection = getProjection(items, 'b', 'a2', 64, 64);
+
+      expect(projection.depth).toBe(1);
+      expect(projection.previousItem.id).toBe('a1');
+      expect(projection.parentId).toBe('a');
+    });
+
+    it('clamps the depth to the root level when dragged back to the left', () => {
+      const items = flattenTree(makeNodes(), null);
+
+      const projection = getProjection(items, 'a1', 'b', -64, 64);
+
+      expect(projection.depth).toBe(0);
+      expect(projection.parentId).toBeNull();
+    });
+
+    it('never projects deeper than one nesting level', () => {
+      const items = flattenTree(makeNodes(), null);
+
+      // Three indentation steps to the right, yet the tree stays two levels deep.
+      expect(getProjection(items, 'b', 'a1', 192, 64).depth).toBe(1);
+    });
+  });
+});

--- a/packages/react/src/components/Tree/utilities/tree.spec.ts
+++ b/packages/react/src/components/Tree/utilities/tree.spec.ts
@@ -1,0 +1,382 @@
+import { FOLDER, IFolder } from '@edifice.io/client';
+import { TreeItem } from '../types';
+import {
+  addNode,
+  arrayUnique,
+  deleteNode,
+  findNodeById,
+  findParentNode,
+  findPathById,
+  getAncestors,
+  getChildrenIds,
+  hasChildren,
+  modifyNode,
+  moveNode,
+  TreeNodeFolderWrapper,
+  updateNode,
+  wrapTreeNode,
+} from './tree';
+
+function makeFolder(partial: Partial<IFolder> & { id: string }): IFolder {
+  return {
+    parentId: '',
+    name: `folder-${partial.id}`,
+    type: 'FOLDER',
+    childNumber: 0,
+    trashed: false,
+    rights: [],
+    ancestors: [],
+    ...partial,
+  } as IFolder;
+}
+
+// root
+// ├── a
+// │   └── a1
+// └── b
+function makeTree(): TreeItem {
+  return {
+    id: 'root',
+    name: 'Root',
+    children: [
+      {
+        id: 'a',
+        name: 'A',
+        children: [{ id: 'a1', name: 'A1' }],
+      },
+      { id: 'b', name: 'B' },
+    ],
+  };
+}
+
+describe('Tree utilities', () => {
+  describe('findNodeById', () => {
+    it('finds a nested node from a single root', () => {
+      expect(findNodeById(makeTree(), 'a1')?.name).toBe('A1');
+    });
+
+    it('finds a node from an array of roots', () => {
+      const forest: TreeItem[] = [
+        { id: 'r1', name: 'R1' },
+        { id: 'r2', name: 'R2', children: [{ id: 'r2a', name: 'R2A' }] },
+      ];
+
+      expect(findNodeById(forest, 'r2a')?.name).toBe('R2A');
+    });
+
+    it('returns undefined when no node matches', () => {
+      expect(findNodeById(makeTree(), 'nope')).toBeUndefined();
+    });
+  });
+
+  describe('getChildrenIds', () => {
+    it('returns the folder children ids plus the folder itself', () => {
+      const data: TreeItem[] = [
+        {
+          id: 'f1',
+          name: 'F1',
+          folder: { childrenIds: ['c1', 'c2'] },
+        },
+      ];
+
+      expect(getChildrenIds(data, 'f1')).toEqual(['c1', 'c2', 'f1']);
+    });
+
+    it('returns the bin alone when asking for the bin', () => {
+      expect(getChildrenIds([], FOLDER.BIN)).toEqual([FOLDER.BIN]);
+    });
+
+    it('falls back to the default folder for an unknown id', () => {
+      expect(getChildrenIds([], 'unknown')).toEqual([FOLDER.DEFAULT]);
+    });
+  });
+
+  describe('getAncestors', () => {
+    it('returns the folder ancestors plus the folder itself', () => {
+      const data: TreeItem[] = [
+        { id: 'f1', name: 'F1', folder: { ancestors: ['root', 'mid'] } },
+      ];
+
+      expect(getAncestors(data, 'f1')).toEqual(['root', 'mid', 'f1']);
+    });
+
+    it('returns the bin alone when asking for the bin', () => {
+      expect(getAncestors([], FOLDER.BIN)).toEqual([FOLDER.BIN]);
+    });
+
+    it('falls back to the default folder for an unknown id', () => {
+      expect(getAncestors([], 'unknown')).toEqual([FOLDER.DEFAULT]);
+    });
+  });
+
+  describe('arrayUnique', () => {
+    it('keeps the first occurrence of each item', () => {
+      expect(arrayUnique(['a', 'b', 'a', 'c', 'b'])).toEqual(['a', 'b', 'c']);
+    });
+
+    it('returns an empty array unchanged', () => {
+      expect(arrayUnique([])).toEqual([]);
+    });
+  });
+
+  describe('addNode', () => {
+    it('appends a wrapped folder under the target parent', () => {
+      const result = addNode(makeTree(), {
+        parentId: 'a',
+        newFolder: makeFolder({ id: 'a2', name: 'A2' }),
+      });
+
+      const parent = findNodeById(result, 'a');
+      expect(parent?.children?.map(({ id }) => id)).toEqual(['a1', 'a2']);
+    });
+
+    it('derives the new folder ancestors from its parent', () => {
+      const tree: TreeItem = {
+        id: 'root',
+        name: 'Root',
+        folder: { ancestors: ['grand'] },
+        children: [],
+      };
+
+      const result = addNode(tree, {
+        parentId: 'root',
+        newFolder: makeFolder({ id: 'child' }),
+      });
+
+      expect(findNodeById(result, 'child')?.folder.ancestors).toEqual([
+        'grand',
+        'root',
+      ]);
+    });
+
+    it('leaves the tree untouched when the parent is missing', () => {
+      const tree = makeTree();
+
+      expect(
+        addNode(tree, {
+          parentId: 'ghost',
+          newFolder: makeFolder({ id: 'x' }),
+        }),
+      ).toEqual(tree);
+    });
+  });
+
+  describe('deleteNode', () => {
+    it('removes every listed node', () => {
+      const result = deleteNode(makeTree(), { folders: ['a1', 'b'] });
+
+      expect(findNodeById(result, 'a1')).toBeUndefined();
+      expect(findNodeById(result, 'b')).toBeUndefined();
+      expect(findNodeById(result, 'a')?.name).toBe('A');
+    });
+
+    it('keeps the root even when it is listed, since a root cannot be dropped', () => {
+      const tree = makeTree();
+
+      expect(deleteNode(tree, { folders: ['root'] })).toEqual(tree);
+    });
+  });
+
+  describe('findParentNode', () => {
+    it('returns the direct parent of a node', () => {
+      expect(findParentNode(makeTree(), 'a1')?.id).toBe('a');
+    });
+
+    it('returns the root when the child is a first-level node', () => {
+      expect(findParentNode(makeTree(), 'b')?.id).toBe('root');
+    });
+
+    it('returns undefined for an unknown child', () => {
+      expect(findParentNode(makeTree(), 'ghost')).toBeUndefined();
+    });
+  });
+
+  describe('hasChildren', () => {
+    it('is true for a node holding children', () => {
+      expect(hasChildren('root', makeTree())).toBe(true);
+    });
+
+    it('is false for a node declaring an empty children array', () => {
+      expect(
+        hasChildren('root', { id: 'root', name: 'Root', children: [] }),
+      ).toBe(false);
+    });
+
+    it('is false for a leaf', () => {
+      expect(hasChildren('leaf', { id: 'leaf', name: 'Leaf' })).toBe(false);
+    });
+
+    // The recursive branch forwards the parent id instead of the searched one,
+    // so only a node passed as the root of the traversal can answer true.
+    it('is false for a nested id, because the lookup only matches the traversal root', () => {
+      expect(hasChildren('a', makeTree())).toBe(false);
+    });
+  });
+
+  describe('modifyNode', () => {
+    it('applies the callback to every node', () => {
+      const result = modifyNode(makeTree(), (node) => ({
+        ...node,
+        name: node.name.toUpperCase(),
+      }));
+
+      expect(findNodeById(result, 'a1')?.name).toBe('A1');
+      expect(findNodeById(result, 'root')?.name).toBe('ROOT');
+    });
+
+    it('drops the nodes for which the callback returns undefined', () => {
+      const result = modifyNode(makeTree(), (node) =>
+        node.id === 'a' ? undefined : node,
+      );
+
+      expect(result.children?.map(({ id }) => id)).toEqual(['b']);
+    });
+
+    it('returns the original node when the callback drops the root', () => {
+      const tree = makeTree();
+
+      expect(modifyNode(tree, () => undefined)).toEqual(tree);
+    });
+
+    it('exposes the parent to the callback', () => {
+      const parents: Array<string | undefined> = [];
+
+      modifyNode(makeTree(), (node, parent) => {
+        parents.push(parent?.id);
+        return node;
+      });
+
+      expect(parents).toEqual([undefined, 'root', 'a', 'root']);
+    });
+  });
+
+  describe('moveNode', () => {
+    it('re-parents a descendant of the destination and updates its ancestors', () => {
+      // root ── b ── c ── d ; moving d directly under b
+      const tree: TreeItem = {
+        id: 'root',
+        name: 'Root',
+        children: [
+          {
+            id: 'b',
+            name: 'B',
+            folder: { ancestors: ['root'] },
+            children: [
+              { id: 'c', name: 'C', children: [{ id: 'd', name: 'D' }] },
+            ],
+          },
+        ],
+      };
+
+      const result = moveNode(tree, { destinationId: 'b', folders: ['d'] });
+
+      const b = findNodeById(result, 'b');
+      expect(b?.children?.map(({ id }) => id)).toEqual(['c', 'd']);
+      expect(findNodeById(result, 'c')?.children ?? []).toEqual([]);
+      expect(b?.children?.[1].folder.ancestors).toEqual(['root', 'b']);
+    });
+
+    // The destination lookup is scoped to the destination subtree, so a node
+    // living elsewhere is removed from its original position without being
+    // re-attached.
+    it('removes a node moved from outside the destination subtree', () => {
+      const result = moveNode(makeTree(), {
+        destinationId: 'b',
+        folders: ['a1'],
+      });
+
+      expect(findNodeById(result, 'a1')).toBeUndefined();
+      expect(findNodeById(result, 'b')?.children ?? []).toEqual([]);
+    });
+
+    it('keeps a node already sitting in the destination children', () => {
+      const result = moveNode(makeTree(), {
+        destinationId: 'a',
+        folders: ['a1'],
+      });
+
+      expect(findNodeById(result, 'a')?.children?.map(({ id }) => id)).toEqual([
+        'a1',
+      ]);
+    });
+  });
+
+  describe('wrapTreeNode', () => {
+    it('replaces the children of the target node with wrapped folders', () => {
+      const folders = [makeFolder({ id: 'f1' }), makeFolder({ id: 'f2' })];
+
+      const result = wrapTreeNode(makeTree(), folders, 'b');
+
+      const b = findNodeById(result, 'b');
+      expect(b?.children?.map(({ id }) => id)).toEqual(['f1', 'f2']);
+      expect(b?.children?.[0]).toBeInstanceOf(TreeNodeFolderWrapper);
+    });
+
+    it('accepts an undefined folder list', () => {
+      const result = wrapTreeNode(makeTree(), undefined, 'b');
+
+      expect(findNodeById(result, 'b')?.children).toBeUndefined();
+    });
+  });
+
+  describe('updateNode', () => {
+    it('swaps the matching node for a wrapper around the new folder', () => {
+      const result = updateNode(makeTree(), {
+        folderId: 'b',
+        newFolder: makeFolder({ id: 'b', name: 'B renamed' }),
+      });
+
+      const b = findNodeById(result, 'b');
+      expect(b?.name).toBe('B renamed');
+      expect(b).toBeInstanceOf(TreeNodeFolderWrapper);
+    });
+
+    it('leaves the tree untouched for an unknown folder id', () => {
+      const tree = makeTree();
+
+      expect(
+        updateNode(tree, {
+          folderId: 'ghost',
+          newFolder: makeFolder({ id: 'ghost' }),
+        }),
+      ).toEqual(tree);
+    });
+  });
+
+  describe('findPathById', () => {
+    it('returns the path from the root down to the node', () => {
+      expect(findPathById(makeTree(), 'a1')).toEqual(['root', 'a', 'a1']);
+    });
+
+    it('returns the node alone when it is the root', () => {
+      expect(findPathById(makeTree(), 'root')).toEqual(['root']);
+    });
+
+    it('walks an array of roots and stops on the first match', () => {
+      const forest: TreeItem[] = [
+        { id: 'r1', name: 'R1' },
+        { id: 'r2', name: 'R2', children: [{ id: 'r2a', name: 'R2A' }] },
+      ];
+
+      expect(findPathById(forest, 'r2a')).toEqual(['r2', 'r2a']);
+    });
+
+    it('returns an empty path for an unknown node', () => {
+      expect(findPathById(makeTree(), 'ghost')).toEqual([]);
+    });
+  });
+
+  describe('TreeNodeFolderWrapper', () => {
+    it('exposes the folder identity and defaults to a childless section-less node', () => {
+      const wrapper = new TreeNodeFolderWrapper(
+        makeFolder({ id: 'f1', name: 'F1', childNumber: 3 }),
+      );
+
+      expect(wrapper.id).toBe('f1');
+      expect(wrapper.name).toBe('F1');
+      expect(wrapper.childNumber).toBe(3);
+      expect(wrapper.section).toBe(false);
+      expect(wrapper.children).toEqual([]);
+    });
+  });
+});

--- a/packages/react/src/components/TreeView/hooks/useTreeView.spec.tsx
+++ b/packages/react/src/components/TreeView/hooks/useTreeView.spec.tsx
@@ -1,0 +1,275 @@
+import { createRef } from 'react';
+import { act, renderHook } from '~/setup';
+import { TreeData } from '../../../types';
+import { TreeViewHandlers_V1 } from '../TreeView';
+import { useTreeView } from './useTreeView';
+
+// a
+// └── a1
+// b
+function makeNodes(): TreeData[] {
+  return [
+    { id: 'a', name: 'A', children: [{ id: 'a1', name: 'A1' }] },
+    { id: 'b', name: 'B' },
+  ];
+}
+
+type Params = Parameters<typeof useTreeView>[0];
+
+function setup(props: Partial<Params> = {}) {
+  const onTreeItemUnfold = vi.fn();
+  const onTreeItemFold = vi.fn();
+  const onTreeItemClick = vi.fn();
+  const ref = createRef<TreeViewHandlers_V1>();
+  // Stable identity: the sibling-scanning effect depends on it.
+  const data = props.data ?? makeNodes();
+
+  const { result, rerender } = renderHook(() =>
+    useTreeView({
+      externalSelectedNodeId: undefined,
+      onTreeItemUnfold,
+      onTreeItemFold,
+      onTreeItemClick,
+      ...props,
+      data,
+      ref,
+    }),
+  );
+
+  return {
+    result,
+    rerender,
+    ref,
+    onTreeItemUnfold,
+    onTreeItemFold,
+    onTreeItemClick,
+  };
+}
+
+const expanded = (result: { current: ReturnType<typeof useTreeView> }) =>
+  Array.from(result.current.expandedNodes);
+
+describe('useTreeView', () => {
+  it('starts with nothing selected, nothing expanded and nothing dragged', () => {
+    const { result } = setup();
+
+    expect(result.current.selectedNodeId).toBeUndefined();
+    expect(expanded(result)).toEqual([]);
+    expect(result.current.draggedNodeId).toBeUndefined();
+  });
+
+  describe('handleItemClick', () => {
+    it('selects the node, expands its path and notifies the parent', () => {
+      const { result, onTreeItemClick, onTreeItemUnfold } = setup();
+
+      act(() => result.current.handleItemClick('a1'));
+
+      expect(result.current.selectedNodeId).toBe('a1');
+      expect(expanded(result)).toEqual(['a', 'a1']);
+      expect(onTreeItemClick).toHaveBeenCalledWith('a1');
+      expect(onTreeItemUnfold).toHaveBeenCalledWith('a');
+    });
+
+    it('re-clicking the selected node keeps it selected', () => {
+      const { result } = setup();
+
+      act(() => result.current.handleItemClick('b'));
+      act(() => result.current.handleItemClick('b'));
+
+      expect(result.current.selectedNodeId).toBe('b');
+    });
+  });
+
+  describe('handleFoldUnfold', () => {
+    it('expands a collapsed node', () => {
+      const { result } = setup();
+
+      act(() => result.current.handleFoldUnfold('a'));
+
+      expect(expanded(result)).toEqual(['a']);
+    });
+
+    it('collapses an expanded node and folds back the remaining ones', () => {
+      const { result, onTreeItemFold } = setup();
+
+      act(() => result.current.handleItemClick('a1'));
+      act(() => result.current.handleFoldUnfold('a1'));
+
+      expect(expanded(result)).toEqual(['a']);
+      expect(onTreeItemFold).toHaveBeenCalledWith('a');
+    });
+  });
+
+  describe('allExpandedNodes', () => {
+    it('expands every first-level node on mount', () => {
+      const { result } = setup({ allExpandedNodes: true });
+
+      expect(expanded(result)).toEqual(['a', 'b']);
+    });
+
+    it('leaves a single root node collapsed', () => {
+      const data: TreeData = {
+        id: 'root',
+        name: 'Root',
+        children: makeNodes(),
+      };
+
+      const { result } = setup({ data, allExpandedNodes: true });
+
+      expect(expanded(result)).toEqual([]);
+    });
+  });
+
+  describe('externalSelectedNodeId', () => {
+    it('selects and expands the path of an existing node', () => {
+      const { result, onTreeItemUnfold } = setup({
+        externalSelectedNodeId: 'a1',
+      });
+
+      expect(result.current.selectedNodeId).toBe('a1');
+      expect(expanded(result)).toEqual(['a', 'a1']);
+      expect(onTreeItemUnfold).toHaveBeenCalledWith('a1');
+    });
+
+    it('still reports an unknown node as selected but expands nothing', () => {
+      const { result } = setup({ externalSelectedNodeId: 'ghost' });
+
+      expect(result.current.selectedNodeId).toBe('ghost');
+      expect(expanded(result)).toEqual([]);
+    });
+
+    it('is ignored while every node is expanded', () => {
+      const { result } = setup({
+        externalSelectedNodeId: 'a1',
+        allExpandedNodes: true,
+      });
+
+      expect(expanded(result)).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('imperative handlers', () => {
+    it('selects a node through the ref', () => {
+      const { result, ref, onTreeItemClick } = setup();
+
+      act(() => ref.current?.select('a1'));
+
+      expect(result.current.selectedNodeId).toBe('a1');
+      expect(expanded(result)).toEqual(['a', 'a1']);
+      expect(onTreeItemClick).toHaveBeenCalledWith('a1');
+    });
+
+    it('unselects everything through the ref, falling back to the prop', () => {
+      const { result, ref } = setup({ externalSelectedNodeId: 'b' });
+
+      act(() => result.current.handleItemClick('a1'));
+      expect(result.current.selectedNodeId).toBe('a1');
+
+      act(() => ref.current?.unselectAll());
+
+      expect(result.current.selectedNodeId).toBe('b');
+    });
+
+    it('expands every first-level node through the ref', () => {
+      const { result, ref } = setup({ allExpandedNodes: true });
+
+      act(() => result.current.handleFoldUnfold('a'));
+      expect(expanded(result)).toEqual(['b']);
+
+      act(() =>
+        (
+          ref.current as unknown as { allExpandedNodes: () => void }
+        ).allExpandedNodes(),
+      );
+
+      expect(expanded(result)).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('siblingsNodes', () => {
+    it('collects the nodes whose siblings have children, from a single root', () => {
+      const data: TreeData = {
+        id: 'root',
+        name: 'Root',
+        children: [
+          { id: 'c1', name: 'C1', children: [{ id: 'g1', name: 'G1' }] },
+          { id: 'c2', name: 'C2' },
+        ],
+      };
+
+      const { result } = setup({ data });
+
+      expect(Array.from(result.current.siblingsNodes.current)).toEqual(['c2']);
+    });
+
+    // The array branch builds its result set but never commits it to the ref.
+    it('stays empty when the data is an array of roots', () => {
+      const { result } = setup();
+
+      expect(Array.from(result.current.siblingsNodes.current)).toEqual([]);
+    });
+  });
+
+  describe('draggedNode', () => {
+    it('expands the hovered node when a drag enters it', () => {
+      const data = makeNodes();
+      const onTreeItemUnfold = vi.fn();
+      const ref = createRef<TreeViewHandlers_V1>();
+      type Props = { draggedNode?: Params['draggedNode'] };
+
+      const { result, rerender } = renderHook(
+        ({ draggedNode }: Props) =>
+          useTreeView({
+            data,
+            ref,
+            externalSelectedNodeId: 'a1',
+            draggedNode,
+            onTreeItemUnfold,
+          }),
+        { initialProps: {} as Props },
+      );
+
+      expect(Array.from(result.current.expandedNodes)).toEqual(['a', 'a1']);
+
+      rerender({
+        draggedNode: { isOver: true, overId: 'b', isTreeview: true },
+      });
+
+      expect(result.current.draggedNodeId).toBe('b');
+      expect(Array.from(result.current.expandedNodes)).toEqual([
+        'a',
+        'a1',
+        'b',
+      ]);
+      expect(onTreeItemUnfold).toHaveBeenCalledWith('b');
+    });
+
+    it('clears the dragged node when the pointer leaves the tree', () => {
+      const { result } = setup({
+        externalSelectedNodeId: 'a1',
+        draggedNode: { isOver: false, overId: 'b', isTreeview: true },
+      });
+
+      expect(result.current.draggedNodeId).toBeUndefined();
+    });
+
+    it('ignores a drag coming from outside the treeview', () => {
+      const { result } = setup({
+        externalSelectedNodeId: 'a1',
+        draggedNode: { isOver: true, overId: 'b', isTreeview: false },
+      });
+
+      expect(result.current.draggedNodeId).toBeUndefined();
+    });
+
+    it('tracks the hovered node even when the selected node is unknown', () => {
+      const { result } = setup({
+        externalSelectedNodeId: 'ghost',
+        draggedNode: { isOver: true, overId: 'b', isTreeview: true },
+      });
+
+      expect(result.current.draggedNodeId).toBe('b');
+      expect(expanded(result)).toEqual([]);
+    });
+  });
+});

--- a/packages/react/src/components/TreeView/utilities/treeview.spec.ts
+++ b/packages/react/src/components/TreeView/utilities/treeview.spec.ts
@@ -1,0 +1,331 @@
+import { FOLDER, IFolder } from '@edifice.io/client';
+import { TreeData } from '../../../types';
+import {
+  addNode,
+  arrayUnique,
+  deleteNode,
+  findNodeById,
+  findParentNode,
+  findPathById,
+  findTreeNode,
+  getAncestors,
+  hasChildren,
+  modifyNode,
+  moveNode,
+  TreeNodeFolderWrapper,
+  updateNode,
+  wrapTreeNode,
+} from './treeview';
+
+function makeFolder(partial: Partial<IFolder> & { id: string }): IFolder {
+  return {
+    parentId: '',
+    name: `folder-${partial.id}`,
+    type: 'FOLDER',
+    childNumber: 0,
+    trashed: false,
+    rights: [],
+    ancestors: [],
+    ...partial,
+  } as IFolder;
+}
+
+// root
+// ├── a
+// │   └── a1
+// └── b
+function makeTree(): TreeData {
+  return {
+    id: 'root',
+    name: 'Root',
+    children: [
+      { id: 'a', name: 'A', children: [{ id: 'a1', name: 'A1' }] },
+      { id: 'b', name: 'B' },
+    ],
+  };
+}
+
+describe('TreeView utilities', () => {
+  describe('findTreeNode', () => {
+    it('returns the root when the predicate matches it', () => {
+      expect(findTreeNode(makeTree(), ({ id }) => id === 'root')?.name).toBe(
+        'Root',
+      );
+    });
+
+    it('walks the children depth-first', () => {
+      expect(findTreeNode(makeTree(), ({ id }) => id === 'a1')?.name).toBe(
+        'A1',
+      );
+    });
+
+    it('returns undefined when nothing matches', () => {
+      expect(findTreeNode(makeTree(), () => false)).toBeUndefined();
+    });
+
+    it('returns the first node satisfying a non-id predicate', () => {
+      expect(findTreeNode(makeTree(), (node) => !node.children)?.id).toBe('a1');
+    });
+  });
+
+  describe('findNodeById', () => {
+    it('finds a nested node from a single root', () => {
+      expect(findNodeById(makeTree(), 'a1')?.name).toBe('A1');
+    });
+
+    it('finds a node from an array of roots', () => {
+      const forest: TreeData[] = [
+        { id: 'r1', name: 'R1' },
+        { id: 'r2', name: 'R2', children: [{ id: 'r2a', name: 'R2A' }] },
+      ];
+
+      expect(findNodeById(forest, 'r2a')?.name).toBe('R2A');
+    });
+
+    it('returns undefined when no node matches', () => {
+      expect(findNodeById(makeTree(), 'nope')).toBeUndefined();
+    });
+  });
+
+  describe('getAncestors', () => {
+    it('returns the folder ancestors plus the folder itself', () => {
+      const data: TreeData = {
+        id: 'root',
+        name: 'Root',
+        children: [
+          { id: 'f1', name: 'F1', folder: { ancestors: ['root', 'mid'] } },
+        ],
+      };
+
+      expect(getAncestors(data, 'f1')).toEqual(['root', 'mid', 'f1']);
+    });
+
+    it('returns the bin alone when asking for the bin', () => {
+      expect(getAncestors(makeTree(), FOLDER.BIN)).toEqual([FOLDER.BIN]);
+    });
+
+    it('falls back to the default folder for an unknown id', () => {
+      expect(getAncestors(makeTree(), 'unknown')).toEqual([FOLDER.DEFAULT]);
+    });
+  });
+
+  describe('arrayUnique', () => {
+    it('keeps the first occurrence of each item', () => {
+      expect(arrayUnique(['a', 'b', 'a'])).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('addNode', () => {
+    it('appends a wrapped folder under the target parent', () => {
+      const result = addNode(makeTree(), {
+        parentId: 'a',
+        newFolder: makeFolder({ id: 'a2', name: 'A2' }),
+      });
+
+      expect(findNodeById(result, 'a')?.children?.map(({ id }) => id)).toEqual([
+        'a1',
+        'a2',
+      ]);
+    });
+
+    it('derives the new folder ancestors from its parent', () => {
+      const tree: TreeData = {
+        id: 'root',
+        name: 'Root',
+        folder: { ancestors: ['grand'] },
+        children: [],
+      };
+
+      const result = addNode(tree, {
+        parentId: 'root',
+        newFolder: makeFolder({ id: 'child' }),
+      });
+
+      expect(findNodeById(result, 'child')?.folder.ancestors).toEqual([
+        'grand',
+        'root',
+      ]);
+    });
+
+    it('leaves the tree untouched when the parent is missing', () => {
+      const tree = makeTree();
+
+      expect(
+        addNode(tree, {
+          parentId: 'ghost',
+          newFolder: makeFolder({ id: 'x' }),
+        }),
+      ).toEqual(tree);
+    });
+  });
+
+  describe('deleteNode', () => {
+    it('removes every listed node', () => {
+      const result = deleteNode(makeTree(), { folders: ['a1', 'b'] });
+
+      expect(findNodeById(result, 'a1')).toBeUndefined();
+      expect(findNodeById(result, 'b')).toBeUndefined();
+      expect(findNodeById(result, 'a')?.name).toBe('A');
+    });
+
+    it('keeps the root even when it is listed, since a root cannot be dropped', () => {
+      const tree = makeTree();
+
+      expect(deleteNode(tree, { folders: ['root'] })).toEqual(tree);
+    });
+  });
+
+  describe('findParentNode', () => {
+    it('returns the direct parent of a node', () => {
+      expect(findParentNode(makeTree(), 'a1')?.id).toBe('a');
+    });
+
+    it('returns undefined for an unknown child', () => {
+      expect(findParentNode(makeTree(), 'ghost')).toBeUndefined();
+    });
+  });
+
+  describe('hasChildren', () => {
+    it('is true for a node holding children', () => {
+      expect(hasChildren('root', makeTree())).toBe(true);
+    });
+
+    it('is false for a node declaring an empty children array', () => {
+      expect(
+        hasChildren('root', { id: 'root', name: 'Root', children: [] }),
+      ).toBe(false);
+    });
+
+    // Same quirk as the Tree flavour: the recursive call forwards the parent id.
+    it('is false for a nested id, because the lookup only matches the traversal root', () => {
+      expect(hasChildren('a', makeTree())).toBe(false);
+    });
+  });
+
+  describe('modifyNode', () => {
+    it('applies the callback to every node', () => {
+      const result = modifyNode(makeTree(), (node) => ({
+        ...node,
+        name: node.name.toLowerCase(),
+      }));
+
+      expect(findNodeById(result, 'root')?.name).toBe('root');
+      expect(findNodeById(result, 'a1')?.name).toBe('a1');
+    });
+
+    it('drops the nodes for which the callback returns undefined', () => {
+      const result = modifyNode(makeTree(), (node) =>
+        node.id === 'b' ? undefined : node,
+      );
+
+      expect(result.children?.map(({ id }) => id)).toEqual(['a']);
+    });
+
+    it('returns the original node when the callback drops the root', () => {
+      const tree = makeTree();
+
+      expect(modifyNode(tree, () => undefined)).toEqual(tree);
+    });
+  });
+
+  describe('moveNode', () => {
+    it('re-parents a descendant of the destination and updates its ancestors', () => {
+      const tree: TreeData = {
+        id: 'root',
+        name: 'Root',
+        children: [
+          {
+            id: 'b',
+            name: 'B',
+            folder: { ancestors: ['root'] },
+            children: [
+              { id: 'c', name: 'C', children: [{ id: 'd', name: 'D' }] },
+            ],
+          },
+        ],
+      };
+
+      const result = moveNode(tree, { destinationId: 'b', folders: ['d'] });
+
+      const b = findNodeById(result, 'b');
+      expect(b?.children?.map(({ id }) => id)).toEqual(['c', 'd']);
+      expect(findNodeById(result, 'c')?.children ?? []).toEqual([]);
+      expect(b?.children?.[1].folder.ancestors).toEqual(['root', 'b']);
+    });
+
+    it('removes a node moved from outside the destination subtree', () => {
+      const result = moveNode(makeTree(), {
+        destinationId: 'b',
+        folders: ['a1'],
+      });
+
+      expect(findNodeById(result, 'a1')).toBeUndefined();
+      expect(findNodeById(result, 'b')?.children ?? []).toEqual([]);
+    });
+  });
+
+  describe('wrapTreeNode', () => {
+    it('replaces the children of the target node with wrapped folders', () => {
+      const result = wrapTreeNode(
+        makeTree(),
+        [makeFolder({ id: 'f1' }), makeFolder({ id: 'f2' })],
+        'b',
+      );
+
+      const b = findNodeById(result, 'b');
+      expect(b?.children?.map(({ id }) => id)).toEqual(['f1', 'f2']);
+      expect(b?.children?.[0]).toBeInstanceOf(TreeNodeFolderWrapper);
+    });
+
+    it('accepts an undefined folder list', () => {
+      const result = wrapTreeNode(makeTree(), undefined, 'b');
+
+      expect(findNodeById(result, 'b')?.children).toBeUndefined();
+    });
+  });
+
+  describe('updateNode', () => {
+    it('swaps the matching node for a wrapper around the new folder', () => {
+      const result = updateNode(makeTree(), {
+        folderId: 'b',
+        newFolder: makeFolder({ id: 'b', name: 'B renamed' }),
+      });
+
+      expect(findNodeById(result, 'b')?.name).toBe('B renamed');
+      expect(findNodeById(result, 'b')).toBeInstanceOf(TreeNodeFolderWrapper);
+    });
+  });
+
+  describe('findPathById', () => {
+    it('returns the path from the root down to the node', () => {
+      expect(findPathById(makeTree(), 'a1')).toEqual(['root', 'a', 'a1']);
+    });
+
+    it('walks an array of roots and stops on the first match', () => {
+      const forest: TreeData[] = [
+        { id: 'r1', name: 'R1' },
+        { id: 'r2', name: 'R2', children: [{ id: 'r2a', name: 'R2A' }] },
+      ];
+
+      expect(findPathById(forest, 'r2a')).toEqual(['r2', 'r2a']);
+    });
+
+    it('returns an empty path for an unknown node', () => {
+      expect(findPathById(makeTree(), 'ghost')).toEqual([]);
+    });
+  });
+
+  describe('TreeNodeFolderWrapper', () => {
+    it('exposes the folder identity and defaults to a childless section-less node', () => {
+      const wrapper = new TreeNodeFolderWrapper(
+        makeFolder({ id: 'f1', name: 'F1', childNumber: 2 }),
+      );
+
+      expect(wrapper.id).toBe('f1');
+      expect(wrapper.name).toBe('F1');
+      expect(wrapper.childNumber).toBe(2);
+      expect(wrapper.section).toBe(false);
+      expect(wrapper.children).toEqual([]);
+    });
+  });
+});

--- a/packages/react/src/hooks/useCantoo/useCantoo.spec.tsx
+++ b/packages/react/src/hooks/useCantoo/useCantoo.spec.tsx
@@ -1,0 +1,104 @@
+import { renderHook, waitFor } from '~/setup';
+import useCantoo from './useCantoo';
+
+const { get, useHasWorkflow } = vi.hoisted(() => ({
+  get: vi.fn(),
+  useHasWorkflow: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: { http: () => ({ get }) },
+}));
+
+vi.mock('../useHasWorkflow', () => ({ useHasWorkflow }));
+
+const CANTOO_WORKFLOW =
+  'org.entcore.portal.controllers.PortalController|optionalFeatureCantoo';
+
+const script = () =>
+  document.getElementById('cantoo-edifice-script') as HTMLScriptElement | null;
+
+describe('useCantoo', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('checks the Cantoo optional-feature workflow', () => {
+    useHasWorkflow.mockReturnValue(false);
+
+    renderHook(() => useCantoo());
+
+    expect(useHasWorkflow).toHaveBeenCalledWith(CANTOO_WORKFLOW);
+  });
+
+  it('injects the Cantoo script when the workflow is granted', async () => {
+    useHasWorkflow.mockReturnValue(true);
+    get.mockResolvedValue({ scriptPath: 'https://cantoo.test/script.js' });
+
+    renderHook(() => useCantoo());
+
+    await waitFor(() => expect(script()).not.toBeNull());
+    expect(get).toHaveBeenCalledWith('/optionalFeature/cantoo');
+    expect(script()?.src).toBe('https://cantoo.test/script.js');
+    expect(script()?.async).toBe(true);
+  });
+
+  it('does nothing without the workflow', () => {
+    useHasWorkflow.mockReturnValue(false);
+
+    renderHook(() => useCantoo());
+
+    expect(get).not.toHaveBeenCalled();
+    expect(script()).toBeNull();
+  });
+
+  it('does nothing while the workflow right is still unresolved', () => {
+    useHasWorkflow.mockReturnValue(undefined);
+
+    renderHook(() => useCantoo());
+
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('does not inject the script twice', async () => {
+    useHasWorkflow.mockReturnValue(true);
+    get.mockResolvedValue({ scriptPath: 'https://cantoo.test/script.js' });
+
+    const { unmount } = renderHook(() => useCantoo());
+    await waitFor(() => expect(script()).not.toBeNull());
+    unmount();
+
+    renderHook(() => useCantoo());
+
+    expect(get).toHaveBeenCalledTimes(1);
+    expect(document.querySelectorAll('#cantoo-edifice-script')).toHaveLength(1);
+  });
+
+  it('injects nothing when the configuration carries no script path', async () => {
+    useHasWorkflow.mockReturnValue(true);
+    get.mockResolvedValue({});
+
+    renderHook(() => useCantoo());
+
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(script()).toBeNull();
+  });
+
+  it('injects nothing when the configuration call resolves empty', async () => {
+    useHasWorkflow.mockReturnValue(true);
+    get.mockResolvedValue(undefined);
+
+    renderHook(() => useCantoo());
+
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(script()).toBeNull();
+  });
+
+  it('returns nothing to render', () => {
+    useHasWorkflow.mockReturnValue(false);
+
+    const { result } = renderHook(() => useCantoo());
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/packages/react/src/hooks/useLibraryUrl/useLibraryUrl.spec.tsx
+++ b/packages/react/src/hooks/useLibraryUrl/useLibraryUrl.spec.tsx
@@ -1,0 +1,129 @@
+import { IWebApp } from '@edifice.io/client';
+import { renderHook } from '~/setup';
+import useLibraryUrl from './useLibraryUrl';
+
+const { useEdificeClient } = vi.hoisted(() => ({
+  useEdificeClient: vi.fn(),
+}));
+
+vi.mock(
+  '../../providers/EdificeClientProvider/EdificeClientProvider.hook',
+  () => ({ useEdificeClient }),
+);
+
+function libraryApp(address: string): IWebApp {
+  return {
+    name: 'Library',
+    address,
+    icon: '',
+    target: '',
+    displayName: 'Library',
+    display: true,
+    prefix: '',
+    casType: '',
+    scope: [],
+    isExternal: true,
+  } as unknown as IWebApp;
+}
+
+function mockClient({
+  apps = [libraryApp('https://library.edifice.io?platformURL=https://ent.fr')],
+  appCode = 'blog',
+}: { apps?: IWebApp[]; appCode?: string } = {}) {
+  useEdificeClient.mockReturnValue({ user: { apps }, appCode });
+}
+
+describe('useLibraryUrl', () => {
+  it('builds the search URL for the current app code', () => {
+    mockClient();
+
+    const { result } = renderHook(() => useLibraryUrl());
+
+    expect(result.current).toBe(
+      'https://library.edifice.io/search/?platformURL=https://ent.fr&application%5B0%5D=Blog&page=1&sort_field=views&sort_order=desc',
+    );
+  });
+
+  it('honors an explicit app code over the ambient one', () => {
+    mockClient({ appCode: 'blog' });
+
+    const { result } = renderHook(() => useLibraryUrl('mindmap'));
+
+    expect(result.current).toContain('application%5B0%5D=MindMap');
+  });
+
+  it('leaves the application name empty for an app absent from the map', () => {
+    mockClient({ appCode: 'unmapped' });
+
+    const { result } = renderHook(() => useLibraryUrl());
+
+    expect(result.current).toContain('application%5B0%5D=undefined');
+  });
+
+  it('does not double the slash when the library host already ends with one', () => {
+    mockClient({
+      apps: [
+        libraryApp('https://library.edifice.io/?platformURL=https://ent.fr'),
+      ],
+    });
+
+    const { result } = renderHook(() => useLibraryUrl());
+
+    expect(result.current).toContain('https://library.edifice.io/search/?');
+  });
+
+  it('returns null when no external library app is exposed', () => {
+    mockClient({
+      apps: [
+        {
+          ...libraryApp('https://blog.edifice.io?platformURL=https://ent.fr'),
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useLibraryUrl());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when the library app is not flagged as external', () => {
+    mockClient({
+      apps: [
+        {
+          ...libraryApp(
+            'https://library.edifice.io?platformURL=https://ent.fr',
+          ),
+          isExternal: false,
+        } as IWebApp,
+      ],
+    });
+
+    const { result } = renderHook(() => useLibraryUrl());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when the library address carries no platform URL', () => {
+    mockClient({ apps: [libraryApp('https://library.edifice.io')] });
+
+    const { result } = renderHook(() => useLibraryUrl());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null when the user has no app at all', () => {
+    mockClient({ apps: [] });
+
+    const { result } = renderHook(() => useLibraryUrl());
+
+    expect(result.current).toBeNull();
+  });
+
+  it('returns null while the user is not loaded yet', () => {
+    useEdificeClient.mockReturnValue({ user: undefined, appCode: 'blog' });
+
+    const { result } = renderHook(() => useLibraryUrl());
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/packages/react/src/hooks/useZendeskGuide/useZendeskGuide.spec.tsx
+++ b/packages/react/src/hooks/useZendeskGuide/useZendeskGuide.spec.tsx
@@ -1,0 +1,492 @@
+import { act, renderHook, waitFor } from '~/setup';
+import useZendeskGuide from './useZendeskGuide';
+
+const {
+  get,
+  useHasWorkflow,
+  useEdificeClient,
+  useEdificeTheme,
+  useIsAdml,
+  useUser,
+} = vi.hoisted(() => ({
+  get: vi.fn(),
+  useHasWorkflow: vi.fn(),
+  useEdificeClient: vi.fn(),
+  useEdificeTheme: vi.fn(),
+  useIsAdml: vi.fn(),
+  useUser: vi.fn(),
+}));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: { http: () => ({ get }) },
+}));
+
+vi.mock('..', () => ({ useIsAdml, useUser }));
+
+vi.mock('../useHasWorkflow', () => ({ useHasWorkflow }));
+
+vi.mock(
+  '../../providers/EdificeClientProvider/EdificeClientProvider.hook',
+  () => ({ useEdificeClient }),
+);
+
+vi.mock(
+  '../../providers/EdificeThemeProvider/EdificeThemeProvider.hook',
+  () => ({
+    useEdificeTheme,
+  }),
+);
+
+type ZendeskMock = ReturnType<typeof vi.fn> & {
+  setLocale: ReturnType<typeof vi.fn>;
+};
+
+let zE: ZendeskMock;
+const initialInnerWidth = window.innerWidth;
+
+const snippet = () =>
+  document.getElementById('ze-snippet') as HTMLScriptElement | null;
+
+/** Calls to `zE('webWidget', 'updateSettings', payload)`, payloads only. */
+const settings = () =>
+  zE.mock.calls
+    .filter(
+      ([target, action]) =>
+        target === 'webWidget' && action === 'updateSettings',
+    )
+    .map(([, , payload]) => payload);
+
+/** Payloads pushed to the help-center suggestions API. */
+const suggestions = () =>
+  zE.mock.calls
+    .filter(
+      ([target, action]) =>
+        target === 'webWidget' && action === 'helpCenter:setSuggestions',
+    )
+    .map(([, , payload]) => payload);
+
+/** Handler registered through `zE('webWidget:on', <event>, handler)`. */
+const widgetHandler = (event: string) =>
+  zE.mock.calls.find(
+    ([target, name]) => target === 'webWidget:on' && name === event,
+  )?.[2] as ((...args: unknown[]) => void) | undefined;
+
+function config(overrides: Record<string, unknown> = {}) {
+  return {
+    key: 'zendesk-key',
+    color: '#123456',
+    module: { labels: {}, default: 'help', profile: [] },
+    ...overrides,
+  };
+}
+
+/** Renders the hook, then plays the snippet load the browser would trigger. */
+async function mountAndLoad({
+  response = config(),
+  pathname = '/',
+}: { response?: unknown; pathname?: string } = {}) {
+  get.mockResolvedValue(response);
+  window.history.pushState({}, '', pathname);
+
+  renderHook(() => useZendeskGuide());
+
+  const script = await waitFor(() => {
+    const element = snippet();
+    expect(element).not.toBeNull();
+    return element as HTMLScriptElement;
+  });
+
+  await act(async () => {
+    script.onload?.(new Event('load'));
+  });
+
+  return script;
+}
+
+describe('useZendeskGuide', () => {
+  beforeEach(() => {
+    zE = vi.fn() as ZendeskMock;
+    zE.setLocale = vi.fn();
+    (window as unknown as { zE: ZendeskMock }).zE = zE;
+
+    useHasWorkflow.mockReturnValue(true);
+    useEdificeClient.mockReturnValue({ currentLanguage: 'fr' });
+    useUser.mockReturnValue({ userDescription: { profiles: ['Teacher'] } });
+    useIsAdml.mockReturnValue({ isAdml: false });
+    useEdificeTheme.mockReturnValue({ theme: { is1d: false } });
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    window.history.pushState({}, '', '/');
+    window.innerWidth = initialInnerWidth;
+    delete (window as unknown as { zE?: ZendeskMock }).zE;
+  });
+
+  describe('snippet injection', () => {
+    it('checks the support workflow before doing anything', () => {
+      useHasWorkflow.mockReturnValue(undefined);
+
+      renderHook(() => useZendeskGuide());
+
+      expect(useHasWorkflow).toHaveBeenCalledWith(
+        'net.atos.entng.support.controllers.DisplayController|view',
+      );
+      expect(get).not.toHaveBeenCalled();
+    });
+
+    it('injects the snippet built from the configuration key', async () => {
+      const script = await mountAndLoad();
+
+      expect(get).toHaveBeenCalledWith('/zendeskGuide/config');
+      expect(script.src).toBe(
+        'https://static.zdassets.com/ekr/snippet.js?key=zendesk-key',
+      );
+    });
+
+    it('injects nothing when the configuration carries no key', async () => {
+      get.mockResolvedValue(config({ key: '' }));
+
+      renderHook(() => useZendeskGuide());
+
+      await waitFor(() => expect(get).toHaveBeenCalled());
+      expect(snippet()).toBeNull();
+    });
+
+    it('injects nothing when the configuration call resolves empty', async () => {
+      get.mockResolvedValue(undefined);
+
+      renderHook(() => useZendeskGuide());
+
+      await waitFor(() => expect(get).toHaveBeenCalled());
+      expect(snippet()).toBeNull();
+    });
+
+    it('does not fetch the configuration when the snippet is already there', () => {
+      const existing = document.createElement('script');
+      existing.id = 'ze-snippet';
+      document.body.appendChild(existing);
+
+      renderHook(() => useZendeskGuide());
+
+      expect(get).not.toHaveBeenCalled();
+    });
+
+    it('returns nothing to render', () => {
+      useHasWorkflow.mockReturnValue(undefined);
+
+      const { result } = renderHook(() => useZendeskGuide());
+
+      expect(result.current).toBeNull();
+    });
+  });
+
+  describe('widget setup on load', () => {
+    it('shows the widget', async () => {
+      await mountAndLoad();
+
+      expect(zE).toHaveBeenCalledWith('webWidget', 'show');
+    });
+
+    it('sets the French locale by default', async () => {
+      await mountAndLoad();
+
+      const localeCallback = zE.mock.calls.find(
+        ([arg]) => typeof arg === 'function',
+      )?.[0] as () => void;
+      localeCallback();
+
+      expect(zE.setLocale).toHaveBeenCalledWith('fr');
+    });
+
+    it('sets the Latin-American Spanish locale for a Spanish session', async () => {
+      useEdificeClient.mockReturnValue({ currentLanguage: 'es' });
+
+      await mountAndLoad();
+
+      const localeCallback = zE.mock.calls.find(
+        ([arg]) => typeof arg === 'function',
+      )?.[0] as () => void;
+      localeCallback();
+
+      expect(zE.setLocale).toHaveBeenCalledWith('es-419');
+    });
+
+    it('applies the configured theme color', async () => {
+      await mountAndLoad();
+
+      expect(settings()[0]).toMatchObject({
+        webWidget: { color: { theme: '#123456' }, zIndex: 3 },
+      });
+    });
+
+    it('falls back to the Edifice yellow when no color is configured', async () => {
+      await mountAndLoad({ response: config({ color: undefined }) });
+
+      expect(settings()[0]).toMatchObject({
+        webWidget: { color: { theme: '#ffc400' } },
+      });
+    });
+
+    it('opens the contact form when the support workflow is granted', async () => {
+      await mountAndLoad();
+
+      expect(settings()[0]).toMatchObject({
+        webWidget: { contactForm: { suppress: false } },
+      });
+    });
+
+    it('suppresses the contact form without the support workflow', async () => {
+      useHasWorkflow.mockReturnValue(false);
+
+      await mountAndLoad();
+
+      expect(settings()[0]).toMatchObject({
+        webWidget: { contactForm: { suppress: true } },
+      });
+    });
+
+    it('keeps the original-article button by default', async () => {
+      await mountAndLoad();
+
+      expect(settings()[0]).toMatchObject({
+        webWidget: { helpCenter: { originalArticleButton: true } },
+      });
+    });
+
+    it('honors an explicitly disabled original-article button', async () => {
+      await mountAndLoad({
+        response: config({ articleRedirectButton: false }),
+      });
+
+      expect(settings()[0]).toMatchObject({
+        webWidget: { helpCenter: { originalArticleButton: false } },
+      });
+    });
+  });
+
+  describe('widget events', () => {
+    it('hides the mobile launcher label once the page is scrolled', async () => {
+      await mountAndLoad();
+      const before = settings().length;
+
+      Object.defineProperty(window, 'scrollY', {
+        value: 40,
+        configurable: true,
+      });
+      window.dispatchEvent(new Event('scroll'));
+
+      expect(settings()[before]).toMatchObject({
+        webWidget: { launcher: { mobile: { labelVisible: false } } },
+      });
+
+      Object.defineProperty(window, 'scrollY', {
+        value: 0,
+        configurable: true,
+      });
+    });
+
+    it('re-opens the contact form when the widget opens with the workflow', async () => {
+      await mountAndLoad();
+      const before = settings().length;
+
+      widgetHandler('open')?.();
+
+      expect(settings()[before]).toMatchObject({
+        webWidget: { contactForm: { suppress: false } },
+      });
+    });
+
+    it('leaves the contact form alone when the widget opens without the workflow', async () => {
+      useHasWorkflow.mockReturnValue(false);
+      await mountAndLoad();
+      const before = settings().length;
+
+      widgetHandler('open')?.();
+
+      expect(settings()).toHaveLength(before);
+    });
+
+    it('redirects the contact form to the support module', async () => {
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await mountAndLoad();
+      const before = settings().length;
+
+      widgetHandler('userEvent')?.({
+        category: 'Zendesk Web Widget',
+        action: 'Contact Form Shown',
+        properties: { name: 'contact-form' },
+      });
+
+      expect(settings()[before]).toMatchObject({
+        webWidget: { contactForm: { suppress: true } },
+      });
+      expect(zE).toHaveBeenCalledWith('webWidget', 'close');
+      expect(open).toHaveBeenCalledWith('/support/tickets/new', '_blank');
+    });
+
+    it('ignores an unrelated widget user event', async () => {
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await mountAndLoad();
+
+      widgetHandler('userEvent')?.({
+        category: 'Zendesk Web Widget',
+        action: 'Something Else',
+        properties: { name: 'contact-form' },
+      });
+
+      expect(open).not.toHaveBeenCalled();
+      expect(zE).not.toHaveBeenCalledWith('webWidget', 'close');
+    });
+
+    it('ignores the contact form event without the support workflow', async () => {
+      useHasWorkflow.mockReturnValue(false);
+      const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+      await mountAndLoad();
+
+      widgetHandler('userEvent')?.({
+        category: 'Zendesk Web Widget',
+        action: 'Contact Form Shown',
+        properties: { name: 'contact-form' },
+      });
+
+      expect(open).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('help-center suggestions', () => {
+    it('suggests the label mapped to the current module', async () => {
+      await mountAndLoad({
+        response: config({
+          module: { labels: { blog: 'blog-help' }, default: 'help' },
+        }),
+        pathname: '/blog/123',
+      });
+
+      expect(suggestions()[0]).toEqual({ labels: ['blog-help'] });
+    });
+
+    it('joins the pathname segments and drops the numeric ones', async () => {
+      await mountAndLoad({
+        response: config({
+          module: {
+            labels: { 'blog/edit': 'blog-edit-help' },
+            default: 'help',
+          },
+        }),
+        pathname: '/blog/42/edit',
+      });
+
+      expect(suggestions()[0]).toEqual({ labels: ['blog-edit-help'] });
+    });
+
+    it('falls back to the default label for an unmapped module', async () => {
+      await mountAndLoad({
+        response: config({
+          module: { labels: { blog: 'blog-help' }, default: 'help' },
+        }),
+        pathname: '/unmapped',
+      });
+
+      expect(suggestions()[0]).toEqual({ labels: ['help'] });
+    });
+
+    it('suggests nothing when the configuration exposes no module data', async () => {
+      await mountAndLoad({ response: config({ module: {} }) });
+
+      expect(suggestions()).toHaveLength(0);
+    });
+
+    it('resolves the adml tag for a local administrator', async () => {
+      useIsAdml.mockReturnValue({ isAdml: true });
+
+      await mountAndLoad({
+        response: config({
+          module: { labels: { blog: 'blog/${adml}' }, default: 'help' },
+        }),
+        pathname: '/blog',
+      });
+
+      expect(suggestions()[0]).toEqual({ labels: ['blog/adml'] });
+    });
+
+    it('strips the adml segment for a regular user', async () => {
+      await mountAndLoad({
+        response: config({
+          module: { labels: { blog: 'blog/${adml}' }, default: 'help' },
+        }),
+        pathname: '/blog',
+      });
+
+      expect(suggestions()[0]).toEqual({ labels: ['blog'] });
+    });
+
+    it('resolves the profile tag in lower case', async () => {
+      await mountAndLoad({
+        response: config({
+          module: { labels: { blog: 'blog/${profile}' }, default: 'help' },
+        }),
+        pathname: '/blog',
+      });
+
+      expect(suggestions()[0]).toEqual({ labels: ['blog/teacher'] });
+    });
+
+    it('resolves the theme tag to 2D by default', async () => {
+      await mountAndLoad({
+        response: config({
+          module: { labels: { blog: 'blog/${theme}' }, default: 'help' },
+        }),
+        pathname: '/blog',
+      });
+
+      expect(suggestions()[0]).toEqual({ labels: ['blog/2D'] });
+    });
+
+    it('resolves the theme tag to 1D on a first-degree theme', async () => {
+      useEdificeTheme.mockReturnValue({ theme: { is1d: true } });
+
+      await mountAndLoad({
+        response: config({
+          module: { labels: { blog: 'blog/${theme}' }, default: 'help' },
+        }),
+        pathname: '/blog',
+      });
+
+      expect(suggestions()[0]).toEqual({ labels: ['blog/1D'] });
+    });
+
+    it('hides the widget on a collaborative wall opened on a small screen', async () => {
+      window.innerWidth = 500;
+
+      await mountAndLoad({
+        response: config({
+          module: {
+            labels: { 'collaborativewall/id': 'cw-help' },
+            default: 'help',
+          },
+        }),
+        pathname: '/collaborativewall/id/1',
+      });
+
+      expect(zE).toHaveBeenCalledWith('webWidget', 'hide');
+      expect(suggestions()[0]).toEqual({ labels: ['cw-help'] });
+    });
+
+    it('keeps the widget visible on a collaborative wall on a desktop screen', async () => {
+      window.innerWidth = 1440;
+
+      await mountAndLoad({
+        response: config({
+          module: {
+            labels: { 'collaborativewall/id': 'cw-help' },
+            default: 'help',
+          },
+        }),
+        pathname: '/collaborativewall/id/1',
+      });
+
+      expect(zE).not.toHaveBeenCalledWith('webWidget', 'hide');
+    });
+  });
+});


### PR DESCRIPTION
# Description

Lot 12 de l'effort de couverture de `@edifice.io/react` : **9 fichiers de specs, 221 tests**. La suite du package passe de **115 fichiers / 663 tests** à **124 / 884**. Aucun fichier de production n'est touché.

Le périmètre diffère de la liste du ticket, après inventaire : la plupart des hooks qu'il énumère (`useDropdown`, `useEdificeIcons`, `useUploadFiles`, `useDate`, `useClickOutside`, `useDropzone`, `useMediaLibrary`) ont **déjà** une spec, comme les composants `Tree`, `SortableTree` et `TreeView`. Le vrai trou était ailleurs :

| Fichier | Tests | Ce qui est couvert |
| --- | --- | --- |
| `Tree/utilities/tree.spec.ts` | 39 | logique pure d'arbre (add / delete / move / wrap / findPath…) |
| `Tree/utilities/tree-sortable.spec.ts` | 43 | flatten, projection de drag, génération des positions |
| `TreeView/utilities/treeview.spec.ts` | 33 | variante `TreeData` + `findTreeNode` |
| `Tree/hooks/useTree.spec.tsx` | 19 | sélection, fold/unfold, drag entrant |
| `Tree/hooks/useTreeSortable.spec.tsx` | 19 | cycle de drag dnd-kit complet, annonces a11y |
| `TreeView/hooks/useTreeView.spec.tsx` | 19 | idem + handlers impératifs exposés par `ref` |
| `useZendeskGuide.spec.tsx` | 32 | injection du snippet, réglages du widget, résolution des labels |
| `useLibraryUrl.spec.tsx` | 9 | construction de l'URL Library |
| `useCantoo.spec.tsx` | 8 | injection du script Cantoo |

Les utilitaires sont testés directement, sans `render` ni `renderHook`, puisque ce sont des fonctions pures.

**Compatibilité Vitest 4** : les specs n'utilisent que `vi.hoisted` + `vi.mock` avec factory, et aucune option de config retirée par la v4. Vérifié en exécutant les 9 fichiers dans un worktree de `feat/ENABLING-841-vite-8` (Vitest 4.1.7 / Vite 8) : **221 tests verts à l'identique**.

**Aucun seuil de couverture n'est modifié** : ce lot est fait en avance de phase de la migration Vite/Vitest (ENABLING-841), les planchers seront recalibrés là-bas sur le moteur AST-aware.

## Trois comportements douteux relevés en chemin

Ils sont **encodés tels quels**, avec un commentaire qui explique pourquoi, plutôt que corrigés dans cette PR — un lot de tests n'a pas à changer le comportement de prod. À arbitrer séparément :

1. **`useTree` boucle à l'infini si l'appelant ne mémoïse pas `data`** — `useEffect([data, shouldExpandAllNodes])` écrit dans `expandedNodes`, donc un tableau recréé à chaque rendu relance l'effet sans fin. Le premier jet de la spec est tombé en OOM avant d'être corrigé. `Tree.tsx` passe une référence stable, donc pas de symptôme connu en prod, mais c'est un piège pour tout nouvel appelant.
2. **`hasChildren` transmet `data.id` au lieu de `folderId`** dans sa récursion : la fonction ne répond juste que pour la racine du parcours.
3. **`moveNode` cherche le nœud à déplacer dans le seul sous-arbre de destination** : un nœud venu d'ailleurs est supprimé sans être rattaché. Dans la même veine, `findItemIndexInTree` renvoie `0` pour « premier enfant imbriqué » comme pour « introuvable ».

Ticket : [ENABLING-1132](https://edifice-community.atlassian.net/browse/ENABLING-1132)

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Comment tester

1. `pnpm test` — 124 fichiers / 884 tests attendus sur `@edifice.io/react`.
2. `pnpm lint && pnpm format` — aucun warning nouveau imputable aux specs.
3. Cibler le lot seul : `pnpm --filter @edifice.io/react exec vitest run src/components/Tree src/components/TreeView src/hooks/useLibraryUrl src/hooks/useCantoo src/hooks/useZendeskGuide`.
4. Après le merge d'ENABLING-841, relancer la suite : les specs sont écrites pour passer sans retouche sous Vitest 4.


[ENABLING-1132]: https://edifice-community.atlassian.net/browse/ENABLING-1132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ