### PR TITLE
test: #ENABLING-1133 couvre Layout, comments, audience, homepage et Grid

### DIFF
--- a/packages/react/src/components/Card/Card.spec.tsx
+++ b/packages/react/src/components/Card/Card.spec.tsx
@@ -90,4 +90,79 @@ describe('Card', () => {
 
     expect(ref.current).toHaveClass('card');
   });
+
+  it('falls back to the placeholder icon code without an application', () => {
+    render(
+      <Card>{(appCode) => <span data-testid="app-code">{appCode}</span>}</Card>,
+    );
+
+    expect(screen.getByTestId('app-code')).toHaveTextContent('placeholder');
+  });
+
+  it('hands the resolved icon code to a render-prop child', () => {
+    render(
+      <Card app={{ address: '/blog', displayName: 'Blog' } as never}>
+        {(appCode) => <span data-testid="app-code">{appCode}</span>}
+      </Card>,
+    );
+
+    expect(screen.getByTestId('app-code').textContent).toBeTruthy();
+  });
+
+  // Without an image source the fallback app icon is rendered, and the
+  // landscape variant stretches it through width/height props.
+  it('stretches the landscape fallback icon to the full width', () => {
+    const { container } = render(
+      <Card>
+        <Card.Image variant="landscape" />
+      </Card>,
+    );
+
+    // `{...style}` is spread as props on the fallback AppIcon, so the effect is
+    // not observable in the DOM — the variant class is.
+    expect(container.querySelector('.card-image.landscape')).not.toBeNull();
+  });
+
+  it('leaves the other variants at their own size', () => {
+    const { container } = render(
+      <Card>
+        <Card.Image variant="small" />
+      </Card>,
+    );
+
+    expect(container.querySelector('.card-image.small')).not.toBeNull();
+  });
+
+  it('renders a user avatar with an empty alt when the creator is unknown', () => {
+    const { container } = render(
+      <Card>
+        <Card.User userSrc="/avatar.png" creatorName="" />
+      </Card>,
+    );
+
+    expect(container.querySelector('img')).toHaveAttribute('alt', '');
+  });
+
+  it('renders no avatar without a user source', () => {
+    const { container } = render(
+      <Card>
+        <Card.User userSrc="" creatorName="Pascal" />
+      </Card>,
+    );
+
+    expect(container.querySelector('img')).toBeNull();
+  });
+
+  it('refuses to render a context-aware part outside of a Card', () => {
+    // The context guard keeps a misplaced part from failing silently.
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => render(<Card.Image imageSrc="/cover.png" />)).toThrow(
+      'Cannot be rendered outside the Card component',
+    );
+
+    consoleError.mockRestore();
+  });
 });

--- a/packages/react/src/components/Combobox/Combobox.spec.tsx
+++ b/packages/react/src/components/Combobox/Combobox.spec.tsx
@@ -17,10 +17,11 @@ function getInput() {
 function ControlledCombobox({
   onSearchResultsChange,
   comboboxRef,
+  ...extraProps
 }: {
   onSearchResultsChange?: (model: (string | number)[]) => void;
   comboboxRef?: React.Ref<ComboboxRef>;
-}) {
+} & Partial<React.ComponentProps<typeof Combobox>>) {
   const [value, setValue] = useState('');
   const [options, setOptions] = useState<OptionListItemType[]>([]);
 
@@ -45,6 +46,7 @@ function ControlledCombobox({
       onSearchInputChange={handleChange}
       onSearchResultsChange={onSearchResultsChange}
       placeholder="Rechercher…"
+      {...extraProps}
     />
   );
 }
@@ -145,5 +147,120 @@ describe('Combobox', () => {
     ref.current?.focus();
 
     expect(getInput()).toHaveFocus();
+  });
+
+  describe('custom rendering', () => {
+    it('hands the whole list over to renderList', async () => {
+      const { user } = render(
+        <ControlledCombobox
+          renderList={(options) => (
+            <div data-testid="custom-list">{options.length} options</div>
+          )}
+        />,
+      );
+
+      await user.type(getInput(), 'ite');
+
+      expect(await screen.findByTestId('custom-list')).toHaveTextContent(
+        '3 options',
+      );
+    });
+
+    it('lets renderListItem decorate each option', async () => {
+      const { user } = render(
+        <ControlledCombobox
+          renderListItem={(option) => (
+            <span data-testid={`option-${option.value}`}>{option.label}</span>
+          )}
+        />,
+      );
+
+      await user.type(getInput(), 'ite');
+
+      expect(await screen.findByTestId('option-first')).toHaveTextContent(
+        'First Item',
+      );
+    });
+
+    it('renders the extra input-group content and the selected items', () => {
+      render(
+        <Combobox
+          value=""
+          options={[]}
+          onSearchInputChange={vi.fn()}
+          renderInputGroup={<span data-testid="input-group">@</span>}
+          renderSelectedItems={<span data-testid="selected">1 selected</span>}
+        />,
+      );
+
+      expect(screen.getByTestId('input-group')).toBeInTheDocument();
+      expect(screen.getByTestId('selected')).toBeInTheDocument();
+    });
+
+    it('drops the input border in the ghost variant', () => {
+      render(
+        <Combobox
+          value=""
+          options={[]}
+          onSearchInputChange={vi.fn()}
+          variant="ghost"
+        />,
+      );
+
+      expect(getInput()).toHaveClass('border-0');
+    });
+  });
+
+  describe('keyboard', () => {
+    it('reports the key releases to the caller', async () => {
+      const onSearchInputKeyUp = vi.fn();
+      const { user } = render(
+        <Combobox
+          value=""
+          options={[]}
+          onSearchInputChange={vi.fn()}
+          onSearchInputKeyUp={onSearchInputKeyUp}
+        />,
+      );
+
+      await user.type(getInput(), 'a');
+
+      expect(onSearchInputKeyUp).toHaveBeenCalled();
+    });
+
+    it('survives a key release without a handler', async () => {
+      const { user } = render(
+        <Combobox value="" options={[]} onSearchInputChange={vi.fn()} />,
+      );
+
+      await user.type(getInput(), 'a');
+
+      expect(getInput()).toHaveValue('a');
+    });
+  });
+
+  describe('opening rules', () => {
+    it('opens as soon as the input reaches the minimum length', async () => {
+      const { user } = render(<ControlledCombobox searchMinLength={2} />);
+
+      await user.type(getInput(), 'it');
+
+      expect(await screen.findByText('First Item')).toBeInTheDocument();
+    });
+
+    it('opens on click when a default option is offered', async () => {
+      const { user } = render(
+        <Combobox
+          value=""
+          options={allOptions}
+          hasDefault
+          onSearchInputChange={vi.fn()}
+        />,
+      );
+
+      await user.click(getInput());
+
+      expect(await screen.findByText('First Item')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/react/src/components/Dropdown/DropdownItems.spec.tsx
+++ b/packages/react/src/components/Dropdown/DropdownItems.spec.tsx
@@ -1,0 +1,345 @@
+import { useState } from 'react';
+import { render, screen } from '~/setup';
+import { Dropdown } from './index';
+
+/**
+ * Covers the Dropdown item flavours (action/select, radio, checkbox), the search
+ * input and the filtering they share. The root behaviour — opening, keyboard
+ * navigation, imperative API — lives in Dropdown.spec.tsx.
+ */
+function openMenu(children: React.ReactNode) {
+  return render(
+    <Dropdown>
+      {(triggerProps) => (
+        <>
+          <Dropdown.Trigger label="Actions" {...triggerProps} />
+          <Dropdown.Menu>{children}</Dropdown.Menu>
+        </>
+      )}
+    </Dropdown>,
+  );
+}
+
+const item = (name: string) => screen.getByRole('menuitem', { name });
+
+describe('Dropdown.Item', () => {
+  it('renders an accessible menu item with its icon and label', async () => {
+    const { user } = openMenu(
+      <Dropdown.Item icon={<span data-testid="icon" />}>Delete</Dropdown.Item>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+
+    expect(item('Delete')).toBeInTheDocument();
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('calls back on click and closes the menu for an action item', async () => {
+    const onClick = vi.fn();
+    const { user } = openMenu(
+      <Dropdown.Item onClick={onClick}>Delete</Dropdown.Item>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.click(item('Delete'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('menuitem')).not.toBeInTheDocument();
+  });
+
+  it('keeps the menu open for a select item', async () => {
+    const onClick = vi.fn();
+    const { user } = openMenu(
+      <Dropdown.Item type="select" onClick={onClick}>
+        Sort by name
+      </Dropdown.Item>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.click(item('Sort by name'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(item('Sort by name')).toBeInTheDocument();
+  });
+
+  it('ignores a click on a disabled item', async () => {
+    const onClick = vi.fn();
+    const { user } = openMenu(
+      <Dropdown.Item disabled onClick={onClick}>
+        Delete
+      </Dropdown.Item>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.click(item('Delete'));
+
+    expect(onClick).not.toHaveBeenCalled();
+    expect(item('Delete')).toHaveClass('text-gray-600');
+  });
+
+  it('applies a minimum width and the custom classes', async () => {
+    const { user } = openMenu(
+      <Dropdown.Item minWidth={240} className="my-item">
+        Delete
+      </Dropdown.Item>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+
+    expect(item('Delete')).toHaveStyle({ minWidth: '240px' });
+    expect(item('Delete')).toHaveClass('my-item');
+  });
+
+  it('marks the hovered item as current', async () => {
+    const { user } = openMenu(
+      <>
+        <Dropdown.Item>First</Dropdown.Item>
+        <Dropdown.Item>Second</Dropdown.Item>
+      </>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Actions' }));
+    await user.hover(item('Second'));
+
+    expect(item('Second')).toHaveAttribute('aria-current', 'true');
+    expect(item('First')).toHaveAttribute('aria-current', 'false');
+  });
+});
+
+describe('Dropdown.RadioItem', () => {
+  function RadioMenu() {
+    const [model, setModel] = useState('asc');
+
+    return (
+      <Dropdown>
+        {(triggerProps) => (
+          <>
+            <Dropdown.Trigger label="Sort" {...triggerProps} />
+            <Dropdown.Menu>
+              <Dropdown.RadioItem value="asc" model={model} onChange={setModel}>
+                Ascending
+              </Dropdown.RadioItem>
+              <Dropdown.RadioItem
+                value="desc"
+                model={model}
+                onChange={setModel}
+              >
+                Descending
+              </Dropdown.RadioItem>
+            </Dropdown.Menu>
+          </>
+        )}
+      </Dropdown>
+    );
+  }
+
+  it('checks the item matching the model', async () => {
+    const { user } = render(<RadioMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Sort' }));
+
+    expect(
+      screen.getByRole('menuitemradio', { name: 'Ascending' }),
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(
+      screen.getByRole('menuitemradio', { name: 'Descending' }),
+    ).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('moves the selection on click', async () => {
+    const { user } = render(<RadioMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Sort' }));
+    await user.click(screen.getByRole('menuitemradio', { name: 'Descending' }));
+
+    expect(
+      screen.getByRole('menuitemradio', { name: 'Descending' }),
+    ).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('only makes the selected item focusable', async () => {
+    const { user } = render(<RadioMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Sort' }));
+
+    expect(
+      screen.getByRole('menuitemradio', { name: 'Ascending' }),
+    ).toHaveAttribute('tabindex', '0');
+    expect(
+      screen.getByRole('menuitemradio', { name: 'Descending' }),
+    ).toHaveAttribute('tabindex', '-1');
+  });
+});
+
+describe('Dropdown.CheckboxItem', () => {
+  function CheckboxMenu() {
+    const [model, setModel] = useState<(string | number)[]>(['blog']);
+
+    const toggle = (value: string | number) =>
+      setModel((current) =>
+        current.includes(value)
+          ? current.filter((entry) => entry !== value)
+          : [...current, value],
+      );
+
+    return (
+      <Dropdown>
+        {(triggerProps) => (
+          <>
+            <Dropdown.Trigger label="Filters" {...triggerProps} />
+            <Dropdown.Menu>
+              <Dropdown.CheckboxItem
+                value="blog"
+                model={model}
+                onChange={toggle}
+              >
+                Blog
+              </Dropdown.CheckboxItem>
+              <Dropdown.CheckboxItem
+                value="wiki"
+                model={model}
+                onChange={toggle}
+              >
+                Wiki
+              </Dropdown.CheckboxItem>
+            </Dropdown.Menu>
+          </>
+        )}
+      </Dropdown>
+    );
+  }
+
+  it('checks the items present in the model', async () => {
+    const { user } = render(<CheckboxMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+
+    expect(
+      screen.getByRole('menuitemcheckbox', { name: 'Blog' }),
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(
+      screen.getByRole('menuitemcheckbox', { name: 'Wiki' }),
+    ).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('adds a value to the model on click', async () => {
+    const { user } = render(<CheckboxMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    await user.click(screen.getByRole('menuitemcheckbox', { name: 'Wiki' }));
+
+    expect(
+      screen.getByRole('menuitemcheckbox', { name: 'Wiki' }),
+    ).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('removes an already selected value', async () => {
+    const { user } = render(<CheckboxMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Filters' }));
+    await user.click(screen.getByRole('menuitemcheckbox', { name: 'Blog' }));
+
+    expect(
+      screen.getByRole('menuitemcheckbox', { name: 'Blog' }),
+    ).toHaveAttribute('aria-checked', 'false');
+  });
+});
+
+describe('Dropdown.SearchInput', () => {
+  function SearchableMenu({
+    onSearch,
+  }: { onSearch?: (q: string) => void } = {}) {
+    return (
+      <Dropdown>
+        {(triggerProps) => (
+          <>
+            <Dropdown.Trigger label="Apps" {...triggerProps} />
+            <Dropdown.Menu>
+              <Dropdown.SearchInput
+                placeholder="Search an app"
+                noResultsLabel="Nothing found"
+                onSearch={onSearch}
+              />
+              <Dropdown.Item searchValue="Blog">Blog</Dropdown.Item>
+              <Dropdown.Item searchValue="Wiki">Wiki</Dropdown.Item>
+            </Dropdown.Menu>
+          </>
+        )}
+      </Dropdown>
+    );
+  }
+
+  it('filters the items matching the query, case-insensitively', async () => {
+    const { user } = render(<SearchableMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Apps' }));
+    await user.type(screen.getByPlaceholderText('Search an app'), 'wik');
+
+    expect(screen.getByRole('menuitem', { name: 'Wiki' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: 'Blog' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('reports the query to the caller', async () => {
+    const onSearch = vi.fn();
+    const { user } = render(<SearchableMenu onSearch={onSearch} />);
+
+    await user.click(screen.getByRole('button', { name: 'Apps' }));
+    await user.type(screen.getByPlaceholderText('Search an app'), 'a');
+
+    expect(onSearch).toHaveBeenCalledWith('a');
+  });
+
+  it('shows the empty label when nothing matches', async () => {
+    const { user } = render(<SearchableMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Apps' }));
+    await user.type(screen.getByPlaceholderText('Search an app'), 'zzz');
+
+    expect(screen.getByText('Nothing found')).toBeInTheDocument();
+  });
+
+  it('shows no empty label while the query is empty', async () => {
+    const { user } = render(<SearchableMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Apps' }));
+
+    expect(screen.queryByText('Nothing found')).not.toBeInTheDocument();
+  });
+
+  it('keeps the items without a search value out of the filtering', async () => {
+    const { user } = render(
+      <Dropdown>
+        {(triggerProps) => (
+          <>
+            <Dropdown.Trigger label="Apps" {...triggerProps} />
+            <Dropdown.Menu>
+              <Dropdown.SearchInput placeholder="Search an app" />
+              <Dropdown.Item searchValue="Blog">Blog</Dropdown.Item>
+              <Dropdown.Item>Always there</Dropdown.Item>
+            </Dropdown.Menu>
+          </>
+        )}
+      </Dropdown>,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Apps' }));
+    await user.type(screen.getByPlaceholderText('Search an app'), 'zzz');
+
+    expect(
+      screen.getByRole('menuitem', { name: 'Always there' }),
+    ).toBeInTheDocument();
+  });
+
+  it('does not let the arrow keys leak to the menu navigation', async () => {
+    const { user } = render(<SearchableMenu />);
+
+    await user.click(screen.getByRole('button', { name: 'Apps' }));
+    const input = screen.getByPlaceholderText('Search an app');
+    input.focus();
+    await user.keyboard('{ArrowDown}');
+
+    expect(input).toHaveFocus();
+  });
+});

--- a/packages/react/src/components/Dropzone/Dropzone.spec.tsx
+++ b/packages/react/src/components/Dropzone/Dropzone.spec.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '~/setup';
+import { fireEvent, render, screen, waitFor } from '~/setup';
 import Dropzone from './Dropzone';
 
 function createFile(name: string, type = 'image/png') {
@@ -83,7 +83,78 @@ describe('Dropzone', () => {
       'image/png,image/jpeg',
     );
   });
+
+  it('highlights the drop area while dragging over a multiple dropzone', () => {
+    const { container } = render(<Dropzone multiple>child content</Dropzone>);
+    const dropzone = container.querySelector('.dropzone') as HTMLElement;
+
+    fireEvent.dragEnter(dropzone);
+
+    expect(dropzone).toHaveClass('is-dragging');
+  });
+
+  it('stops highlighting a single-file dropzone that already holds a file', async () => {
+    const { container } = render(
+      <Dropzone multiple={false}>child content</Dropzone>,
+    );
+    relaxFileList(getFileInput(container));
+    const dropzone = container.querySelector('.dropzone') as HTMLElement;
+
+    fireEventDrop(dropzone, [createFile('a.png')]);
+    await waitFor(() =>
+      expect(container.querySelector('.drop-file-wrapper')).toHaveClass(
+        'd-block',
+      ),
+    );
+
+    fireEvent.dragEnter(dropzone);
+
+    expect(dropzone).not.toHaveClass('is-dragging');
+  });
+
+  it('ignores a second drop on a single-file dropzone', async () => {
+    const { container } = render(
+      <Dropzone multiple={false}>child content</Dropzone>,
+    );
+    relaxFileList(getFileInput(container));
+    const dropzone = container.querySelector('.dropzone') as HTMLElement;
+
+    fireEventDrop(dropzone, [createFile('a.png')]);
+    await waitFor(() =>
+      expect(container.querySelector('.drop-file-wrapper')).toHaveClass(
+        'd-block',
+      ),
+    );
+
+    fireEventDrop(dropzone, [createFile('b.png')]);
+
+    // The drop handler is detached once a file is there, so nothing is added.
+    await waitFor(() =>
+      expect(screen.queryByText('b.png')).not.toBeInTheDocument(),
+    );
+  });
+
+  it('refuses to render a part outside of a Dropzone', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    expect(() => render(<Dropzone.File />)).toThrow(
+      'Cannot be rendered outside Dropzone Provider',
+    );
+
+    consoleError.mockRestore();
+  });
 });
+
+// jsdom's FileList setter rejects a plain array, unlike a real dataTransfer.
+function relaxFileList(input: HTMLInputElement) {
+  Object.defineProperty(input, 'files', {
+    value: undefined,
+    writable: true,
+    configurable: true,
+  });
+}
 
 function fireEventDrop(element: HTMLElement, files: File[]) {
   const dataTransfer = { files };

--- a/packages/react/src/components/Grid/Grid.spec.tsx
+++ b/packages/react/src/components/Grid/Grid.spec.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from '~/setup';
+import { Grid } from './Grid';
+
+describe('Grid', () => {
+  it('renders its children inside a grid container', () => {
+    render(
+      <Grid>
+        <span>cell</span>
+      </Grid>,
+    );
+
+    expect(screen.getByText('cell')).toBeInTheDocument();
+    expect(document.querySelector('.grid')).toBeInTheDocument();
+  });
+
+  it('appends the custom classes to the grid class', () => {
+    render(<Grid className="my-grid">content</Grid>);
+
+    expect(document.querySelector('.grid')).toHaveClass('grid', 'my-grid');
+  });
+
+  it('forwards the remaining props to the container', () => {
+    render(
+      <Grid data-testid="the-grid" id="grid-1">
+        content
+      </Grid>,
+    );
+
+    expect(screen.getByTestId('the-grid')).toHaveAttribute('id', 'grid-1');
+  });
+});
+
+describe('Grid.Col', () => {
+  it('sets the mobile span', () => {
+    render(<Grid.Col sm="4">cell</Grid.Col>);
+
+    expect(screen.getByText('cell')).toHaveClass('g-col-4');
+  });
+
+  it('sets one span class per declared breakpoint', () => {
+    render(
+      <Grid.Col sm="4" md="6" lg="8" xl="10">
+        cell
+      </Grid.Col>,
+    );
+
+    expect(screen.getByText('cell')).toHaveClass(
+      'g-col-4',
+      'g-col-md-6',
+      'g-col-lg-8',
+      'g-col-xl-10',
+    );
+  });
+
+  it('emits no class for the breakpoints left out', () => {
+    render(<Grid.Col sm="4">cell</Grid.Col>);
+
+    const cell = screen.getByText('cell');
+    expect(cell.className).toBe('g-col-4');
+  });
+
+  it('appends the custom classes to the span ones', () => {
+    render(
+      <Grid.Col sm="4" className="p-16">
+        cell
+      </Grid.Col>,
+    );
+
+    expect(screen.getByText('cell')).toHaveClass('g-col-4', 'p-16');
+  });
+
+  it('renders a div by default', () => {
+    render(<Grid.Col sm="4">cell</Grid.Col>);
+
+    expect(screen.getByText('cell').tagName).toBe('DIV');
+  });
+
+  it('renders the requested element instead', () => {
+    render(
+      <Grid.Col sm="4" as="section">
+        cell
+      </Grid.Col>,
+    );
+
+    expect(screen.getByText('cell').tagName).toBe('SECTION');
+  });
+
+  it('forwards the remaining props to the column', () => {
+    render(
+      <Grid.Col sm="4" role="listitem" aria-label="first">
+        cell
+      </Grid.Col>,
+    );
+
+    expect(screen.getByRole('listitem', { name: 'first' })).toBeInTheDocument();
+  });
+
+  it('is exposed under a readable display name', () => {
+    expect(Grid.displayName).toBe('Grid');
+    expect(Grid.Col.displayName).toBe('Grid.Col');
+  });
+});

--- a/packages/react/src/components/Layout/components/Header.spec.tsx
+++ b/packages/react/src/components/Layout/components/Header.spec.tsx
@@ -1,0 +1,360 @@
+import { render, screen } from '~/setup';
+import Header from './Header';
+
+const {
+  useConversation,
+  useHasWorkflow,
+  useUser,
+  useEdificeClient,
+  useEdificeTheme,
+  useHeader,
+  useHelp,
+} = vi.hoisted(() => ({
+  useConversation: vi.fn(),
+  useHasWorkflow: vi.fn(),
+  useUser: vi.fn(),
+  useEdificeClient: vi.fn(),
+  useEdificeTheme: vi.fn(),
+  useHeader: vi.fn(),
+  useHelp: vi.fn(),
+}));
+
+vi.mock('../../../hooks', () => ({
+  useConversation,
+  useHasWorkflow,
+  useUser,
+}));
+
+vi.mock(
+  '../../../providers/EdificeClientProvider/EdificeClientProvider.hook',
+  () => ({ useEdificeClient }),
+);
+
+vi.mock(
+  '../../../providers/EdificeThemeProvider/EdificeThemeProvider.hook',
+  () => ({ useEdificeTheme }),
+);
+
+vi.mock('../hooks', () => ({ useHelp }));
+vi.mock('../hooks/useHeader', () => ({ default: useHeader }));
+
+// The search engine writes into window.location, which jsdom refuses.
+vi.mock('./SearchEngine', () => ({
+  default: () => <li data-testid="search-engine" />,
+}));
+
+vi.mock('./Help', () => ({
+  default: ({ isHelpOpen }: { isHelpOpen: boolean }) =>
+    isHelpOpen ? <div data-testid="help-modal" /> : null,
+}));
+
+type HeaderState = Partial<{
+  title: string;
+  bookmarkedApps: unknown[];
+  isAppsHovered: boolean;
+  userAvatar: string;
+  userName: string;
+  welcomeUser: string;
+  communityWorkflow: boolean;
+  communitiesWorkflow: boolean;
+  conversationWorflow: boolean;
+  searchWorkflow: boolean;
+  isCollapsed: boolean;
+}>;
+
+function setup({
+  is1d = false,
+  messages = 0,
+  zimbraWorkflow = false,
+  workflows = {},
+  language = 'fr',
+  currentApp,
+  helpOpen = false,
+  state = {},
+  ...rest
+}: {
+  is1d?: boolean;
+  messages?: number;
+  zimbraWorkflow?: boolean;
+  workflows?: Record<string, boolean>;
+  language?: string;
+  currentApp?: { address: string };
+  helpOpen?: boolean;
+  logoutCallback?: string | undefined;
+  state?: HeaderState;
+} = {}) {
+  const toggleCollapsedNav = vi.fn();
+  const setIsModalOpen = vi.fn();
+
+  useConversation.mockReturnValue({
+    messages,
+    msgLink: '/zimbra/zimbra',
+    zimbraWorkflow,
+  });
+  useUser.mockReturnValue({
+    user: { userId: 'user-1' },
+    avatar: '/avatar.png',
+  });
+  useEdificeClient.mockReturnValue({
+    currentLanguage: language,
+    currentApp,
+  });
+  // An explicit `logoutCallback: undefined` must survive, hence the key check
+  // rather than a default parameter.
+  useEdificeTheme.mockReturnValue({
+    theme: {
+      logoutCallback:
+        'logoutCallback' in rest ? rest.logoutCallback : '/portal',
+    },
+  });
+  useHasWorkflow.mockImplementation((workflow: string) => workflows[workflow]);
+  useHelp.mockReturnValue({
+    isModalOpen: helpOpen,
+    setIsModalOpen,
+    parsedContent: undefined,
+    parsedHeadline: undefined,
+    error: false,
+  });
+  useHeader.mockReturnValue({
+    title: 'Mon application',
+    bookmarkedApps: [],
+    appsRef: { current: null },
+    isAppsHovered: false,
+    popoverAppsId: 'apps-popover',
+    userAvatar: '/avatar.png',
+    userName: 'Pascal',
+    welcomeUser: 'Bonjour Pascal',
+    communityWorkflow: false,
+    communitiesWorkflow: false,
+    conversationWorflow: false,
+    searchWorkflow: false,
+    isCollapsed: true,
+    toggleCollapsedNav,
+    ...state,
+  });
+
+  return {
+    ...render(<Header is1d={is1d} src="/assets" />),
+    toggleCollapsedNav,
+    setIsModalOpen,
+  };
+}
+
+const OLD_HELP =
+  'org.entcore.portal.controllers.PortalController|oldHelpEnable';
+const CARBONIO =
+  'org.entcore.auth.controllers.CarbonioPreauthController|preauth';
+
+const header = () => document.querySelector('header');
+
+describe('Layout Header', () => {
+  describe('degree variants', () => {
+    it('marks a second-degree header', () => {
+      setup();
+
+      expect(header()).toHaveClass('header', 'no-1d');
+      expect(header()).not.toHaveClass('no-2d');
+    });
+
+    it('marks a first-degree header', () => {
+      setup({ is1d: true });
+
+      expect(header()).toHaveClass('no-2d');
+    });
+  });
+
+  describe('conversation', () => {
+    it('links to the conversation when the workflow is granted', () => {
+      setup({ state: { conversationWorflow: true } });
+
+      expect(
+        screen.getByRole('link', { name: 'conversation' }),
+      ).toHaveAttribute('href', '/conversation/conversation');
+    });
+
+    it('hides the conversation without the workflow', () => {
+      setup();
+
+      expect(
+        screen.queryByRole('link', { name: 'conversation' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('badges the number of unread messages', () => {
+      setup({ messages: 3, state: { conversationWorflow: true } });
+
+      expect(screen.getByText('3')).toBeInTheDocument();
+    });
+
+    it('shows no badge without any message', () => {
+      setup({ messages: 0, state: { conversationWorflow: true } });
+
+      expect(screen.queryByText('0')).not.toBeInTheDocument();
+    });
+
+    it('links to zimbra when that workflow is granted instead', () => {
+      setup({ zimbraWorkflow: true });
+
+      expect(
+        screen.getByRole('link', { name: 'conversation' }),
+      ).toHaveAttribute('href', '/zimbra/zimbra');
+    });
+
+    it('opens the carbonio preauth link in a new tab', () => {
+      setup({ workflows: { [CARBONIO]: true } });
+
+      const link = screen.getByRole('link', { name: 'conversation' });
+      expect(link).toHaveAttribute('href', '/auth/carbonio/preauth');
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+  });
+
+  describe('help', () => {
+    it('offers the help button for a French session with the legacy workflow', async () => {
+      const { user, setIsModalOpen } = setup({
+        language: 'fr',
+        workflows: { [OLD_HELP]: true },
+      });
+
+      await user.click(screen.getByRole('button', { name: 'Support' }));
+
+      expect(setIsModalOpen).toHaveBeenCalledWith(true);
+    });
+
+    it('hides the help button in another language', () => {
+      setup({ language: 'en', workflows: { [OLD_HELP]: true } });
+
+      expect(
+        screen.queryByRole('button', { name: 'Support' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the help button without the legacy workflow', () => {
+      setup({ language: 'fr' });
+
+      expect(
+        screen.queryByRole('button', { name: 'Support' }),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the help modal once opened', () => {
+      setup({
+        language: 'fr',
+        workflows: { [OLD_HELP]: true },
+        helpOpen: true,
+      });
+
+      expect(screen.getByTestId('help-modal')).toBeInTheDocument();
+    });
+  });
+
+  describe('secondary navigation', () => {
+    it('links to the applications and the user account', () => {
+      setup();
+
+      expect(
+        screen.getByRole('link', { name: 'navbar.applications' }),
+      ).toHaveAttribute('href', '/welcome');
+      expect(
+        screen.getByRole('link', { name: /navbar.myaccount/ }),
+      ).toHaveAttribute('href', '/userbook/mon-compte');
+    });
+
+    it('appends the theme callback to the logout link', () => {
+      setup();
+
+      expect(
+        screen.getByRole('link', { name: /navbar.disconnect/ }),
+      ).toHaveAttribute('href', '/auth/logout?callback=/portal');
+    });
+
+    it('logs out without a callback when the theme has none', () => {
+      setup({ logoutCallback: undefined });
+
+      expect(
+        screen.getByRole('link', { name: /navbar.disconnect/ }),
+      ).toHaveAttribute('href', '/auth/logout?callback=');
+    });
+
+    it('shows the community entry when its workflow is granted', () => {
+      setup({ state: { communityWorkflow: true } });
+
+      expect(
+        screen.getByRole('link', { name: 'navbar.community' }),
+      ).toHaveAttribute('href', '/community');
+    });
+
+    it('shows the communities entry when its workflow is granted', () => {
+      setup({ state: { communitiesWorkflow: true } });
+
+      expect(
+        screen.getByRole('link', { name: 'navbar.community' }),
+      ).toHaveAttribute('href', '/communities');
+    });
+
+    it('shows the search engine when its workflow is granted', () => {
+      setup({ state: { searchWorkflow: true } });
+
+      expect(screen.getByTestId('search-engine')).toBeInTheDocument();
+    });
+
+    it('hides the search engine otherwise', () => {
+      setup();
+
+      expect(screen.queryByTestId('search-engine')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('collapsed menu', () => {
+    it('is closed by default and toggles on click', async () => {
+      const { user, toggleCollapsedNav } = setup();
+
+      const toggle = screen.getByRole('button', { name: 'navbar.open.menu' });
+      expect(toggle).toHaveAttribute('aria-expanded', 'false');
+      expect(document.querySelector('.dropdown-menu')).not.toHaveClass('show');
+
+      await user.click(toggle);
+
+      expect(toggleCollapsedNav).toHaveBeenCalledTimes(1);
+    });
+
+    it('is shown when the navigation is expanded', () => {
+      setup({ state: { isCollapsed: false } });
+
+      expect(
+        screen.getByRole('button', { name: 'navbar.open.menu' }),
+      ).toHaveAttribute('aria-expanded', 'true');
+      expect(document.querySelector('.dropdown-menu')).toHaveClass('show');
+    });
+  });
+
+  describe('first-degree navigation', () => {
+    it('falls back to the timeline when no application is current', () => {
+      setup({ is1d: true });
+
+      expect(
+        screen.getByRole('link', { name: 'Mon application' }),
+      ).toHaveAttribute('href', '/timeline/timeline');
+    });
+
+    it('links the title to the current application', () => {
+      setup({ is1d: true, currentApp: { address: '/blog' } });
+
+      expect(
+        screen.getByRole('link', { name: 'Mon application' }),
+      ).toHaveAttribute('href', '/blog');
+    });
+
+    it('welcomes the user next to their avatar', () => {
+      setup({ is1d: true });
+
+      expect(screen.getByText('Bonjour Pascal')).toBeInTheDocument();
+    });
+
+    it('badges the messages with the first-degree styling', () => {
+      setup({ is1d: true, messages: 5, state: { conversationWorflow: true } });
+
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react/src/components/Layout/components/NavLink.spec.tsx
+++ b/packages/react/src/components/Layout/components/NavLink.spec.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from '~/setup';
+import { NavLink } from './NavLink';
+
+describe('NavLink', () => {
+  it('renders a link to the given target with the nav-link class', () => {
+    render(<NavLink link="/blog">Blog</NavLink>);
+
+    const link = screen.getByRole('link', { name: 'Blog' });
+    expect(link).toHaveAttribute('href', '/blog');
+    expect(link).toHaveClass('nav-link');
+  });
+
+  it('appends the custom classes to the default one', () => {
+    render(
+      <NavLink link="/blog" className="dropdown-item">
+        Blog
+      </NavLink>,
+    );
+
+    expect(screen.getByRole('link')).toHaveClass('nav-link', 'dropdown-item');
+  });
+
+  it('exposes the translated label to assistive technologies only', () => {
+    render(
+      <NavLink link="/blog" translate="Aller au blog">
+        <span aria-hidden="true">icon</span>
+      </NavLink>,
+    );
+
+    expect(screen.getByRole('link', { name: 'Aller au blog' })).toBeVisible();
+  });
+
+  it('renders no hidden label without the translate prop', () => {
+    render(<NavLink link="/blog">Blog</NavLink>);
+
+    expect(document.querySelector('.nav-text')).toBeNull();
+  });
+
+  it('forwards the remaining props to the anchor', () => {
+    render(
+      <NavLink link="/blog" button aria-current="page">
+        Blog
+      </NavLink>,
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute('aria-current', 'page');
+  });
+});

--- a/packages/react/src/components/Layout/components/WidgetApps.spec.tsx
+++ b/packages/react/src/components/Layout/components/WidgetApps.spec.tsx
@@ -1,0 +1,132 @@
+import { IWebApp } from '@edifice.io/client';
+import { render, screen } from '~/setup';
+import WidgetApps, { WidgetAppsBody, WidgetAppsFooter } from './WidgetApps';
+
+function makeApp(partial: Partial<IWebApp> & { name: string }): IWebApp {
+  return {
+    address: `/${partial.name.toLowerCase()}`,
+    display: true,
+    displayName: partial.name,
+    icon: '',
+    isExternal: false,
+    prefix: '',
+    scope: [],
+    target: '',
+    ...partial,
+  } as unknown as IWebApp;
+}
+
+describe('WidgetApps', () => {
+  it('renders its children inside the applications widget', () => {
+    render(
+      <WidgetApps>
+        <span>widget content</span>
+      </WidgetApps>,
+    );
+
+    expect(screen.getByText('widget content')).toBeInTheDocument();
+  });
+});
+
+describe('WidgetAppsFooter', () => {
+  it('links to the whole application list', () => {
+    render(<WidgetAppsFooter />);
+
+    expect(screen.getByRole('link', { name: 'plus' })).toHaveAttribute(
+      'href',
+      '/welcome',
+    );
+  });
+});
+
+describe('WidgetAppsBody', () => {
+  it('invites the user to bookmark apps when none is bookmarked', () => {
+    render(<WidgetAppsBody bookmarkedApps={[]} />);
+
+    expect(screen.getByText('navbar.myapps.more')).toBeInTheDocument();
+    expect(screen.queryAllByRole('link')).toHaveLength(0);
+  });
+
+  it('renders one link per bookmarked app, pointing at its address', () => {
+    render(
+      <WidgetAppsBody
+        bookmarkedApps={[makeApp({ name: 'Blog' }), makeApp({ name: 'Wiki' })]}
+      />,
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', '/blog');
+    expect(screen.getByTitle('Blog')).toBeInTheDocument();
+  });
+
+  it('caps the list at six apps', () => {
+    render(
+      <WidgetAppsBody
+        bookmarkedApps={Array.from({ length: 9 }, (_, index) =>
+          makeApp({ name: `App${index}` }),
+        )}
+      />,
+    );
+
+    expect(screen.getAllByRole('link')).toHaveLength(6);
+  });
+
+  it('prefers the prefix over the display name for the title', () => {
+    render(
+      <WidgetAppsBody
+        bookmarkedApps={[makeApp({ name: 'Blog', prefix: '/blog-prefix' })]}
+      />,
+    );
+
+    expect(screen.getByTitle('blog-prefix')).toBeInTheDocument();
+  });
+
+  it('ignores a prefix too short to carry a translation key', () => {
+    render(
+      <WidgetAppsBody
+        bookmarkedApps={[makeApp({ name: 'Blog', prefix: '/' })]}
+      />,
+    );
+
+    expect(screen.getByTitle('Blog')).toBeInTheDocument();
+  });
+
+  it('opens the administration app in a new tab', () => {
+    render(
+      <WidgetAppsBody bookmarkedApps={[makeApp({ name: 'Administration' })]} />,
+    );
+
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('opens an external app in a new tab', () => {
+    render(
+      <WidgetAppsBody
+        bookmarkedApps={[makeApp({ name: 'Library', isExternal: true })]}
+      />,
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute('target', '_blank');
+  });
+
+  it('honors an app already targeting a new tab', () => {
+    render(
+      <WidgetAppsBody
+        bookmarkedApps={[makeApp({ name: 'Blog', target: '_blank' })]}
+      />,
+    );
+
+    expect(screen.getByRole('link')).toHaveAttribute('target', '_blank');
+  });
+
+  it('keeps an internal app in the current tab', () => {
+    render(<WidgetAppsBody bookmarkedApps={[makeApp({ name: 'Blog' })]} />);
+
+    const link = screen.getByRole('link');
+    expect(link).not.toHaveAttribute('target');
+    expect(link).not.toHaveAttribute('rel');
+  });
+});

--- a/packages/react/src/components/Layout/hooks/useHelp.spec.tsx
+++ b/packages/react/src/components/Layout/hooks/useHelp.spec.tsx
@@ -1,0 +1,274 @@
+import { render, renderHook, screen, waitFor } from '~/setup';
+import { useHelp } from './useHelp';
+
+const { useEdificeClient, useEdificeTheme } = vi.hoisted(() => ({
+  useEdificeClient: vi.fn(),
+  useEdificeTheme: vi.fn(),
+}));
+
+vi.mock(
+  '../../../providers/EdificeClientProvider/EdificeClientProvider.hook',
+  () => ({ useEdificeClient }),
+);
+
+vi.mock(
+  '../../../providers/EdificeThemeProvider/EdificeThemeProvider.hook',
+  () => ({ useEdificeTheme }),
+);
+
+const fetchMock = vi.fn();
+
+// Minimal help page: a headline, a table of contents and two sections.
+// Two constraints come from how the hook reads the parsed tree: the string must
+// start on the `<html>` tag (a leading text node would make the parser return an
+// array, which the hook does not look into), and `<html>` needs a second child
+// besides `<body>` — the hook calls `.find()` on its children, which is only an
+// array when there are several.
+const helpPage =
+  '<html><head><title>Aide</title></head><body>' +
+  '<p>Aide en ligne</p>' +
+  '<div id="TOC"><ul>' +
+  '<li><a href="#présentation">Présentation</a></li>' +
+  '<li><a href="#creation">Création</a></li>' +
+  '</ul></div>' +
+  '<div class="section level2" id="présentation">' +
+  '<h2>Titre présentation</h2><img src="images/screen.png" />' +
+  '</div>' +
+  '<div class="section level2" id="creation"><h2>Titre création</h2></div>' +
+  '</body></html>';
+
+function mockFetch({
+  status = 200,
+  html = helpPage,
+}: { status?: number; html?: string } = {}) {
+  fetchMock.mockResolvedValue({ status, text: async () => html });
+}
+
+function HelpContent({
+  workflow = true,
+}: {
+  workflow?: boolean | Record<string, boolean>;
+}) {
+  const { parsedContent, parsedHeadline, error } = useHelp(workflow);
+
+  return (
+    <div>
+      {error && <span>help-error</span>}
+      {parsedHeadline && <span data-testid="headline">{parsedHeadline}</span>}
+      {parsedContent}
+    </div>
+  );
+}
+
+describe('useHelp', () => {
+  beforeEach(() => {
+    useEdificeClient.mockReturnValue({ appCode: 'blog' });
+    useEdificeTheme.mockReturnValue({ theme: { is1d: false } });
+    vi.stubGlobal('fetch', fetchMock);
+    mockFetch();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    window.history.pushState({}, '', '/');
+  });
+
+  describe('help URL resolution', () => {
+    it('does not fetch anything without the legacy help workflow', () => {
+      renderHook(() => useHelp(false));
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('targets the help page of the current application', async () => {
+      renderHook(() => useHelp(true));
+
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith('/help-2d/application/blog/'),
+      );
+    });
+
+    it('targets the first-degree help path on a 1D theme', async () => {
+      useEdificeTheme.mockReturnValue({ theme: { is1d: true } });
+
+      renderHook(() => useHelp(true));
+
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith('/help-1d/application/blog/'),
+      );
+    });
+
+    it('falls back to the portal help page without an application code', async () => {
+      useEdificeClient.mockReturnValue({ appCode: '' });
+
+      renderHook(() => useHelp(true));
+
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith('/help-2d/application/portal/'),
+      );
+    });
+
+    it('reads the application from the eliot parameter on the adapter route', async () => {
+      window.history.pushState({}, '', '/adapter?eliot=mon-appli&other=1');
+
+      renderHook(() => useHelp(true));
+
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/help-2d/application/mon-appli/',
+        ),
+      );
+    });
+
+    it('maps the class administration route to its own help page', async () => {
+      window.history.pushState({}, '', '/directory/class-admin/1234');
+
+      renderHook(() => useHelp(true));
+
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/help-2d/application/parametrage-de-la-classe/',
+        ),
+      );
+    });
+
+    it.each([
+      '/userbook/mon-compte',
+      '/timeline/preferencesView',
+      '/timeline/historyView',
+    ])('maps %s to the userbook help page', async (pathname) => {
+      window.history.pushState({}, '', pathname);
+
+      renderHook(() => useHelp(true));
+
+      await waitFor(() =>
+        expect(fetchMock).toHaveBeenCalledWith(
+          '/help-2d/application/userbook/',
+        ),
+      );
+    });
+
+    // The effect only depends on the application code and the help path, so a
+    // workflow resolved after the first render does not trigger the fetch.
+    it('does not refetch when the workflow flag arrives later', async () => {
+      const { rerender } = renderHook(
+        ({ workflow }: { workflow: boolean }) => useHelp(workflow),
+        { initialProps: { workflow: false } },
+      );
+
+      rerender({ workflow: true });
+
+      await waitFor(() => expect(fetchMock).not.toHaveBeenCalled());
+    });
+  });
+
+  describe('error handling', () => {
+    it('flags an error on a missing help page', async () => {
+      mockFetch({ status: 404, html: 'not found' });
+
+      const { result } = renderHook(() => useHelp(true));
+
+      await waitFor(() => expect(result.current.error).toBe(true));
+      expect(result.current.html).toBe('');
+    });
+
+    it('flags an error when the request fails', async () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      fetchMock.mockRejectedValue(new Error('network down'));
+
+      const { result } = renderHook(() => useHelp(true));
+
+      await waitFor(() => expect(result.current.error).toBe(true));
+      expect(consoleError).toHaveBeenCalled();
+    });
+
+    it('clears the error flag on a successful fetch', async () => {
+      const { result } = renderHook(() => useHelp(true));
+
+      await waitFor(() => expect(result.current.html).not.toBe(''));
+      expect(result.current.error).toBe(false);
+    });
+  });
+
+  describe('parsed content', () => {
+    it('extracts the headline from the first paragraph of the body', async () => {
+      render(<HelpContent />);
+
+      expect(await screen.findByTestId('headline')).toHaveTextContent(
+        'Aide en ligne',
+      );
+    });
+
+    // A hidden section is out of the accessibility tree, so the assertions go
+    // through the DOM rather than through a role query.
+    it('shows the active section and hides the others', async () => {
+      render(<HelpContent />);
+
+      await screen.findByRole('heading', { name: 'Titre présentation' });
+
+      expect(document.getElementById('présentation')).not.toHaveAttribute(
+        'hidden',
+      );
+      expect(document.getElementById('creation')).toHaveAttribute('hidden');
+    });
+
+    it('rewrites the section images against the help path', async () => {
+      render(<HelpContent />);
+
+      await waitFor(() =>
+        expect(document.querySelector('img')).toHaveAttribute(
+          'src',
+          '/help-2d/images/screen.png',
+        ),
+      );
+    });
+
+    it('switches the visible section when a table-of-contents entry is clicked', async () => {
+      const { user } = render(<HelpContent />);
+
+      const entry = await screen.findByText('Création');
+      await user.click(entry);
+
+      expect(document.getElementById('creation')).not.toHaveAttribute('hidden');
+      expect(document.getElementById('présentation')).toHaveAttribute('hidden');
+    });
+
+    it('collapses the table of contents through its burger button', async () => {
+      const { user } = render(<HelpContent />);
+
+      await screen.findByText('Création');
+      const list = document.getElementById('TOC-list');
+      expect(list).toHaveStyle({ display: 'block' });
+
+      await user.click(screen.getByRole('button'));
+
+      expect(document.getElementById('TOC-list')).toHaveStyle({
+        display: 'none',
+      });
+    });
+
+    it('exposes no parsed content before the page is loaded', () => {
+      const { result } = renderHook(() => useHelp(false));
+
+      expect(result.current.html).toBe('');
+      expect(result.current.parsedContent).toBeUndefined();
+      expect(result.current.parsedHeadline).toBeUndefined();
+    });
+  });
+
+  describe('modal state', () => {
+    it('starts closed and opens on demand', async () => {
+      const { result } = renderHook(() => useHelp(false));
+
+      expect(result.current.isModalOpen).toBe(false);
+
+      await waitFor(() => {
+        result.current.setIsModalOpen(true);
+      });
+
+      expect(result.current.isModalOpen).toBe(true);
+    });
+  });
+});

--- a/packages/react/src/components/MediaViewer/MediaWrapper.spec.tsx
+++ b/packages/react/src/components/MediaViewer/MediaWrapper.spec.tsx
@@ -1,0 +1,79 @@
+import { MediaLibraryType } from '../../modules/multimedia';
+import { render, screen } from '~/setup';
+import { MediaWrapper } from './MediaWrapper';
+
+// The PDF viewer relies on react-pdf, already neutralised by the test setup.
+vi.mock('./PdfViewer', () => ({
+  default: ({ mediaUrl }: { mediaUrl: string }) => (
+    <div data-testid="pdf-viewer">{mediaUrl}</div>
+  ),
+}));
+
+const renderMedia = (
+  mediaType: MediaLibraryType,
+  {
+    mimeType,
+    mediaUrl = '/media/file',
+  }: { mimeType?: string; mediaUrl?: string } = {},
+) =>
+  render(
+    <MediaWrapper
+      mediaType={mediaType}
+      mediaUrl={mediaUrl}
+      mimeType={mimeType}
+    />,
+  );
+
+describe('MediaWrapper', () => {
+  it('renders an image', () => {
+    renderMedia('image');
+
+    expect(screen.getByRole('img')).toHaveAttribute('src', '/media/file');
+  });
+
+  describe('attachment', () => {
+    it('delegates a PDF to the dedicated viewer', () => {
+      renderMedia('attachment', { mimeType: 'application/pdf' });
+
+      expect(screen.getByTestId('pdf-viewer')).toHaveTextContent('/media/file');
+    });
+
+    it('offers a download link for any other mime type', () => {
+      renderMedia('attachment', { mimeType: 'application/msword' });
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('href', '/media/file');
+      expect(link).toHaveAttribute('download');
+      expect(screen.getByText('Download')).toBeInTheDocument();
+    });
+
+    it('offers a download link when the mime type is unknown', () => {
+      renderMedia('attachment');
+
+      expect(screen.getByRole('link')).toHaveAttribute('download');
+    });
+  });
+
+  describe('hyperlink', () => {
+    it('opens the link instead of downloading it', () => {
+      renderMedia('hyperlink');
+
+      const link = screen.getByRole('link');
+      expect(link).toHaveAttribute('target', '_blank');
+      expect(link).not.toHaveAttribute('download');
+      expect(screen.getByText('Open link')).toBeInTheDocument();
+    });
+
+    it('delegates a PDF hyperlink to the dedicated viewer', () => {
+      renderMedia('hyperlink', { mimeType: 'application/pdf' });
+
+      expect(screen.getByTestId('pdf-viewer')).toBeInTheDocument();
+    });
+  });
+
+  it('renders nothing for an unsupported media type', () => {
+    const { container } = renderMedia('unknown' as MediaLibraryType);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/react/src/components/MediaViewer/ToolbarViewer.spec.tsx
+++ b/packages/react/src/components/MediaViewer/ToolbarViewer.spec.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '~/setup';
+import ToolbarViewer from './ToolbarViewer';
+
+function setup({
+  nbMedia,
+  mediaUrl,
+  currentIndex = 0,
+}: { nbMedia?: number; mediaUrl?: string; currentIndex?: number } = {}) {
+  const onClose = vi.fn();
+
+  return {
+    ...render(
+      <ToolbarViewer
+        onClose={onClose}
+        mediaName="photo-de-classe.jpg"
+        nbMedia={nbMedia}
+        mediaUrl={mediaUrl}
+        currentIndex={currentIndex}
+      />,
+    ),
+    onClose,
+  };
+}
+
+describe('ToolbarViewer', () => {
+  it('shows the media name', () => {
+    setup();
+
+    expect(screen.getByText('photo-de-classe.jpg')).toBeInTheDocument();
+  });
+
+  it('counts the current media within the whole set', () => {
+    setup({ nbMedia: 4, currentIndex: 1 });
+
+    expect(screen.getByText('2/4')).toBeInTheDocument();
+  });
+
+  it('shows the position alone for a single media', () => {
+    setup({ currentIndex: 0 });
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('offers no media action without a URL', () => {
+    setup();
+
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it('offers the media actions once a URL is known', () => {
+    setup({ mediaUrl: '/media/file' });
+
+    expect(screen.getAllByRole('button').length).toBeGreaterThan(1);
+  });
+
+  it('closes on the close button', async () => {
+    const { user, onClose } = setup();
+
+    await user.click(screen.getAllByRole('button')[0]);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on the Escape key', async () => {
+    const { user, onClose } = setup();
+
+    await user.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops listening to the keyboard once unmounted', async () => {
+    const { user, onClose, unmount } = setup();
+
+    unmount();
+    await user.keyboard('{Escape}');
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/components/MediaViewer/ToolbarZoom.spec.tsx
+++ b/packages/react/src/components/MediaViewer/ToolbarZoom.spec.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '~/setup';
+import ToolbarZoom from './ToolbarZoom';
+
+describe('ToolbarZoom', () => {
+  it('offers a zoom-out and a zoom-in button', () => {
+    render(<ToolbarZoom zoomIn={vi.fn()} zoomOut={vi.fn()} />);
+
+    expect(screen.getAllByRole('button')).toHaveLength(2);
+  });
+
+  it('zooms out on the first button', async () => {
+    const zoomOut = vi.fn();
+    const { user } = render(<ToolbarZoom zoomIn={vi.fn()} zoomOut={zoomOut} />);
+
+    await user.click(screen.getAllByRole('button')[0]);
+
+    expect(zoomOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('zooms in on the second button', async () => {
+    const zoomIn = vi.fn();
+    const { user } = render(<ToolbarZoom zoomIn={zoomIn} zoomOut={vi.fn()} />);
+
+    await user.click(screen.getAllByRole('button')[1]);
+
+    expect(zoomIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not mix the two callbacks up', async () => {
+    const zoomIn = vi.fn();
+    const zoomOut = vi.fn();
+    const { user } = render(<ToolbarZoom zoomIn={zoomIn} zoomOut={zoomOut} />);
+
+    await user.click(screen.getAllByRole('button')[0]);
+
+    expect(zoomIn).not.toHaveBeenCalled();
+    expect(zoomOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders inside the zoom toolbar container', () => {
+    render(<ToolbarZoom zoomIn={vi.fn()} zoomOut={vi.fn()} />);
+
+    expect(
+      document.querySelector('.media-viewer-toolbar-zoom-container'),
+    ).toBeInTheDocument();
+    expect(
+      document.querySelector('.media-viewer-toolbar-zoom'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/components/Menu/hooks/useMenu.spec.tsx
+++ b/packages/react/src/components/Menu/hooks/useMenu.spec.tsx
@@ -1,0 +1,114 @@
+import { KeyboardEvent } from 'react';
+import { act, renderHook } from '~/setup';
+import { useMenu } from './useMenu';
+
+const keyEvent = (code: string) => {
+  const event = {
+    code,
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+  };
+  return event as unknown as KeyboardEvent<HTMLUListElement> & typeof event;
+};
+
+/** Builds the `<li><button/></li>` structure the hook drives. */
+function registerItems(menuItems: Set<HTMLLIElement>, count: number) {
+  const buttons: HTMLButtonElement[] = [];
+
+  for (let index = 0; index < count; index++) {
+    const listItem = document.createElement('li');
+    const button = document.createElement('button');
+    button.textContent = `item-${index}`;
+    button.setAttribute('tabindex', index === 0 ? '0' : '-1');
+    listItem.appendChild(button);
+    document.body.appendChild(listItem);
+    menuItems.add(listItem);
+    buttons.push(button);
+  }
+
+  return buttons;
+}
+
+describe('useMenu', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('exposes the menu refs and the props shared by its items', () => {
+    const { result } = renderHook(() => useMenu());
+
+    expect(result.current.menuRef.current).toBeNull();
+    expect(result.current.menuItems.size).toBe(0);
+    expect(result.current.childProps).toEqual({
+      'data-menubar-menuitem': '',
+      'role': 'menuitem',
+    });
+  });
+
+  it('moves the focus down the list, wrapping at the end', async () => {
+    const { result } = renderHook(() => useMenu());
+    const buttons = registerItems(result.current.menuItems, 3);
+
+    await act(() => result.current.onKeyDown(keyEvent('ArrowDown')));
+    expect(buttons[1]).toHaveFocus();
+    expect(buttons[1]).toHaveAttribute('tabindex', '0');
+    expect(buttons[0]).toHaveAttribute('tabindex', '-1');
+
+    await act(() => result.current.onKeyDown(keyEvent('ArrowDown')));
+    expect(buttons[2]).toHaveFocus();
+
+    await act(() => result.current.onKeyDown(keyEvent('ArrowDown')));
+    expect(buttons[0]).toHaveFocus();
+  });
+
+  it('moves the focus up the list, wrapping at the beginning', async () => {
+    const { result } = renderHook(() => useMenu());
+    const buttons = registerItems(result.current.menuItems, 3);
+
+    await act(() => result.current.onKeyDown(keyEvent('ArrowUp')));
+
+    expect(buttons[2]).toHaveFocus();
+  });
+
+  it('jumps to the last item on End and back to the first on Home', async () => {
+    const { result } = renderHook(() => useMenu());
+    const buttons = registerItems(result.current.menuItems, 3);
+
+    await act(() => result.current.onKeyDown(keyEvent('End')));
+    expect(buttons[2]).toHaveFocus();
+
+    await act(() => result.current.onKeyDown(keyEvent('Home')));
+    expect(buttons[0]).toHaveFocus();
+  });
+
+  it('prevents the default scroll on the navigation keys', async () => {
+    const { result } = renderHook(() => useMenu());
+    registerItems(result.current.menuItems, 2);
+
+    const event = keyEvent('ArrowDown');
+    await act(() => result.current.onKeyDown(event));
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(event.stopPropagation).toHaveBeenCalled();
+  });
+
+  it('leaves any other key alone', async () => {
+    const { result } = renderHook(() => useMenu());
+    const buttons = registerItems(result.current.menuItems, 2);
+    buttons[0].focus();
+
+    const event = keyEvent('KeyA');
+    await act(() => result.current.onKeyDown(event));
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(buttons[0]).toHaveFocus();
+  });
+
+  it('does not throw on an empty menu', async () => {
+    const { result } = renderHook(() => useMenu());
+
+    await expect(
+      act(() => result.current.onKeyDown(keyEvent('ArrowDown'))),
+    ).resolves.not.toThrow();
+  });
+});

--- a/packages/react/src/components/PageLayout/PageLayout.spec.tsx
+++ b/packages/react/src/components/PageLayout/PageLayout.spec.tsx
@@ -1,0 +1,415 @@
+import { render, screen } from '~/setup';
+import PageLayout from './PageLayout';
+import { useOverlayStore } from './store/overlayStore';
+
+vi.mock(
+  '../../providers/EdificeThemeProvider/EdificeThemeProvider.hook',
+  () => ({ useEdificeTheme: () => ({ theme: { basePath: '/assets' } }) }),
+);
+
+// The default header pulls the whole homepage header in; the layout itself is
+// what is under test here.
+vi.mock('../../modules/homepage/components/Header/Header', () => ({
+  default: () => <div data-testid="default-header" />,
+}));
+
+const root = () => document.querySelector('.pagelayout');
+const mainArea = () => document.querySelector('.pagelayout-mainarea');
+
+describe('PageLayout', () => {
+  afterEach(() => {
+    useOverlayStore.setState({ overlayOpen: false });
+  });
+
+  describe('root', () => {
+    it('renders the centered variant by default', () => {
+      render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(root()).toHaveClass('pagelayout', 'pagelayout-centered');
+      expect(screen.getByText('content')).toBeInTheDocument();
+    });
+
+    it('renders the fullpage variant when asked', () => {
+      render(
+        <PageLayout variant="fullpage">
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(root()).toHaveClass('pagelayout-fullpage');
+    });
+
+    it('carries the scroll mode as a class', () => {
+      render(
+        <PageLayout scrollMode="page">
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(root()).toHaveClass('pagelayout-scroll-page');
+    });
+
+    it('carries no scroll class without a scroll mode', () => {
+      render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(root()?.className).not.toContain('pagelayout-scroll-');
+    });
+
+    it('appends the custom classes and forwards the remaining props', () => {
+      render(
+        <PageLayout className="my-page" id="page-1">
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(root()).toHaveClass('my-page');
+      expect(root()).toHaveAttribute('id', 'page-1');
+    });
+  });
+
+  describe('main area layout', () => {
+    it('flags both sidebars', () => {
+      render(
+        <PageLayout>
+          <PageLayout.SidebarLeft>left</PageLayout.SidebarLeft>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.SidebarRight>right</PageLayout.SidebarRight>
+        </PageLayout>,
+      );
+
+      expect(mainArea()).toHaveClass('has-both-sidebars');
+    });
+
+    it('flags a left sidebar alone', () => {
+      render(
+        <PageLayout>
+          <PageLayout.SidebarLeft>left</PageLayout.SidebarLeft>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(mainArea()).toHaveClass('has-left-sidebar-only');
+    });
+
+    it('flags a right sidebar alone', () => {
+      render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.SidebarRight>right</PageLayout.SidebarRight>
+        </PageLayout>,
+      );
+
+      expect(mainArea()).toHaveClass('has-right-sidebar-only');
+    });
+
+    it('flags no sidebar when there is none', () => {
+      render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(mainArea()?.className).toBe('pagelayout-mainarea');
+    });
+
+    it('adds a gap on demand', () => {
+      render(
+        <PageLayout withGap>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(mainArea()).toHaveClass('has-gap');
+    });
+
+    it('keeps a plain child inside the main area', () => {
+      render(
+        <PageLayout>
+          <span>loose child</span>
+        </PageLayout>,
+      );
+
+      expect(mainArea()).toContainElement(screen.getByText('loose child'));
+    });
+
+    // `Children.toArray` flattens nested arrays but keeps a fragment as a single
+    // child, so the compound parts inside it are never recognised — contrary to
+    // what the comment in PageLayout.tsx claims. A fragment-wrapped sidebar ends
+    // up rendered as a plain child, without its layout class.
+    it('does not detect compound children wrapped in a fragment', () => {
+      render(
+        <PageLayout>
+          <>
+            <PageLayout.SidebarLeft>left</PageLayout.SidebarLeft>
+            <PageLayout.Content>content</PageLayout.Content>
+          </>
+        </PageLayout>,
+      );
+
+      expect(mainArea()).not.toHaveClass('has-left-sidebar-only');
+      expect(screen.getByText('left')).toBeInTheDocument();
+    });
+
+    it('detects compound children passed as an array', () => {
+      render(
+        <PageLayout>
+          {[
+            <PageLayout.SidebarLeft key="left">left</PageLayout.SidebarLeft>,
+            <PageLayout.Content key="content">content</PageLayout.Content>,
+          ]}
+        </PageLayout>,
+      );
+
+      expect(mainArea()).toHaveClass('has-left-sidebar-only');
+    });
+  });
+
+  describe('header', () => {
+    it('renders the custom header and its spacer', () => {
+      render(
+        <PageLayout>
+          <PageLayout.Header>
+            <span>my header</span>
+          </PageLayout.Header>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(screen.getByText('my header')).toBeInTheDocument();
+      expect(
+        document.querySelector('.pagelayout-headerspacer'),
+      ).toBeInTheDocument();
+    });
+
+    it('renders no spacer without a header', () => {
+      render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(document.querySelector('.pagelayout-headerspacer')).toBeNull();
+    });
+
+    it('falls back to the platform header when none is provided', () => {
+      render(
+        <PageLayout>
+          <PageLayout.Header />
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(screen.getByTestId('default-header')).toBeInTheDocument();
+    });
+  });
+
+  describe('breadcrumb placement', () => {
+    it('sits outside the main area in centered mode', () => {
+      render(
+        <PageLayout>
+          <PageLayout.Breadcrumb>crumbs</PageLayout.Breadcrumb>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(mainArea()).not.toContainElement(screen.getByText('crumbs'));
+      expect(root()).toContainElement(screen.getByText('crumbs'));
+    });
+
+    it('sits inside the main area in fullpage mode', () => {
+      render(
+        <PageLayout variant="fullpage">
+          <PageLayout.Breadcrumb>crumbs</PageLayout.Breadcrumb>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(mainArea()).toContainElement(screen.getByText('crumbs'));
+    });
+  });
+
+  describe('no-padding configuration', () => {
+    it('propagates the flags to each column through the context', () => {
+      render(
+        <PageLayout
+          noPadding={{ sidebarLeft: true, content: true, sidebarRight: true }}
+        >
+          <PageLayout.SidebarLeft>left</PageLayout.SidebarLeft>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.SidebarRight>right</PageLayout.SidebarRight>
+        </PageLayout>,
+      );
+
+      expect(document.querySelector('.pagelayout-sidebarleft')).toHaveClass(
+        'pagelayout-sidebarleft--no-padding',
+      );
+      expect(document.querySelector('.pagelayout-content')).toHaveClass(
+        'pagelayout-content--no-padding',
+      );
+      expect(document.querySelector('.pagelayout-sidebarright')).toHaveClass(
+        'pagelayout-sidebarright--no-padding',
+      );
+    });
+
+    it('keeps the padding by default', () => {
+      render(
+        <PageLayout>
+          <PageLayout.SidebarLeft>left</PageLayout.SidebarLeft>
+          <PageLayout.Content>content</PageLayout.Content>
+        </PageLayout>,
+      );
+
+      expect(document.querySelector('.pagelayout-content')?.className).toBe(
+        'pagelayout-content',
+      );
+    });
+  });
+
+  describe('overlay', () => {
+    it('is closed and inert by default', () => {
+      render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.Overlay>panel</PageLayout.Overlay>
+        </PageLayout>,
+      );
+
+      const overlay = document.querySelector('.pagelayout-overlay');
+      expect(overlay).not.toHaveClass('pagelayout-overlay-open');
+      expect(overlay).toHaveAttribute('aria-hidden', 'true');
+      expect(
+        screen.queryByTestId('pagelayout-overlay-close-button'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('opens with a close button when the store says so', () => {
+      useOverlayStore.setState({ overlayOpen: true });
+
+      render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.Overlay>panel</PageLayout.Overlay>
+        </PageLayout>,
+      );
+
+      expect(document.querySelector('.pagelayout-overlay')).toHaveClass(
+        'pagelayout-overlay-open',
+      );
+      expect(
+        screen.getByTestId('pagelayout-overlay-close-button'),
+      ).toBeInTheDocument();
+    });
+
+    it('closes on the close button and notifies the caller', async () => {
+      useOverlayStore.setState({ overlayOpen: true });
+      const onClose = vi.fn();
+
+      const { user } = render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.Overlay onClose={onClose}>panel</PageLayout.Overlay>
+        </PageLayout>,
+      );
+
+      await user.click(screen.getByTestId('pagelayout-overlay-close-button'));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(useOverlayStore.getState().overlayOpen).toBe(false);
+    });
+
+    it('hides the close button on demand', () => {
+      useOverlayStore.setState({ overlayOpen: true });
+
+      render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.Overlay closeButton={false}>panel</PageLayout.Overlay>
+        </PageLayout>,
+      );
+
+      expect(
+        screen.queryByTestId('pagelayout-overlay-close-button'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders a backdrop closing the overlay on click', async () => {
+      useOverlayStore.setState({ overlayOpen: true });
+      const onClose = vi.fn();
+
+      const { user } = render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.Overlay backdrop onClose={onClose}>
+            panel
+          </PageLayout.Overlay>
+        </PageLayout>,
+      );
+
+      const backdrop = document.querySelector('.pagelayout-overlaybackdrop');
+      expect(backdrop).toBeInTheDocument();
+
+      await user.click(backdrop as Element);
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders no backdrop by default', () => {
+      useOverlayStore.setState({ overlayOpen: true });
+
+      render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.Overlay>panel</PageLayout.Overlay>
+        </PageLayout>,
+      );
+
+      expect(document.querySelector('.pagelayout-overlaybackdrop')).toBeNull();
+    });
+
+    it('closes on the Escape key while open', async () => {
+      useOverlayStore.setState({ overlayOpen: true });
+      const onClose = vi.fn();
+
+      const { user } = render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.Overlay onClose={onClose}>panel</PageLayout.Overlay>
+        </PageLayout>,
+      );
+
+      await user.keyboard('{Escape}');
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(useOverlayStore.getState().overlayOpen).toBe(false);
+    });
+
+    it('ignores the Escape key while closed', async () => {
+      const onClose = vi.fn();
+
+      const { user } = render(
+        <PageLayout>
+          <PageLayout.Content>content</PageLayout.Content>
+          <PageLayout.Overlay onClose={onClose}>panel</PageLayout.Overlay>
+        </PageLayout>,
+      );
+
+      await user.keyboard('{Escape}');
+
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it('exposes readable display names for the compound parts', () => {
+    expect(PageLayout.displayName).toBe('PageLayout');
+    expect(PageLayout.Content.displayName).toBe('PageLayout.Content');
+    expect(PageLayout.Overlay.displayName).toBe('PageLayout.Overlay');
+  });
+});

--- a/packages/react/src/components/Select/Select.spec.tsx
+++ b/packages/react/src/components/Select/Select.spec.tsx
@@ -107,4 +107,47 @@ describe('Select', () => {
 
     expect(getTrigger()).toHaveTextContent('Droit');
   });
+
+  describe('plain string options', () => {
+    it('lists them and selects one', async () => {
+      const onValueChange = vi.fn();
+      const { user } = render(
+        <Select
+          options={['Chimie', 'Droit']}
+          placeholderOption="Choisir…"
+          onValueChange={onValueChange}
+        />,
+      );
+
+      await user.click(getTrigger());
+      await user.click(screen.getByText('Droit'));
+
+      expect(getTrigger()).toHaveTextContent('Droit');
+      expect(onValueChange).toHaveBeenCalledWith('Droit');
+    });
+
+    it('preselects the matching default value', () => {
+      render(
+        <Select
+          options={['Chimie', 'Droit']}
+          placeholderOption="Choisir…"
+          defaultValue="Chimie"
+        />,
+      );
+
+      expect(getTrigger()).toHaveTextContent('Chimie');
+    });
+
+    it('ignores a default value absent from the options', () => {
+      render(
+        <Select
+          options={['Chimie', 'Droit']}
+          placeholderOption="Choisir…"
+          defaultValue="Physique"
+        />,
+      );
+
+      expect(getTrigger()).toHaveTextContent('Choisir…');
+    });
+  });
 });

--- a/packages/react/src/components/Tabs/hooks/useTabs.spec.tsx
+++ b/packages/react/src/components/Tabs/hooks/useTabs.spec.tsx
@@ -1,0 +1,181 @@
+import { KeyboardEvent } from 'react';
+import { act, renderHook } from '~/setup';
+import { TabsItemProps } from '../components/TabsItem';
+import { useTabs } from './useTabs';
+
+const items = [
+  { id: 'first', label: 'First' },
+  { id: 'second', label: 'Second' },
+  { id: 'third', label: 'Third' },
+] as unknown as TabsItemProps[];
+
+const keyEvent = (code: string) =>
+  ({ code }) as unknown as KeyboardEvent<HTMLButtonElement>;
+
+function setup({
+  defaultId = 'first',
+  tabItems = items,
+}: { defaultId?: string; tabItems?: TabsItemProps[] } = {}) {
+  const onChange = vi.fn();
+
+  return {
+    ...renderHook(() => useTabs({ defaultId, items: tabItems, onChange })),
+    onChange,
+  };
+}
+
+describe('useTabs', () => {
+  it('starts on the default tab and announces it', () => {
+    const { result, onChange } = setup();
+
+    expect(result.current.activeTab).toBe('first');
+    expect(onChange).toHaveBeenCalledWith(items[0]);
+  });
+
+  it('starts with no active tab without a default', () => {
+    const { result, onChange } = setup({ defaultId: '' });
+
+    expect(result.current.activeTab).toBe('');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('selects a tab on demand and announces the change', async () => {
+    const { result, onChange } = setup();
+
+    await act(() => result.current.setSelectedTab('third'));
+
+    expect(result.current.activeTab).toBe('third');
+    expect(onChange).toHaveBeenLastCalledWith(items[2]);
+  });
+
+  // Selecting an unknown id lands on the default tab: the positioning effect
+  // resets it, which in turn announces that tab rather than the unknown one.
+  it('announces the default tab when an unknown id is selected', async () => {
+    const { result, onChange } = setup();
+    onChange.mockClear();
+
+    await act(() => result.current.setSelectedTab('ghost'));
+
+    expect(result.current.activeTab).toBe('first');
+    expect(onChange).toHaveBeenCalledWith(items[0]);
+  });
+
+  it('falls back to the default tab when the active one disappears', async () => {
+    const { result } = setup({ defaultId: 'second' });
+
+    await act(() => result.current.setSelectedTab('ghost'));
+
+    expect(result.current.activeTab).toBe('second');
+  });
+
+  describe('keyboard navigation', () => {
+    it('moves to the next tab on ArrowRight', async () => {
+      const { result } = setup();
+
+      await act(() => result.current.onKeyDown(keyEvent('ArrowRight')));
+
+      expect(result.current.activeTab).toBe('second');
+    });
+
+    it('wraps to the first tab from the last one', async () => {
+      const { result } = setup({ defaultId: 'third' });
+
+      await act(() => result.current.onKeyDown(keyEvent('ArrowRight')));
+
+      expect(result.current.activeTab).toBe('first');
+    });
+
+    it('moves to the previous tab on ArrowLeft', async () => {
+      const { result } = setup({ defaultId: 'second' });
+
+      await act(() => result.current.onKeyDown(keyEvent('ArrowLeft')));
+
+      expect(result.current.activeTab).toBe('first');
+    });
+
+    it('wraps to the last tab from the first one', async () => {
+      const { result } = setup();
+
+      await act(() => result.current.onKeyDown(keyEvent('ArrowLeft')));
+
+      expect(result.current.activeTab).toBe('third');
+    });
+
+    it('jumps to the first tab on Home', async () => {
+      const { result } = setup({ defaultId: 'third' });
+
+      await act(() => result.current.onKeyDown(keyEvent('Home')));
+
+      expect(result.current.activeTab).toBe('first');
+    });
+
+    it('jumps to the last tab on End', async () => {
+      const { result } = setup();
+
+      await act(() => result.current.onKeyDown(keyEvent('End')));
+
+      expect(result.current.activeTab).toBe('third');
+    });
+
+    it('ignores any other key', async () => {
+      const { result } = setup();
+
+      await act(() => result.current.onKeyDown(keyEvent('KeyA')));
+
+      expect(result.current.activeTab).toBe('first');
+    });
+  });
+
+  describe('underline position', () => {
+    it('stays at the origin while no tab element is registered', () => {
+      const { result } = setup();
+
+      expect(result.current.tabUnderlineLeft).toBe(0);
+      expect(result.current.tabUnderlineWidth).toBe(0);
+    });
+
+    it('follows the active tab element and focuses it', async () => {
+      const { result } = setup();
+
+      const button = document.createElement('button');
+      Object.defineProperties(button, {
+        offsetLeft: { value: 120, configurable: true },
+        clientWidth: { value: 80, configurable: true },
+      });
+      document.body.appendChild(button);
+
+      await act(() => {
+        result.current.tabsRef.current[1] = button;
+        result.current.setSelectedTab('second');
+      });
+
+      expect(result.current.tabUnderlineLeft).toBe(120);
+      expect(result.current.tabUnderlineWidth).toBe(80);
+      expect(button).toHaveFocus();
+
+      button.remove();
+    });
+
+    // Focusing a tab while typing in an input would close the mobile keyboard.
+    it('leaves an input alone when it holds the focus', async () => {
+      const { result } = setup();
+
+      const input = document.createElement('input');
+      document.body.appendChild(input);
+      input.focus();
+
+      const button = document.createElement('button');
+      document.body.appendChild(button);
+
+      await act(() => {
+        result.current.tabsRef.current[1] = button;
+        result.current.setSelectedTab('second');
+      });
+
+      expect(input).toHaveFocus();
+
+      input.remove();
+      button.remove();
+    });
+  });
+});

--- a/packages/react/src/components/Toolbar/Toolbar.spec.tsx
+++ b/packages/react/src/components/Toolbar/Toolbar.spec.tsx
@@ -232,4 +232,137 @@ describe('Toolbar', () => {
     expect(toolbar).toHaveAttribute('aria-controls', 'editor-1');
     expect(ref.current).toBe(toolbar);
   });
+
+  it('moves to the previous item with ArrowLeft, away from the ends', () => {
+    const items: ToolbarItem[] = [
+      { type: 'button', name: 'one', props: { children: 'One' } },
+      { type: 'button', name: 'two', props: { children: 'Two' } },
+      { type: 'button', name: 'three', props: { children: 'Three' } },
+    ];
+    const { container } = render(<Toolbar items={items} />);
+    const [one, , three] = getButtons(container);
+
+    three.focus();
+    fireEvent.keyDown(three, { code: 'ArrowLeft' });
+
+    expect(getButtons(container)[1]).toHaveFocus();
+    expect(one).not.toHaveFocus();
+  });
+
+  it('leaves the focus alone on any other key', () => {
+    const items: ToolbarItem[] = [
+      { type: 'button', name: 'one', props: { children: 'One' } },
+      { type: 'button', name: 'two', props: { children: 'Two' } },
+    ];
+    const { container } = render(<Toolbar items={items} />);
+    const [one] = getButtons(container);
+
+    one.focus();
+    fireEvent.keyDown(one, { code: 'KeyA' });
+
+    expect(one).toHaveFocus();
+  });
+
+  describe('tooltips', () => {
+    it('accepts a plain string, placed on top', async () => {
+      const items: ToolbarItem[] = [
+        {
+          type: 'icon',
+          name: 'save',
+          tooltip: 'Save the document',
+          props: { 'icon': <span />, 'aria-label': 'save' },
+        },
+      ];
+      const { user } = render(<Toolbar items={items} />);
+
+      await user.hover(screen.getByRole('button', { name: 'save' }));
+
+      expect(await screen.findByText('Save the document')).toBeInTheDocument();
+    });
+
+    it('accepts a message and its position', async () => {
+      const items: ToolbarItem[] = [
+        {
+          type: 'icon',
+          name: 'save',
+          tooltip: { message: 'Save the document', position: 'bottom' },
+          props: { 'icon': <span />, 'aria-label': 'save' },
+        },
+      ];
+      const { user } = render(<Toolbar items={items} />);
+
+      await user.hover(screen.getByRole('button', { name: 'save' }));
+
+      expect(await screen.findByText('Save the document')).toBeInTheDocument();
+    });
+
+    it('renders no tooltip when the item declares none', async () => {
+      const items: ToolbarItem[] = [
+        {
+          type: 'icon',
+          name: 'save',
+          props: { 'icon': <span />, 'aria-label': 'save' },
+        },
+      ];
+      const { user } = render(<Toolbar items={items} />);
+
+      await user.hover(screen.getByRole('button', { name: 'save' }));
+
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('items without a name', () => {
+    it('falls back to the item index as a key for a button', () => {
+      const items = [
+        { type: 'button', props: { children: 'First' } },
+        { type: 'button', props: { children: 'Second' } },
+      ] as unknown as ToolbarItem[];
+      const { container } = render(<Toolbar items={items} />);
+
+      expect(getButtons(container)).toHaveLength(2);
+    });
+
+    it('falls back to the item index as a key for an icon', () => {
+      const items = [
+        { type: 'icon', props: { icon: <span /> } },
+        { type: 'icon', props: { icon: <span /> } },
+      ] as unknown as ToolbarItem[];
+      const { container } = render(<Toolbar items={items} />);
+
+      expect(getButtons(container)).toHaveLength(2);
+    });
+
+    it('falls back to the item index as a key for a dropdown', () => {
+      const items = [
+        {
+          type: 'dropdown',
+          props: {
+            children: (triggerProps: object) => (
+              <>
+                <Dropdown.Trigger label="More" {...triggerProps} />
+                <Dropdown.Menu>
+                  <Dropdown.Item>Action</Dropdown.Item>
+                </Dropdown.Menu>
+              </>
+            ),
+          },
+        },
+      ] as unknown as ToolbarItem[];
+
+      render(<Toolbar items={items} />);
+
+      expect(screen.getByRole('button', { name: 'More' })).toBeInTheDocument();
+    });
+  });
+
+  it('renders nothing for an unknown item type', () => {
+    const items = [
+      { type: 'unknown-type', name: 'ghost', props: {} },
+    ] as unknown as ToolbarItem[];
+
+    render(<Toolbar items={items} />);
+
+    expect(screen.getByRole('toolbar')).toBeEmptyDOMElement();
+  });
 });

--- a/packages/react/src/components/UserRightsList/SaveBookmark.spec.tsx
+++ b/packages/react/src/components/UserRightsList/SaveBookmark.spec.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from '~/setup';
+import { SaveBookmark } from './SaveBookmark';
+
+const input = () => screen.getByTestId('common-save-bookmark-name-input');
+const saveButton = () => screen.getByTestId('common-save-bookmark-save-button');
+
+describe('SaveBookmark', () => {
+  it('cannot be saved while the name is empty', () => {
+    render(<SaveBookmark onSave={vi.fn()} />);
+
+    expect(saveButton()).toBeDisabled();
+  });
+
+  it('enables the save button as soon as a name is typed', async () => {
+    const { user } = render(<SaveBookmark onSave={vi.fn()} />);
+
+    await user.type(input(), 'Ma classe');
+
+    expect(saveButton()).toBeEnabled();
+  });
+
+  it('saves the typed name and clears the field', async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { user } = render(<SaveBookmark onSave={onSave} />);
+
+    await user.type(input(), 'Ma classe');
+    await user.click(saveButton());
+
+    expect(onSave).toHaveBeenCalledWith('Ma classe');
+    await waitFor(() => expect(input()).toHaveValue(''));
+  });
+
+  it('locks the button while the save is in flight', async () => {
+    let resolveSave: () => void = () => {};
+    const onSave = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSave = resolve;
+        }),
+    );
+    const { user } = render(<SaveBookmark onSave={onSave} />);
+
+    await user.type(input(), 'Ma classe');
+    await user.click(saveButton());
+
+    expect(saveButton()).toBeDisabled();
+
+    resolveSave();
+    await waitFor(() => expect(input()).toHaveValue(''));
+  });
+});

--- a/packages/react/src/components/UserRightsList/helpers/rightsHelpers.spec.ts
+++ b/packages/react/src/components/UserRightsList/helpers/rightsHelpers.spec.ts
@@ -1,0 +1,199 @@
+import { IUserInfo } from '@edifice.io/client';
+import { SharingItem } from '../../../types';
+import { ResourceRights } from '../types/types';
+import { createRightsHelpers } from './rightsHelpers';
+
+// Rights of a typical resource: contributing implies reading, and managing
+// implies contributing. A read-only right excludes contributing.
+const resourceRights: ResourceRights = {
+  read: { priority: 0, default: true, requires: [], excludes: [] },
+  comment: { priority: 1, default: false, requires: ['read'], excludes: [] },
+  contrib: { priority: 2, default: false, requires: ['read'], excludes: [] },
+  manager: {
+    priority: 3,
+    default: false,
+    requires: ['read', 'contrib'],
+    excludes: [],
+  },
+};
+
+const helpers = createRightsHelpers(resourceRights);
+
+function item(permission: string[]): SharingItem {
+  return {
+    recipientId: 'user-2',
+    recipientType: 'user',
+    displayName: 'Someone',
+    permission,
+  };
+}
+
+const user = {
+  userId: 'user-1',
+  username: 'Pascal',
+} as unknown as IUserInfo;
+
+describe('createRightsHelpers', () => {
+  describe('applyRight', () => {
+    it('adds a right along with the rights it requires', () => {
+      const result = helpers.applyRight(item(['read']), 'manager', true);
+
+      expect(result.permission).toEqual(
+        expect.arrayContaining(['read', 'contrib', 'manager']),
+      );
+    });
+
+    it('does not duplicate a right already granted', () => {
+      const result = helpers.applyRight(item(['read']), 'read', true);
+
+      expect(result.permission).toEqual(['read']);
+    });
+
+    it('drops the rights excluded by the one being added', () => {
+      const exclusive = createRightsHelpers({
+        read: { priority: 0, default: true, requires: [], excludes: [] },
+        contrib: {
+          priority: 1,
+          default: false,
+          requires: ['read'],
+          excludes: [],
+        },
+        publish: {
+          priority: 2,
+          default: false,
+          requires: ['read'],
+          excludes: ['contrib'],
+        },
+      });
+
+      const result = exclusive.applyRight(
+        item(['read', 'contrib']),
+        'publish',
+        true,
+      );
+
+      expect(result.permission).not.toContain('contrib');
+      expect(result.permission).toEqual(
+        expect.arrayContaining(['read', 'publish']),
+      );
+    });
+
+    it('removes a right and everything depending on it, transitively', () => {
+      const result = helpers.applyRight(
+        item(['read', 'contrib', 'manager', 'comment']),
+        'read',
+        false,
+      );
+
+      expect(result.permission).toEqual([]);
+    });
+
+    it('removes only the dependents of the right being taken away', () => {
+      const result = helpers.applyRight(
+        item(['read', 'contrib', 'manager', 'comment']),
+        'contrib',
+        false,
+      );
+
+      expect(result.permission).toEqual(['read', 'comment']);
+    });
+
+    it('is a no-op when removing a right the item does not hold', () => {
+      const result = helpers.applyRight(item(['read']), 'manager', false);
+
+      expect(result.permission).toEqual(['read']);
+    });
+
+    it('keeps the rest of the item untouched', () => {
+      const result = helpers.applyRight(item(['read']), 'comment', true);
+
+      expect(result).toMatchObject({
+        recipientId: 'user-2',
+        recipientType: 'user',
+        displayName: 'Someone',
+      });
+    });
+  });
+
+  describe('toggleRight', () => {
+    it('grants a right the item does not hold', () => {
+      const result = helpers.toggleRight(item(['read']), 'contrib');
+
+      expect(result.permission).toContain('contrib');
+    });
+
+    it('revokes a right the item already holds', () => {
+      const result = helpers.toggleRight(item(['read', 'contrib']), 'contrib');
+
+      expect(result.permission).not.toContain('contrib');
+    });
+
+    it('revokes the dependents along the way', () => {
+      const result = helpers.toggleRight(
+        item(['read', 'contrib', 'manager']),
+        'contrib',
+      );
+
+      expect(result.permission).toEqual(['read']);
+    });
+  });
+
+  describe('createOwnerItem', () => {
+    it('grants every right of the resource to the owner', () => {
+      const result = helpers.createOwnerItem(user);
+
+      expect(result).toEqual({
+        recipientId: 'user-1',
+        recipientType: 'user',
+        displayName: 'Pascal',
+        permission: ['read', 'comment', 'contrib', 'manager'],
+      });
+    });
+
+    it('tolerates a user without an id', () => {
+      const result = helpers.createOwnerItem({
+        username: 'Anonyme',
+      } as unknown as IUserInfo);
+
+      expect(result.recipientId).toBe('');
+    });
+  });
+
+  describe('getOwnerItem', () => {
+    it('names the session user as owner while creating a resource', () => {
+      const result = helpers.getOwnerItem('', user, true);
+
+      expect(result.displayName).toBe('Pascal');
+      expect(result.recipientId).toBe('user-1');
+    });
+
+    it('names the session user as owner of their own resource', () => {
+      const result = helpers.getOwnerItem('user-1', user, false);
+
+      expect(result.displayName).toBe('Pascal');
+    });
+
+    it('falls back to a generic owner for someone else resource', () => {
+      const result = helpers.getOwnerItem('user-9', user, false);
+
+      expect(result).toEqual({
+        recipientId: 'user-9',
+        recipientType: 'user',
+        displayName: 'owner',
+        permission: ['read', 'comment', 'contrib', 'manager'],
+      });
+    });
+
+    it('throws when neither an owner nor a creating user is known', () => {
+      expect(() => helpers.getOwnerItem('', undefined, true)).toThrow(
+        'Owner ID or user is required',
+      );
+    });
+
+    it('throws when the resource has no owner and is not being created', () => {
+      expect(() => helpers.getOwnerItem('', user, false)).toThrow(
+        'Owner ID or user is required',
+      );
+    });
+  });
+});

--- a/packages/react/src/components/UserRightsList/hooks/useBookmarkEntries.spec.tsx
+++ b/packages/react/src/components/UserRightsList/hooks/useBookmarkEntries.spec.tsx
@@ -1,0 +1,217 @@
+import { act, renderHook } from '~/setup';
+import { SharingItem } from '../../../types';
+import {
+  BookmarkInput,
+  ResourceRightName,
+  ResourceRights,
+} from '../types/types';
+import { useBookmarkEntries } from './useBookmarkEntries';
+
+const resourceRights: ResourceRights = {
+  read: { priority: 0, default: true, requires: [], excludes: [] },
+  contrib: { priority: 1, default: false, requires: ['read'], excludes: [] },
+};
+
+function bookmark(
+  id: string,
+  users: { id: string; displayName: string }[] = [
+    { id: `${id}-user-1`, displayName: 'User 1' },
+  ],
+): BookmarkInput {
+  return { id, name: `Bookmark ${id}`, users };
+}
+
+function setup({
+  existingRecipientIds = new Set<string>(),
+}: { existingRecipientIds?: Set<string> } = {}) {
+  const addItems = vi.fn();
+  const deleteItemsByIds = vi.fn();
+  const applyRightToIds = vi.fn();
+  const toggleRight = (item: SharingItem, rightName: ResourceRightName) => ({
+    ...item,
+    permission: item.permission.includes(rightName)
+      ? item.permission.filter((right) => right !== rightName)
+      : [...item.permission, rightName],
+  });
+
+  return {
+    ...renderHook(() =>
+      useBookmarkEntries({
+        resourceRights,
+        existingRecipientIds,
+        toggleRight,
+        addItems,
+        deleteItemsByIds,
+        applyRightToIds,
+      }),
+    ),
+    addItems,
+    deleteItemsByIds,
+    applyRightToIds,
+  };
+}
+
+const entryIds = (entries: { id: string }[]) => entries.map(({ id }) => id);
+
+describe('useBookmarkEntries', () => {
+  it('starts without any bookmark', () => {
+    const { result } = setup();
+
+    expect(result.current.bookmarkEntries).toEqual([]);
+    expect(result.current.bookmarkUserIds.size).toBe(0);
+  });
+
+  describe('addBookmark', () => {
+    it('registers the bookmark with the default rights and shares its users', async () => {
+      const { result, addItems } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+
+      expect(result.current.bookmarkEntries[0]).toMatchObject({
+        id: 'b1',
+        name: 'Bookmark b1',
+        permission: ['read'],
+        isExpanded: false,
+      });
+      expect(addItems).toHaveBeenCalledWith([
+        expect.objectContaining({
+          recipientId: 'b1-user-1',
+          permission: ['read'],
+        }),
+      ]);
+      expect(Array.from(result.current.bookmarkUserIds)).toEqual(['b1-user-1']);
+    });
+
+    it('ignores a bookmark already registered', async () => {
+      const { result, addItems } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+      addItems.mockClear();
+      await act(() => result.current.addBookmark(bookmark('b1')));
+
+      expect(result.current.bookmarkEntries).toHaveLength(1);
+      expect(addItems).not.toHaveBeenCalled();
+    });
+
+    it('skips the users already shared with', async () => {
+      const { result, addItems } = setup({
+        existingRecipientIds: new Set(['known-user']),
+      });
+
+      await act(() =>
+        result.current.addBookmark(
+          bookmark('b1', [
+            { id: 'known-user', displayName: 'Known' },
+            { id: 'new-user', displayName: 'New' },
+          ]),
+        ),
+      );
+
+      expect(addItems).toHaveBeenCalledWith([
+        expect.objectContaining({ recipientId: 'new-user' }),
+      ]);
+      expect(result.current.bookmarkEntries[0].userIds).toEqual(['new-user']);
+    });
+  });
+
+  describe('deleteBookmark', () => {
+    it('removes the bookmark and unshares its users', async () => {
+      const { result, deleteItemsByIds } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+      await act(() => result.current.deleteBookmark('b1'));
+
+      expect(result.current.bookmarkEntries).toEqual([]);
+      expect(deleteItemsByIds).toHaveBeenCalledWith(new Set(['b1-user-1']));
+    });
+
+    it('ignores an unknown bookmark', async () => {
+      const { result, deleteItemsByIds } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+      await act(() => result.current.deleteBookmark('ghost'));
+
+      expect(entryIds(result.current.bookmarkEntries)).toEqual(['b1']);
+      expect(deleteItemsByIds).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggleBookmarkRight', () => {
+    it('grants the right on the row and on every user of the bookmark', async () => {
+      const { result, applyRightToIds } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+      await act(() => result.current.toggleBookmarkRight('b1', 'contrib'));
+
+      expect(result.current.bookmarkEntries[0].permission).toContain('contrib');
+      expect(applyRightToIds).toHaveBeenCalledWith(
+        new Set(['b1-user-1']),
+        'contrib',
+        true,
+      );
+    });
+
+    it('revokes a right already granted', async () => {
+      const { result, applyRightToIds } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+      await act(() => result.current.toggleBookmarkRight('b1', 'read'));
+
+      expect(result.current.bookmarkEntries[0].permission).not.toContain(
+        'read',
+      );
+      expect(applyRightToIds).toHaveBeenCalledWith(
+        new Set(['b1-user-1']),
+        'read',
+        false,
+      );
+    });
+
+    it('leaves the other bookmarks alone', async () => {
+      const { result } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+      await act(() => result.current.addBookmark(bookmark('b2')));
+      await act(() => result.current.toggleBookmarkRight('b2', 'contrib'));
+
+      expect(result.current.bookmarkEntries[0].permission).not.toContain(
+        'contrib',
+      );
+      expect(result.current.bookmarkEntries[1].permission).toContain('contrib');
+    });
+
+    it('ignores an unknown bookmark', async () => {
+      const { result, applyRightToIds } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+      await act(() => result.current.toggleBookmarkRight('ghost', 'contrib'));
+
+      expect(result.current.bookmarkEntries[0].permission).toEqual(['read']);
+      expect(applyRightToIds).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toggleExpand', () => {
+    it('opens and closes a bookmark row', async () => {
+      const { result } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+      await act(() => result.current.toggleExpand('b1'));
+      expect(result.current.bookmarkEntries[0].isExpanded).toBe(true);
+
+      await act(() => result.current.toggleExpand('b1'));
+      expect(result.current.bookmarkEntries[0].isExpanded).toBe(false);
+    });
+
+    it('leaves the other bookmarks collapsed', async () => {
+      const { result } = setup();
+
+      await act(() => result.current.addBookmark(bookmark('b1')));
+      await act(() => result.current.addBookmark(bookmark('b2')));
+      await act(() => result.current.toggleExpand('b2'));
+
+      expect(result.current.bookmarkEntries[0].isExpanded).toBe(false);
+      expect(result.current.bookmarkEntries[1].isExpanded).toBe(true);
+    });
+  });
+});

--- a/packages/react/src/components/UserRightsList/hooks/useSharingItems.spec.tsx
+++ b/packages/react/src/components/UserRightsList/hooks/useSharingItems.spec.tsx
@@ -1,0 +1,209 @@
+import { act, renderHook } from '~/setup';
+import { SharingItem } from '../../../types';
+import { ResourceRightName } from '../types/types';
+import { useSharingItems } from './useSharingItems';
+
+function sharing(recipientId: string, permission = ['read']): SharingItem {
+  return {
+    recipientId,
+    recipientType: 'user',
+    displayName: `User ${recipientId}`,
+    permission,
+  };
+}
+
+function setup({ initialSharings }: { initialSharings?: SharingItem[] } = {}) {
+  const onChange = vi.fn();
+  const onAddItems = vi.fn();
+  const onDeleteItems = vi.fn();
+
+  // Minimal right algebra: toggling flips the right, applying sets it.
+  const toggleRight = (item: SharingItem, rightName: ResourceRightName) => ({
+    ...item,
+    permission: item.permission.includes(rightName)
+      ? item.permission.filter((right) => right !== rightName)
+      : [...item.permission, rightName],
+  });
+  const applyRight = (
+    item: SharingItem,
+    rightName: ResourceRightName,
+    add: boolean,
+  ) => ({
+    ...item,
+    permission: add
+      ? [...new Set([...item.permission, rightName])]
+      : item.permission.filter((right) => right !== rightName),
+  });
+
+  return {
+    ...renderHook(() =>
+      useSharingItems({
+        initialSharings: initialSharings as SharingItem[],
+        toggleRight,
+        applyRight,
+        onChange,
+        onAddItems,
+        onDeleteItems,
+      }),
+    ),
+    onChange,
+    onAddItems,
+    onDeleteItems,
+  };
+}
+
+const ids = (items: SharingItem[]) =>
+  items.map(({ recipientId }) => recipientId);
+
+describe('useSharingItems', () => {
+  it('starts from the sharings it is given', () => {
+    const { result } = setup({ initialSharings: [sharing('a')] });
+
+    expect(ids(result.current.items)).toEqual(['a']);
+  });
+
+  it('starts empty when no sharing is given', () => {
+    const { result } = setup();
+
+    expect(result.current.items).toEqual([]);
+  });
+
+  describe('addItem', () => {
+    it('appends an item and reports it', async () => {
+      const { result, onChange, onAddItems } = setup({ initialSharings: [] });
+
+      await act(() => result.current.addItem(sharing('a')));
+
+      expect(ids(result.current.items)).toEqual(['a']);
+      expect(onAddItems).toHaveBeenCalledWith([
+        expect.objectContaining({ recipientId: 'a' }),
+      ]);
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('ignores a recipient already in the list', async () => {
+      const { result, onAddItems } = setup({ initialSharings: [sharing('a')] });
+
+      await act(() => result.current.addItem(sharing('a')));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(onAddItems).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('addItems', () => {
+    it('appends the recipients not already listed', async () => {
+      const { result, onAddItems } = setup({ initialSharings: [sharing('a')] });
+
+      await act(() =>
+        result.current.addItems([sharing('a'), sharing('b'), sharing('c')]),
+      );
+
+      expect(ids(result.current.items)).toEqual(['a', 'b', 'c']);
+      expect(onAddItems).toHaveBeenCalledWith([
+        expect.objectContaining({ recipientId: 'b' }),
+        expect.objectContaining({ recipientId: 'c' }),
+      ]);
+    });
+
+    it('does nothing when every recipient is already listed', async () => {
+      const { result, onChange, onAddItems } = setup({
+        initialSharings: [sharing('a')],
+      });
+
+      await act(() => result.current.addItems([sharing('a')]));
+
+      expect(result.current.items).toHaveLength(1);
+      expect(onAddItems).not.toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does nothing for an empty batch', async () => {
+      const { result, onAddItems } = setup({ initialSharings: [sharing('a')] });
+
+      await act(() => result.current.addItems([]));
+
+      expect(onAddItems).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteItem', () => {
+    it('removes the recipient and reports it', async () => {
+      const { result, onDeleteItems } = setup({
+        initialSharings: [sharing('a'), sharing('b')],
+      });
+
+      await act(() => result.current.deleteItem(sharing('a')));
+
+      expect(ids(result.current.items)).toEqual(['b']);
+      expect(onDeleteItems).toHaveBeenCalledWith([
+        expect.objectContaining({ recipientId: 'a' }),
+      ]);
+    });
+
+    it('does nothing for a recipient absent from the list', async () => {
+      const { result, onChange, onDeleteItems } = setup({
+        initialSharings: [sharing('a')],
+      });
+
+      await act(() => result.current.deleteItem(sharing('ghost')));
+
+      expect(ids(result.current.items)).toEqual(['a']);
+      expect(onDeleteItems).not.toHaveBeenCalled();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('deleteItemsByIds', () => {
+    it('removes every listed recipient at once', async () => {
+      const { result, onDeleteItems } = setup({
+        initialSharings: [sharing('a'), sharing('b'), sharing('c')],
+      });
+
+      await act(() => result.current.deleteItemsByIds(new Set(['a', 'c'])));
+
+      expect(ids(result.current.items)).toEqual(['b']);
+      expect(onDeleteItems).toHaveBeenCalled();
+    });
+  });
+
+  describe('rights', () => {
+    it('toggles a right on a single recipient', async () => {
+      const { result, onChange } = setup({
+        initialSharings: [sharing('a'), sharing('b')],
+      });
+
+      await act(() => result.current.changeRight(sharing('a'), 'contrib'));
+
+      expect(result.current.items[0].permission).toContain('contrib');
+      expect(result.current.items[1].permission).not.toContain('contrib');
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('applies a right to a set of recipients', async () => {
+      const { result } = setup({
+        initialSharings: [sharing('a'), sharing('b'), sharing('c')],
+      });
+
+      await act(() =>
+        result.current.applyRightToIds(new Set(['a', 'c']), 'contrib', true),
+      );
+
+      expect(result.current.items[0].permission).toContain('contrib');
+      expect(result.current.items[1].permission).not.toContain('contrib');
+      expect(result.current.items[2].permission).toContain('contrib');
+    });
+
+    it('removes a right from a set of recipients', async () => {
+      const { result } = setup({
+        initialSharings: [sharing('a', ['read', 'contrib'])],
+      });
+
+      await act(() =>
+        result.current.applyRightToIds(new Set(['a']), 'contrib', false),
+      );
+
+      expect(result.current.items[0].permission).not.toContain('contrib');
+    });
+  });
+});

--- a/packages/react/src/hooks/useDropzone/useDropzone.spec.tsx
+++ b/packages/react/src/hooks/useDropzone/useDropzone.spec.tsx
@@ -1,6 +1,15 @@
 import { act, renderHook } from '~/setup';
 import useDropzone from './useDropzone';
 
+// The HEIC converter is imported dynamically and relies on canvas/Worker, both
+// absent from jsdom.
+const { isHeic, heicTo } = vi.hoisted(() => ({
+  isHeic: vi.fn(),
+  heicTo: vi.fn(),
+}));
+
+vi.mock('heic-to', () => ({ isHeic, heicTo }));
+
 function createFile(name: string, type = 'image/png') {
   return new File(['content'], name, { type });
 }
@@ -126,5 +135,124 @@ describe('useDropzone', () => {
     });
 
     expect(result.current.files.map((f) => f.name)).toEqual(['keep.png']);
+  });
+
+  it('replaces the last file of the list', async () => {
+    const { result } = renderHook(() => useDropzone());
+
+    await act(async () => {
+      await result.current.addFile(createFile('a.png'));
+    });
+    await act(async () => {
+      await result.current.addFile(createFile('b.png'));
+    });
+    await act(() => result.current.replaceFileAt(1, createFile('c.png')));
+
+    expect(result.current.files.map(({ name }) => name)).toEqual([
+      'a.png',
+      'c.png',
+    ]);
+  });
+
+  it('leaves the list untouched for an out-of-range index', async () => {
+    const { result } = renderHook(() => useDropzone());
+
+    await act(async () => {
+      await result.current.addFile(createFile('a.png'));
+    });
+    await act(() => result.current.replaceFileAt(9, createFile('c.png')));
+
+    expect(result.current.files.map(({ name }) => name)).toEqual(['a.png']);
+  });
+
+  it('adds nothing when given an empty selection', async () => {
+    const { result } = renderHook(() => useDropzone());
+
+    await act(async () => {
+      await result.current.addFiles([]);
+    });
+
+    expect(result.current.files).toEqual([]);
+  });
+
+  // `addFiles` sanitises the names and converts HEIC images into `filesToAdd`,
+  // but the default branch stores the untouched `files` argument instead — so
+  // both only reach the list when `forceFilters` is on.
+  it('strips the characters vertx chokes on when filters are forced', async () => {
+    const { result } = renderHook(() => useDropzone({ forceFilters: true }));
+
+    await act(async () => {
+      await result.current.addFile(createFile('photo!:,;="\'.png'));
+    });
+
+    expect(result.current.files[0].name).toBe('photo.png');
+  });
+
+  it('keeps the raw file name without forced filters', async () => {
+    const { result } = renderHook(() => useDropzone());
+
+    await act(async () => {
+      await result.current.addFile(createFile('photo!:,;="\'.png'));
+    });
+
+    expect(result.current.files[0].name).toBe('photo!:,;="\'.png');
+  });
+
+  describe('HEIC images', () => {
+    it('converts a HEIC image to JPEG when filters are forced', async () => {
+      isHeic.mockReturnValue(true);
+      heicTo.mockResolvedValue(new Blob(['jpeg'], { type: 'image/jpeg' }));
+      const { result } = renderHook(() => useDropzone({ forceFilters: true }));
+
+      await act(async () => {
+        await result.current.addFile(createFile('photo.heic', 'image/heic'));
+      });
+
+      expect(heicTo).toHaveBeenCalled();
+      expect(result.current.files[0].name).toBe('photo.jpeg');
+      expect(result.current.files[0].type).toBe('image/jpeg');
+    });
+
+    // Same quirk as the name sanitising: the converted file never reaches the
+    // list unless the filters are forced.
+    it('stores the untouched HEIC file without forced filters', async () => {
+      isHeic.mockReturnValue(true);
+      heicTo.mockResolvedValue(new Blob(['jpeg'], { type: 'image/jpeg' }));
+      const { result } = renderHook(() => useDropzone());
+
+      await act(async () => {
+        await result.current.addFile(createFile('photo.heic', 'image/heic'));
+      });
+
+      expect(heicTo).toHaveBeenCalled();
+      expect(result.current.files[0].type).toBe('image/heic');
+    });
+
+    it('keeps the original file when the conversion fails', async () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      isHeic.mockReturnValue(true);
+      heicTo.mockRejectedValue(new Error('conversion failed'));
+      const { result } = renderHook(() => useDropzone({ forceFilters: true }));
+
+      await act(async () => {
+        await result.current.addFile(createFile('photo.heic', 'image/heic'));
+      });
+
+      expect(result.current.files[0].name).toBe('photo.heic');
+      consoleError.mockRestore();
+    });
+
+    it('never loads the converter for a plain image', async () => {
+      const { result } = renderHook(() => useDropzone({ forceFilters: true }));
+
+      await act(async () => {
+        await result.current.addFile(createFile('photo.png'));
+      });
+
+      expect(heicTo).not.toHaveBeenCalled();
+      expect(result.current.files[0].name).toBe('photo.png');
+    });
   });
 });

--- a/packages/react/src/modules/audience/ReactionSummary.spec.tsx
+++ b/packages/react/src/modules/audience/ReactionSummary.spec.tsx
@@ -1,0 +1,85 @@
+import { ReactionSummaryData } from '@edifice.io/client';
+import { render, screen } from '~/setup';
+import ReactionSummary from './ReactionSummary';
+
+function summary(
+  partial: Partial<ReactionSummaryData> = {},
+): ReactionSummaryData {
+  return {
+    userReaction: null,
+    totalReactionsCounter: 0,
+    ...partial,
+  } as ReactionSummaryData;
+}
+
+const icons = () => document.querySelectorAll('.reaction-overlap');
+
+describe('ReactionSummary', () => {
+  it('displays the total number of reactions', () => {
+    render(<ReactionSummary summary={summary({ totalReactionsCounter: 7 })} />);
+
+    expect(screen.getByRole('button')).toHaveTextContent('7');
+  });
+
+  it('is disabled and shows a single placeholder icon without any reaction', () => {
+    render(<ReactionSummary />);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+    expect(icons()).toHaveLength(1);
+  });
+
+  it('shows one icon per reaction type once there are reactions', () => {
+    render(
+      <ReactionSummary
+        summary={summary({
+          totalReactionsCounter: 5,
+          reactionTypes: ['REACTION_1', 'REACTION_3'],
+        })}
+      />,
+    );
+
+    expect(icons()).toHaveLength(2);
+    expect(screen.getByRole('button')).toBeEnabled();
+  });
+
+  it('shows no icon when the reaction types are missing', () => {
+    render(<ReactionSummary summary={summary({ totalReactionsCounter: 5 })} />);
+
+    expect(icons()).toHaveLength(0);
+  });
+
+  it('calls back on click', async () => {
+    const onClick = vi.fn();
+    const { user } = render(
+      <ReactionSummary
+        summary={summary({
+          totalReactionsCounter: 2,
+          reactionTypes: ['REACTION_1'],
+        })}
+        onClick={onClick}
+      />,
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not bubble the click up to a clickable parent', async () => {
+    const onParentClick = vi.fn();
+    const { user } = render(
+      <div onClick={onParentClick}>
+        <ReactionSummary
+          summary={summary({
+            totalReactionsCounter: 2,
+            reactionTypes: ['REACTION_1'],
+          })}
+        />
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+});

--- a/packages/react/src/modules/audience/ViewsByProfileCard.spec.tsx
+++ b/packages/react/src/modules/audience/ViewsByProfileCard.spec.tsx
@@ -1,0 +1,67 @@
+import { ViewsDetailsProfile } from '@edifice.io/client';
+import { render, screen } from '~/setup';
+import ViewsByProfileCard from './ViewsByProfileCard';
+
+const viewsByProfile = (profile: string, counter = 3): ViewsDetailsProfile =>
+  ({ profile, counter }) as unknown as ViewsDetailsProfile;
+
+describe('ViewsByProfileCard', () => {
+  it('displays the counter of the profile', () => {
+    render(
+      <ViewsByProfileCard viewsByProfile={viewsByProfile('Student', 8)} />,
+    );
+
+    expect(screen.getByText('8')).toBeInTheDocument();
+  });
+
+  it('labels the line with the translated profile', () => {
+    render(<ViewsByProfileCard viewsByProfile={viewsByProfile('Student')} />);
+
+    expect(screen.getByText('Student')).toBeInTheDocument();
+  });
+
+  it('falls back to the raw key for a profile with no translation', () => {
+    render(<ViewsByProfileCard viewsByProfile={viewsByProfile('Alien')} />);
+
+    expect(
+      screen.getByText('audience.views.uniqueViewsPerProfile.alien'),
+    ).toBeInTheDocument();
+  });
+
+  it.each(['Student', 'Relative', 'Teacher', 'Personnel', 'Guest'])(
+    'renders the dedicated icon and modifier class for %s',
+    (profile) => {
+      render(<ViewsByProfileCard viewsByProfile={viewsByProfile(profile)} />);
+
+      expect(
+        document.querySelector(
+          `.views-detail-icon-${profile.toLowerCase()} svg`,
+        ),
+      ).not.toBeNull();
+    },
+  );
+
+  it('falls back to the generic users icon for an unknown profile', () => {
+    render(<ViewsByProfileCard viewsByProfile={viewsByProfile('Alien')} />);
+
+    expect(
+      document.querySelector('.views-detail-icon-alien svg'),
+    ).not.toBeNull();
+  });
+
+  it('renders a different icon for a known profile and for the fallback', () => {
+    const { container: known, unmount } = render(
+      <ViewsByProfileCard viewsByProfile={viewsByProfile('Student')} />,
+    );
+    const knownMarkup = known.querySelector('.views-detail-icon')?.innerHTML;
+    unmount();
+
+    const { container: unknown } = render(
+      <ViewsByProfileCard viewsByProfile={viewsByProfile('Alien')} />,
+    );
+
+    expect(unknown.querySelector('.views-detail-icon')?.innerHTML).not.toBe(
+      knownMarkup,
+    );
+  });
+});

--- a/packages/react/src/modules/audience/ViewsCounter.spec.tsx
+++ b/packages/react/src/modules/audience/ViewsCounter.spec.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '~/setup';
+import ViewsCounter from './ViewsCounter';
+
+describe('ViewsCounter', () => {
+  it('displays the number of views', () => {
+    render(<ViewsCounter viewsCounter={12} />);
+
+    expect(screen.getByRole('button')).toHaveTextContent('12');
+  });
+
+  it('abbreviates a large counter', () => {
+    render(<ViewsCounter viewsCounter={12000} />);
+
+    expect(screen.getByRole('button').textContent).not.toBe('12000');
+  });
+
+  it('is disabled while nobody has viewed the resource', () => {
+    render(<ViewsCounter viewsCounter={0} />);
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('is enabled as soon as there is one view', () => {
+    render(<ViewsCounter viewsCounter={1} />);
+
+    expect(screen.getByRole('button')).toBeEnabled();
+  });
+
+  it('calls back on click', async () => {
+    const onClick = vi.fn();
+    const { user } = render(
+      <ViewsCounter viewsCounter={3} onClick={onClick} />,
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not bubble the click up to a clickable parent', async () => {
+    const onParentClick = vi.fn();
+    const { user } = render(
+      <div onClick={onParentClick}>
+        <ViewsCounter viewsCounter={3} />
+      </div>,
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+
+  it('appends the custom classes to its own', () => {
+    render(<ViewsCounter viewsCounter={3} className="my-class" />);
+
+    expect(screen.getByRole('button')).toHaveClass('btn-icon', 'my-class');
+  });
+
+  it('forwards the remaining props to the button', () => {
+    render(<ViewsCounter viewsCounter={3} aria-label="views" />);
+
+    expect(screen.getByRole('button', { name: 'views' })).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/modules/audience/hooks/useReactionIcons.spec.tsx
+++ b/packages/react/src/modules/audience/hooks/useReactionIcons.spec.tsx
@@ -1,0 +1,85 @@
+import { ReactionType } from '@edifice.io/client';
+import { render, renderHook } from '~/setup';
+import useReactionIcons from './useReactionIcons';
+
+const setup = () => renderHook(() => useReactionIcons()).result;
+
+/** Every reaction icon is an SVG, told apart by its rendered markup. */
+const markupOf = (icon: React.ReactNode) => {
+  const { container, unmount } = render(<>{icon}</>);
+  const html = container.innerHTML;
+  unmount();
+  return html;
+};
+
+describe('useReactionIcons', () => {
+  describe('getReactionIcon', () => {
+    it.each<ReactionType>([
+      'REACTION_1',
+      'REACTION_2',
+      'REACTION_3',
+      'REACTION_4',
+    ])('renders a distinct icon for %s', (reactionType) => {
+      const { current } = setup();
+
+      expect(markupOf(current.getReactionIcon(reactionType))).toContain('svg');
+    });
+
+    it('renders a different icon for each reaction type', () => {
+      const { current } = setup();
+
+      const markups = (
+        ['REACTION_1', 'REACTION_2', 'REACTION_3', 'REACTION_4'] as const
+      ).map((type) => markupOf(current.getReactionIcon(type)));
+
+      expect(new Set(markups).size).toBe(4);
+    });
+
+    it('renders the counter variant when asked for it', () => {
+      const { current } = setup();
+
+      expect(markupOf(current.getReactionIcon('REACTION_1', true))).not.toBe(
+        markupOf(current.getReactionIcon('REACTION_1', false)),
+      );
+    });
+
+    it('falls back to the generic reaction icon for an unknown type', () => {
+      const { current } = setup();
+
+      const fallback = markupOf(current.getReactionIcon());
+      expect(fallback).toContain('svg');
+      expect(markupOf(current.getReactionIcon(null))).toBe(fallback);
+      expect(
+        markupOf(current.getReactionIcon('REACTION_9' as ReactionType)),
+      ).toBe(fallback);
+    });
+
+    it('ignores the counter flag on the fallback icon', () => {
+      const { current } = setup();
+
+      expect(markupOf(current.getReactionIcon(null, true))).toBe(
+        markupOf(current.getReactionIcon(null, false)),
+      );
+    });
+  });
+
+  describe('getReactionLabel', () => {
+    it.each([
+      ['REACTION_1', 'audience.reaction.thanks'],
+      ['REACTION_2', 'audience.reaction.great'],
+      ['REACTION_3', 'audience.reaction.congrats'],
+      ['REACTION_4', 'audience.reaction.interesting'],
+    ] as const)('maps %s to %s', (reactionType, key) => {
+      const { current } = setup();
+
+      expect(current.getReactionLabel(reactionType)).toBe(key);
+    });
+
+    it('falls back to the default label', () => {
+      const { current } = setup();
+
+      expect(current.getReactionLabel()).toBe('audience.reaction.default');
+      expect(current.getReactionLabel(null)).toBe('audience.reaction.default');
+    });
+  });
+});

--- a/packages/react/src/modules/comments/components/Comment.spec.tsx
+++ b/packages/react/src/modules/comments/components/Comment.spec.tsx
@@ -1,0 +1,256 @@
+import { UserProfile } from '@edifice.io/client';
+import { render, screen } from '~/setup';
+import { CommentProps } from '../types';
+import { Comment } from './Comment';
+
+const { useCommentsContext } = vi.hoisted(() => ({
+  useCommentsContext: vi.fn(),
+}));
+
+vi.mock('../hooks/useCommentsContext', () => ({ useCommentsContext }));
+
+// The replies block has its own spec; here it only needs to be identifiable.
+vi.mock('./CommentReplies', () => ({
+  CommentReplies: () => <div data-testid="comment-replies" />,
+}));
+
+vi.mock('./CommentAvatar', () => ({
+  CommentAvatar: ({ id }: { id: string }) => (
+    <div data-testid={`avatar-${id}`} />
+  ),
+}));
+
+function comment(
+  partial: Partial<CommentProps> & { id: string },
+): CommentProps {
+  return {
+    comment: `content ${partial.id}`,
+    authorId: 'author-1',
+    authorName: 'Author One',
+    createdAt: Date.now() - 60_000,
+    ...partial,
+  };
+}
+
+type ContextOverrides = {
+  defaultComments?: CommentProps[];
+  editCommentId?: string | null;
+  type?: 'edit' | 'read';
+  userRights?: { manager?: boolean };
+  allowReplies?: boolean;
+};
+
+function setup({
+  target = comment({ id: 'c1' }),
+  userId = 'author-1',
+  ...overrides
+}: ContextOverrides & { target?: CommentProps; userId?: string } = {}) {
+  const handlers = {
+    handleDeleteComment: vi.fn(),
+    handleModifyComment: vi.fn(),
+    handleReset: vi.fn(),
+    handleUpdateComment: vi.fn(),
+    handleReplyToComment: vi.fn(),
+  };
+
+  useCommentsContext.mockReturnValue({
+    defaultComments: overrides.defaultComments ?? [target],
+    editCommentId: overrides.editCommentId ?? null,
+    options: {
+      maxCommentLength: 200,
+      allowReplies: overrides.allowReplies ?? true,
+    },
+    type: overrides.type ?? 'edit',
+    userRights: overrides.userRights ?? {},
+    ...handlers,
+  });
+
+  return {
+    ...render(
+      <Comment
+        comment={target}
+        userId={userId}
+        profile={'Teacher' as UserProfile[number]}
+      />,
+    ),
+    handlers,
+  };
+}
+
+describe('Comment', () => {
+  describe('reading a comment', () => {
+    it('shows the author, the content and the replies block', () => {
+      setup();
+
+      expect(screen.getByText('Author One')).toBeInTheDocument();
+      expect(screen.getByText('content c1')).toBeInTheDocument();
+      expect(screen.getByTestId('comment-replies')).toBeInTheDocument();
+      expect(screen.getByTestId('avatar-author-1')).toBeInTheDocument();
+    });
+
+    it('offers reply, edit and remove to the author in edit mode', () => {
+      setup();
+
+      expect(screen.getByText('Reply')).toBeInTheDocument();
+      expect(screen.getByTestId('comment-edit')).toBeInTheDocument();
+      expect(screen.getByTestId('comment-delete')).toBeInTheDocument();
+    });
+
+    it('offers no action at all in read mode', () => {
+      setup({ type: 'read' });
+
+      expect(screen.queryByText('Reply')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('comment-edit')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('comment-delete')).not.toBeInTheDocument();
+    });
+
+    it('hides edit and remove from another user', () => {
+      setup({ userId: 'someone-else' });
+
+      expect(screen.queryByTestId('comment-edit')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('comment-delete')).not.toBeInTheDocument();
+    });
+
+    it('still allows a manager to remove someone else comment', () => {
+      setup({ userId: 'someone-else', userRights: { manager: true } });
+
+      expect(screen.queryByTestId('comment-edit')).not.toBeInTheDocument();
+      expect(screen.getByTestId('comment-delete')).toBeInTheDocument();
+    });
+
+    it('hides the reply button on a reply', () => {
+      setup({ target: comment({ id: 'c1', replyTo: 'parent' }) });
+
+      expect(screen.queryByText('Reply')).not.toBeInTheDocument();
+    });
+
+    it('hides the reply button when replies are disabled', () => {
+      setup({ allowReplies: false });
+
+      expect(screen.queryByText('Reply')).not.toBeInTheDocument();
+    });
+
+    it('asks to reply to this comment', async () => {
+      const { user, handlers } = setup();
+
+      await user.click(screen.getByText('Reply'));
+
+      expect(handlers.handleReplyToComment).toHaveBeenCalledWith('c1');
+    });
+  });
+
+  describe('deleted comment', () => {
+    it('shows the deleted placeholder and the replies when a reply survives', () => {
+      const target = comment({ id: 'c1', deleted: true });
+
+      setup({
+        target,
+        defaultComments: [target, comment({ id: 'r1', replyTo: 'c1' })],
+      });
+
+      expect(screen.getByTestId('comment-replies')).toBeInTheDocument();
+      expect(screen.queryByTestId('div-comment-read')).not.toBeInTheDocument();
+    });
+
+    it('shows nothing when every reply is deleted too', () => {
+      const target = comment({ id: 'c1', deleted: true });
+
+      setup({
+        target,
+        defaultComments: [
+          target,
+          comment({ id: 'r1', replyTo: 'c1', deleted: true }),
+        ],
+      });
+
+      expect(screen.queryByTestId('comment-replies')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('div-comment-read')).not.toBeInTheDocument();
+    });
+
+    it('shows nothing when the deleted comment has no reply', () => {
+      const target = comment({ id: 'c1', deleted: true });
+
+      setup({ target, defaultComments: [target] });
+
+      expect(screen.queryByTestId('comment-replies')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('editing a comment', () => {
+    it('switches to a textarea prefilled by the edit action', async () => {
+      const target = comment({ id: 'c1' });
+      const { user, handlers } = setup({ target });
+
+      await user.click(screen.getByTestId('comment-edit'));
+
+      expect(handlers.handleModifyComment).toHaveBeenCalledWith('c1');
+    });
+
+    it('renders the edition form for the comment being edited', () => {
+      setup({ editCommentId: 'c1' });
+
+      const textarea = screen.getByPlaceholderText('Your comment');
+      expect(textarea).toBeInTheDocument();
+      expect(textarea).toHaveAttribute('maxlength', '200');
+      expect(screen.getByTestId('comment-save')).toBeInTheDocument();
+    });
+
+    it('highlights the comment being edited', () => {
+      setup({ editCommentId: 'c1' });
+
+      expect(screen.getByTestId('div-comment-read')).toHaveClass('bg-gray-200');
+    });
+
+    it('saves the edited content', async () => {
+      const { user, handlers } = setup({ editCommentId: 'c1' });
+
+      await user.type(
+        screen.getByPlaceholderText('Your comment'),
+        'nouveau contenu',
+      );
+      await user.click(screen.getByTestId('comment-save'));
+
+      expect(handlers.handleUpdateComment).toHaveBeenCalledWith(
+        'nouveau contenu',
+      );
+    });
+
+    it('cancels the edition', async () => {
+      const { user, handlers } = setup({ editCommentId: 'c1' });
+
+      await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+      expect(handlers.handleReset).toHaveBeenCalledTimes(1);
+    });
+
+    it('counts the typed characters against the maximum', async () => {
+      const { user } = setup({ editCommentId: 'c1' });
+
+      await user.type(screen.getByPlaceholderText('Your comment'), 'abc');
+
+      expect(screen.getByText('3 / 200')).toBeInTheDocument();
+    });
+  });
+
+  describe('deletion modal', () => {
+    it('opens on the remove button and deletes on confirmation', async () => {
+      const { user, handlers } = setup();
+
+      await user.click(screen.getByTestId('comment-delete'));
+
+      const confirm = await screen.findByText('comment.delete.modal.delete');
+      await user.click(confirm);
+
+      expect(handlers.handleDeleteComment).toHaveBeenCalledWith('c1');
+    });
+
+    it('closes without deleting on cancellation', async () => {
+      const { user, handlers } = setup();
+
+      await user.click(screen.getByTestId('comment-delete'));
+      await user.click(await screen.findByRole('button', { name: 'Cancel' }));
+
+      expect(handlers.handleDeleteComment).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/modules/comments/components/CommentDate.spec.tsx
+++ b/packages/react/src/modules/comments/components/CommentDate.spec.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '~/setup';
+import { CommentDate } from './CommentDate';
+
+const A_MINUTE_AGO = () => Date.now() - 60_000;
+
+describe('CommentDate', () => {
+  it('shows the publication date of a comment never edited', () => {
+    render(<CommentDate createdAt={A_MINUTE_AGO()} updatedAt={undefined} />);
+
+    expect(screen.getByTestId('comment-info-date').textContent).toMatch(
+      /^Published /,
+    );
+  });
+
+  it('shows the edition date once the comment has been edited', () => {
+    render(<CommentDate createdAt={1000} updatedAt={A_MINUTE_AGO()} />);
+
+    expect(screen.getByTestId('comment-info-date').textContent).toMatch(
+      /^Modified /,
+    );
+  });
+
+  it('renders a separator alongside the date', () => {
+    render(<CommentDate createdAt={A_MINUTE_AGO()} updatedAt={undefined} />);
+
+    expect(screen.getByText('|')).toBeInTheDocument();
+  });
+
+  it('renders nothing without any date', () => {
+    render(<CommentDate createdAt={0} updatedAt={undefined} />);
+
+    expect(screen.queryByTestId('comment-info-date')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing when both dates are zero', () => {
+    render(<CommentDate createdAt={0} updatedAt={0} />);
+
+    expect(screen.queryByTestId('comment-info-date')).not.toBeInTheDocument();
+  });
+});

--- a/packages/react/src/modules/comments/components/CommentReplies.spec.tsx
+++ b/packages/react/src/modules/comments/components/CommentReplies.spec.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from '~/setup';
+import { CommentProps } from '../types';
+import { CommentReplies } from './CommentReplies';
+
+const { useCommentReplies } = vi.hoisted(() => ({
+  useCommentReplies: vi.fn(),
+}));
+
+vi.mock('../hooks/useCommentReplies', () => ({ useCommentReplies }));
+
+// Both children are covered by their own specs.
+vi.mock('./Comment', () => ({
+  Comment: ({
+    comment,
+    profile,
+    userId,
+  }: {
+    comment: CommentProps;
+    profile: string;
+    userId: string;
+  }) => (
+    <div data-testid={`reply-${comment.id}`} data-profile={profile}>
+      {userId}
+    </div>
+  ),
+}));
+
+vi.mock('./CommentForm', () => ({
+  CommentForm: ({ replyTo }: { replyTo?: string }) => (
+    <div data-testid={`reply-form-${replyTo}`} />
+  ),
+}));
+
+function comment(
+  partial: Partial<CommentProps> & { id: string },
+): CommentProps {
+  return {
+    comment: `content ${partial.id}`,
+    authorId: 'author-1',
+    authorName: 'Author One',
+    createdAt: 1000,
+    ...partial,
+  };
+}
+
+const parent = comment({ id: 'parent' });
+
+function setup(
+  options: {
+    displayedReplies?: CommentProps[];
+    showCommentForm?: boolean;
+    showMoreReplies?: boolean;
+    profiles?: ({ userId: string; profile: string } | undefined)[];
+  } = {},
+) {
+  const {
+    displayedReplies = [],
+    showCommentForm = false,
+    showMoreReplies = false,
+  } = options;
+  // An explicit `profiles: undefined` must survive, hence the key check.
+  const profiles =
+    'profiles' in options
+      ? options.profiles
+      : [{ userId: 'author-1', profile: 'Teacher' }];
+  const handleMoreReplies = vi.fn();
+
+  useCommentReplies.mockReturnValue({
+    t: (key: string) => key,
+    profiles,
+    user: { userId: 'user-1' },
+    displayedReplies,
+    showCommentForm,
+    showMoreReplies,
+    handleMoreReplies,
+  });
+
+  return {
+    ...render(<CommentReplies parentComment={parent} />),
+    handleMoreReplies,
+  };
+}
+
+describe('CommentReplies', () => {
+  it('renders the reply form for the comment being replied to', () => {
+    setup({ showCommentForm: true });
+
+    expect(screen.getByTestId('reply-form-parent')).toBeInTheDocument();
+  });
+
+  it('renders no reply form otherwise', () => {
+    setup();
+
+    expect(screen.queryByTestId('reply-form-parent')).not.toBeInTheDocument();
+  });
+
+  it('renders one comment per displayed reply', () => {
+    setup({
+      displayedReplies: [
+        comment({ id: 'r1', replyTo: 'parent' }),
+        comment({ id: 'r2', replyTo: 'parent' }),
+      ],
+    });
+
+    expect(screen.getByTestId('reply-r1')).toBeInTheDocument();
+    expect(screen.getByTestId('reply-r2')).toBeInTheDocument();
+  });
+
+  it('passes the author profile down to each reply', () => {
+    setup({
+      displayedReplies: [comment({ id: 'r1', authorId: 'author-1' })],
+    });
+
+    expect(screen.getByTestId('reply-r1')).toHaveAttribute(
+      'data-profile',
+      'Teacher',
+    );
+  });
+
+  it('falls back to the guest profile for an unknown author', () => {
+    setup({
+      displayedReplies: [comment({ id: 'r1', authorId: 'unknown-author' })],
+    });
+
+    expect(screen.getByTestId('reply-r1')).toHaveAttribute(
+      'data-profile',
+      'Guest',
+    );
+  });
+
+  it('falls back to the guest profile when the profiles are not loaded', () => {
+    setup({
+      profiles: undefined,
+      displayedReplies: [comment({ id: 'r1' })],
+    });
+
+    expect(screen.getByTestId('reply-r1')).toHaveAttribute(
+      'data-profile',
+      'Guest',
+    );
+  });
+
+  it('skips a deleted reply', () => {
+    setup({
+      displayedReplies: [
+        comment({ id: 'r1' }),
+        comment({ id: 'r2', deleted: true }),
+      ],
+    });
+
+    expect(screen.getByTestId('reply-r1')).toBeInTheDocument();
+    expect(screen.queryByTestId('reply-r2')).not.toBeInTheDocument();
+  });
+
+  it('offers to load more replies', async () => {
+    const { user, handleMoreReplies } = setup({ showMoreReplies: true });
+
+    await user.click(screen.getByText('comment.more.replies'));
+
+    expect(handleMoreReplies).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the load-more button when everything is displayed', () => {
+    setup();
+
+    expect(screen.queryByText('comment.more.replies')).not.toBeInTheDocument();
+  });
+});

--- a/packages/react/src/modules/comments/hooks/useAutosizeTextarea.spec.tsx
+++ b/packages/react/src/modules/comments/hooks/useAutosizeTextarea.spec.tsx
@@ -1,0 +1,96 @@
+import { render, renderHook } from '~/setup';
+import { useAutosizeTextarea } from './useAutosizeTextarea';
+
+/** jsdom always reports a zero scrollHeight, so it is faked per test. */
+function stubScrollHeight(value: number) {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'scrollHeight',
+  );
+
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => value,
+  });
+
+  return () => {
+    if (descriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', descriptor);
+    }
+  };
+}
+
+function Textarea({
+  autoFocus,
+  defaultValue = '',
+}: {
+  autoFocus?: boolean;
+  defaultValue?: string;
+}) {
+  const [ref, onFocus, resize] = useAutosizeTextarea(autoFocus);
+
+  return (
+    <textarea
+      ref={ref}
+      defaultValue={defaultValue}
+      onFocus={onFocus}
+      onChange={resize}
+      data-testid="textarea"
+    />
+  );
+}
+
+describe('useAutosizeTextarea', () => {
+  it('grows the textarea to its content height', () => {
+    const restore = stubScrollHeight(120);
+
+    const { getByTestId } = render(<Textarea />);
+
+    expect(getByTestId('textarea')).toHaveStyle({ height: '120px' });
+    restore();
+  });
+
+  it('recomputes the height when the content changes', async () => {
+    const restore = stubScrollHeight(60);
+    const { getByTestId, user } = render(<Textarea />);
+
+    expect(getByTestId('textarea')).toHaveStyle({ height: '60px' });
+
+    restore();
+    const grown = stubScrollHeight(180);
+    await user.type(getByTestId('textarea'), 'a longer content');
+
+    expect(getByTestId('textarea')).toHaveStyle({ height: '180px' });
+    grown();
+  });
+
+  it('focuses the textarea when asked to', () => {
+    const { getByTestId } = render(<Textarea autoFocus />);
+
+    expect(getByTestId('textarea')).toHaveFocus();
+  });
+
+  it('leaves the focus alone by default', () => {
+    const { getByTestId } = render(<Textarea />);
+
+    expect(getByTestId('textarea')).not.toHaveFocus();
+  });
+
+  it('places the caret at the end of the existing content on focus', async () => {
+    const { getByTestId, user } = render(<Textarea defaultValue="bonjour" />);
+    const textarea = getByTestId('textarea') as HTMLTextAreaElement;
+
+    await user.click(textarea);
+
+    expect(textarea.selectionStart).toBe('bonjour'.length);
+    expect(textarea.selectionEnd).toBe('bonjour'.length);
+  });
+
+  it('does nothing when no element is attached to the ref', () => {
+    const { result } = renderHook(() => useAutosizeTextarea());
+    const [ref, , resize] = result.current;
+
+    expect(ref.current).toBeNull();
+    expect(() => resize()).not.toThrow();
+  });
+});

--- a/packages/react/src/modules/comments/hooks/useCommentReplies.spec.tsx
+++ b/packages/react/src/modules/comments/hooks/useCommentReplies.spec.tsx
@@ -1,0 +1,195 @@
+import { act, renderHook } from '~/setup';
+import { CommentProps } from '../types';
+import { useCommentReplies } from './useCommentReplies';
+
+const { useCommentsContext, useEdificeClient } = vi.hoisted(() => ({
+  useCommentsContext: vi.fn(),
+  useEdificeClient: vi.fn(),
+}));
+
+vi.mock('./useCommentsContext', () => ({ useCommentsContext }));
+
+vi.mock(
+  '../../../providers/EdificeClientProvider/EdificeClientProvider.hook',
+  () => ({ useEdificeClient }),
+);
+
+function comment(
+  partial: Partial<CommentProps> & { id: string },
+): CommentProps {
+  return {
+    comment: `content ${partial.id}`,
+    authorId: 'author-1',
+    authorName: 'Author One',
+    createdAt: 1000,
+    ...partial,
+  };
+}
+
+const parent = comment({ id: 'parent' });
+
+function setup({
+  defaultComments = [],
+  replyToCommentId = null,
+  maxReplies = 2,
+  additionalReplies = 2,
+  parentComment = parent,
+}: {
+  defaultComments?: CommentProps[];
+  replyToCommentId?: string | null;
+  maxReplies?: number;
+  additionalReplies?: number;
+  parentComment?: CommentProps;
+} = {}) {
+  useCommentsContext.mockReturnValue({
+    profiles: [{ userId: 'author-1', profile: 'Teacher' }],
+    options: { maxReplies, additionalReplies },
+    replyToCommentId,
+    defaultComments,
+  });
+
+  return renderHook(() => useCommentReplies({ parentComment }));
+}
+
+const ids = (comments: CommentProps[]) => comments.map(({ id }) => id);
+
+describe('useCommentReplies', () => {
+  beforeEach(() => {
+    useEdificeClient.mockReturnValue({ user: { userId: 'user-1' } });
+  });
+
+  describe('displayed replies', () => {
+    it('keeps only the replies of the parent comment', () => {
+      const { result } = setup({
+        defaultComments: [
+          comment({ id: 'r1', replyTo: 'parent' }),
+          comment({ id: 'other', replyTo: 'another-parent' }),
+          comment({ id: 'top-level' }),
+        ],
+      });
+
+      expect(ids(result.current.displayedReplies)).toEqual(['r1']);
+    });
+
+    it('sorts the replies from the oldest to the most recent', () => {
+      const { result } = setup({
+        maxReplies: 5,
+        defaultComments: [
+          comment({ id: 'recent', replyTo: 'parent', createdAt: 3 }),
+          comment({ id: 'old', replyTo: 'parent', createdAt: 1 }),
+          comment({ id: 'middle', replyTo: 'parent', createdAt: 2 }),
+        ],
+      });
+
+      expect(ids(result.current.displayedReplies)).toEqual([
+        'old',
+        'middle',
+        'recent',
+      ]);
+    });
+
+    it('drops the deleted replies', () => {
+      const { result } = setup({
+        defaultComments: [
+          comment({ id: 'kept', replyTo: 'parent' }),
+          comment({ id: 'gone', replyTo: 'parent', deleted: true }),
+        ],
+      });
+
+      expect(ids(result.current.displayedReplies)).toEqual(['kept']);
+    });
+
+    it('caps the list at the configured maximum', () => {
+      const { result } = setup({
+        maxReplies: 1,
+        defaultComments: [
+          comment({ id: 'r1', replyTo: 'parent', createdAt: 1 }),
+          comment({ id: 'r2', replyTo: 'parent', createdAt: 2 }),
+        ],
+      });
+
+      expect(ids(result.current.displayedReplies)).toEqual(['r1']);
+      expect(result.current.showMoreReplies).toBe(true);
+    });
+
+    it('reports no further replies when everything is displayed', () => {
+      const { result } = setup({
+        defaultComments: [comment({ id: 'r1', replyTo: 'parent' })],
+      });
+
+      expect(result.current.showMoreReplies).toBe(false);
+    });
+
+    it('handles an undefined comment list', () => {
+      const { result } = setup({ defaultComments: undefined });
+
+      expect(result.current.displayedReplies).toEqual([]);
+      expect(result.current.showMoreReplies).toBe(false);
+    });
+  });
+
+  describe('handleMoreReplies', () => {
+    it('extends the page by the configured increment', async () => {
+      const { result } = setup({
+        maxReplies: 1,
+        additionalReplies: 2,
+        defaultComments: [
+          comment({ id: 'r1', replyTo: 'parent', createdAt: 1 }),
+          comment({ id: 'r2', replyTo: 'parent', createdAt: 2 }),
+          comment({ id: 'r3', replyTo: 'parent', createdAt: 3 }),
+        ],
+      });
+
+      await act(() => result.current.handleMoreReplies());
+
+      expect(ids(result.current.displayedReplies)).toEqual(['r1', 'r2', 'r3']);
+      expect(result.current.showMoreReplies).toBe(false);
+    });
+
+    it('falls back to two more replies without an explicit increment', async () => {
+      const { result } = setup({
+        maxReplies: 1,
+        additionalReplies: undefined,
+        defaultComments: Array.from({ length: 5 }, (_, index) =>
+          comment({ id: `r${index}`, replyTo: 'parent', createdAt: index }),
+        ),
+      });
+
+      await act(() => result.current.handleMoreReplies());
+
+      expect(result.current.displayedReplies).toHaveLength(3);
+    });
+  });
+
+  describe('reply form', () => {
+    it('opens for the comment being replied to', () => {
+      const { result } = setup({ replyToCommentId: 'parent' });
+
+      expect(result.current.showCommentForm).toBe(true);
+    });
+
+    it('stays closed for another comment', () => {
+      const { result } = setup({ replyToCommentId: 'another-comment' });
+
+      expect(result.current.showCommentForm).toBe(false);
+    });
+
+    it('stays closed on a deleted comment', () => {
+      const { result } = setup({
+        replyToCommentId: 'parent',
+        parentComment: comment({ id: 'parent', deleted: true }),
+      });
+
+      expect(result.current.showCommentForm).toBe(false);
+    });
+  });
+
+  it('forwards the profiles from the context and the session user', () => {
+    const { result } = setup();
+
+    expect(result.current.profiles).toEqual([
+      { userId: 'author-1', profile: 'Teacher' },
+    ]);
+    expect(result.current.user).toEqual({ userId: 'user-1' });
+  });
+});

--- a/packages/react/src/modules/comments/hooks/useComments.spec.tsx
+++ b/packages/react/src/modules/comments/hooks/useComments.spec.tsx
@@ -1,0 +1,322 @@
+import { act, renderHook } from '~/setup';
+import { CommentCallbacks, CommentOptions, CommentProps } from '../types';
+import { useComments } from './useComments';
+
+const { useProfileQueries, useEdificeClient } = vi.hoisted(() => ({
+  useProfileQueries: vi.fn(),
+  useEdificeClient: vi.fn(),
+}));
+
+vi.mock('./useProfileQueries', () => ({ useProfileQueries }));
+
+vi.mock(
+  '../../../providers/EdificeClientProvider/EdificeClientProvider.hook',
+  () => ({ useEdificeClient }),
+);
+
+function comment(
+  partial: Partial<CommentProps> & { id: string },
+): CommentProps {
+  return {
+    comment: `content ${partial.id}`,
+    authorId: 'author-1',
+    authorName: 'Author One',
+    createdAt: 1000,
+    ...partial,
+  };
+}
+
+const options: CommentOptions = {
+  maxComments: 2,
+  additionalComments: 2,
+  maxReplies: 2,
+  additionalReplies: 2,
+};
+
+function setup({
+  defaultComments,
+  type = 'edit',
+  overrides = {},
+}: {
+  defaultComments?: CommentProps[];
+  type?: 'edit' | 'read';
+  overrides?: Partial<CommentOptions>;
+} = {}) {
+  const callbacks: CommentCallbacks = {
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  };
+
+  const { result } = renderHook(() =>
+    useComments({
+      defaultComments,
+      options: { ...options, ...overrides },
+      type,
+      callbacks,
+    }),
+  );
+
+  return { result, callbacks };
+}
+
+const ids = (comments: CommentProps[]) => comments.map(({ id }) => id);
+
+describe('useComments', () => {
+  beforeEach(() => {
+    useEdificeClient.mockReturnValue({ user: { userId: 'user-1' } });
+    useProfileQueries.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  describe('displayed comments', () => {
+    it('sorts the comments from the most recent to the oldest', () => {
+      const { result } = setup({
+        type: 'read',
+        defaultComments: [
+          comment({ id: 'old', createdAt: 1 }),
+          comment({ id: 'recent', createdAt: 3 }),
+          comment({ id: 'middle', createdAt: 2 }),
+        ],
+      });
+
+      expect(ids(result.current.displayedComments)).toEqual([
+        'recent',
+        'middle',
+        'old',
+      ]);
+    });
+
+    it('leaves the replies out of the top-level list', () => {
+      const { result } = setup({
+        type: 'read',
+        defaultComments: [
+          comment({ id: 'parent' }),
+          comment({ id: 'reply', replyTo: 'parent' }),
+        ],
+      });
+
+      expect(ids(result.current.displayedComments)).toEqual(['parent']);
+    });
+
+    it('drops a deleted comment that carries no reply', () => {
+      const { result } = setup({
+        type: 'read',
+        defaultComments: [
+          comment({ id: 'kept' }),
+          comment({ id: 'gone', deleted: true }),
+        ],
+      });
+
+      expect(ids(result.current.displayedComments)).toEqual(['kept']);
+    });
+
+    it('keeps a deleted comment whose thread still holds a reply', () => {
+      const { result } = setup({
+        type: 'read',
+        defaultComments: [
+          comment({ id: 'deleted-parent', deleted: true }),
+          comment({ id: 'reply', replyTo: 'deleted-parent' }),
+        ],
+      });
+
+      expect(ids(result.current.displayedComments)).toEqual(['deleted-parent']);
+    });
+
+    it('paginates in edit mode only', () => {
+      const three = [
+        comment({ id: 'a', createdAt: 3 }),
+        comment({ id: 'b', createdAt: 2 }),
+        comment({ id: 'c', createdAt: 1 }),
+      ];
+
+      const edit = setup({ defaultComments: three });
+      expect(ids(edit.result.current.displayedComments)).toEqual(['a', 'b']);
+      expect(edit.result.current.showMoreComments).toBe(true);
+
+      const read = setup({ type: 'read', defaultComments: three });
+      expect(ids(read.result.current.displayedComments)).toEqual([
+        'a',
+        'b',
+        'c',
+      ]);
+      expect(read.result.current.showMoreComments).toBe(false);
+    });
+
+    it('handles an undefined comment list', () => {
+      const { result } = setup();
+
+      expect(result.current.displayedComments).toEqual([]);
+      expect(result.current.showMoreComments).toBe(false);
+    });
+  });
+
+  describe('handleMoreComments', () => {
+    it('extends the page by the configured increment', async () => {
+      const { result } = setup({
+        defaultComments: [
+          comment({ id: 'a', createdAt: 4 }),
+          comment({ id: 'b', createdAt: 3 }),
+          comment({ id: 'c', createdAt: 2 }),
+          comment({ id: 'd', createdAt: 1 }),
+        ],
+      });
+
+      expect(result.current.displayedComments).toHaveLength(2);
+
+      await act(() => result.current.handleMoreComments());
+
+      expect(ids(result.current.displayedComments)).toEqual([
+        'a',
+        'b',
+        'c',
+        'd',
+      ]);
+      expect(result.current.showMoreComments).toBe(false);
+    });
+
+    it('falls back to five more comments without an explicit increment', async () => {
+      const { result } = setup({
+        defaultComments: Array.from({ length: 8 }, (_, index) =>
+          comment({ id: `c${index}`, createdAt: 8 - index }),
+        ),
+        overrides: { additionalComments: undefined },
+      });
+
+      await act(() => result.current.handleMoreComments());
+
+      expect(result.current.displayedComments).toHaveLength(7);
+    });
+  });
+
+  describe('title', () => {
+    it('uses the plural label beyond one comment', () => {
+      const { result } = setup({
+        defaultComments: [comment({ id: 'a' }), comment({ id: 'b' })],
+      });
+
+      expect(result.current.title).toBe('2 comments');
+    });
+
+    it('uses the singular label for one comment', () => {
+      const { result } = setup({ defaultComments: [comment({ id: 'a' })] });
+
+      expect(result.current.title).toBe('1 comment');
+    });
+
+    it('counts zero without any comment', () => {
+      const { result } = setup();
+
+      expect(result.current.title).toBe('0 comment');
+    });
+
+    it('leaves the deleted comments out of the count', () => {
+      const { result } = setup({
+        defaultComments: [
+          comment({ id: 'a' }),
+          comment({ id: 'b', deleted: true }),
+        ],
+      });
+
+      expect(result.current.title).toBe('1 comment');
+    });
+  });
+
+  describe('callbacks in edit mode', () => {
+    it('deletes a comment', () => {
+      const { result, callbacks } = setup();
+
+      result.current.handleDeleteComment('comment-1');
+
+      expect(callbacks.delete).toHaveBeenCalledWith('comment-1');
+    });
+
+    it('creates a comment', () => {
+      const { result, callbacks } = setup();
+
+      result.current.handleCreateComment('hello');
+
+      expect(callbacks.post).toHaveBeenCalledWith('hello', undefined);
+    });
+
+    it('creates a reply and closes the reply form', async () => {
+      const { result, callbacks } = setup();
+
+      await act(() => result.current.handleReplyToComment('parent'));
+      expect(result.current.replyToCommentId).toBe('parent');
+
+      await act(() => result.current.handleCreateComment('hello', 'parent'));
+
+      expect(callbacks.post).toHaveBeenCalledWith('hello', 'parent');
+      expect(result.current.replyToCommentId).toBeNull();
+    });
+
+    it('updates the comment being edited and leaves edition', async () => {
+      const { result, callbacks } = setup();
+
+      await act(() => result.current.handleModifyComment('comment-1'));
+      expect(result.current.editCommentId).toBe('comment-1');
+
+      await act(() => result.current.handleUpdateComment('edited'));
+
+      expect(callbacks.put).toHaveBeenCalledWith({
+        comment: 'edited',
+        commentId: 'comment-1',
+      });
+      expect(result.current.editCommentId).toBeNull();
+    });
+
+    it('ignores an update while no comment is being edited', async () => {
+      const { result, callbacks } = setup();
+
+      await act(() => result.current.handleUpdateComment('edited'));
+
+      expect(callbacks.put).not.toHaveBeenCalled();
+    });
+
+    it('resets the edition state', async () => {
+      const { result } = setup();
+
+      await act(() => result.current.handleModifyComment('comment-1'));
+      await act(() => result.current.handleReset());
+
+      expect(result.current.editCommentId).toBeNull();
+    });
+  });
+
+  describe('callbacks in read mode', () => {
+    it('never calls the mutation callbacks', async () => {
+      const { result, callbacks } = setup({ type: 'read' });
+
+      await act(() => result.current.handleModifyComment('comment-1'));
+      result.current.handleDeleteComment('comment-1');
+      result.current.handleCreateComment('hello');
+      await act(() => result.current.handleUpdateComment('edited'));
+
+      expect(callbacks.delete).not.toHaveBeenCalled();
+      expect(callbacks.post).not.toHaveBeenCalled();
+      expect(callbacks.put).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('exposed data', () => {
+    it('queries the profile of every distinct author', () => {
+      setup({
+        type: 'read',
+        defaultComments: [
+          comment({ id: 'a', authorId: 'author-1' }),
+          comment({ id: 'b', authorId: 'author-2' }),
+          comment({ id: 'c', authorId: 'author-1' }),
+        ],
+      });
+
+      expect(useProfileQueries).toHaveBeenCalledWith(['author-1', 'author-2']);
+    });
+
+    it('forwards the session user and the empty-screen illustration', () => {
+      const { result } = setup();
+
+      expect(result.current.user).toEqual({ userId: 'user-1' });
+      expect(result.current.emptyscreenPath).toBeTruthy();
+    });
+  });
+});

--- a/packages/react/src/modules/comments/provider/CommentProvider.spec.tsx
+++ b/packages/react/src/modules/comments/provider/CommentProvider.spec.tsx
@@ -1,0 +1,201 @@
+import { render, screen } from '~/setup';
+import { CommentCallbacks, CommentProps, RootProps } from '../types';
+import CommentProvider from './CommentProvider';
+
+const { useProfileQueries, useEdificeClient } = vi.hoisted(() => ({
+  useProfileQueries: vi.fn(),
+  useEdificeClient: vi.fn(),
+}));
+
+vi.mock('../hooks/useProfileQueries', () => ({ useProfileQueries }));
+
+vi.mock(
+  '../../../providers/EdificeClientProvider/EdificeClientProvider.hook',
+  () => ({ useEdificeClient }),
+);
+
+// Both children read the same context; only the provider is under test here.
+vi.mock('../components/CommentForm', () => ({
+  CommentForm: ({ userId }: { userId: string }) => (
+    <div data-testid={`comment-form-${userId}`} />
+  ),
+}));
+
+vi.mock('../components/CommentList', () => ({
+  CommentList: () => <div data-testid="comment-list" />,
+}));
+
+function comment(
+  partial: Partial<CommentProps> & { id: string },
+): CommentProps {
+  return {
+    comment: `content ${partial.id}`,
+    authorId: 'author-1',
+    authorName: 'Author One',
+    createdAt: 1000,
+    ...partial,
+  };
+}
+
+const callbacks: CommentCallbacks = {
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
+
+function setup({
+  comments = [],
+  type = 'edit',
+  options,
+  isLoading = false,
+}: {
+  comments?: CommentProps[];
+  type?: 'edit' | 'read';
+  options?: Partial<RootProps['options']>;
+  isLoading?: boolean;
+} = {}) {
+  useProfileQueries.mockReturnValue({ data: [], isLoading });
+
+  const props = (
+    type === 'edit'
+      ? { type, comments, options, callbacks, rights: { manager: true } }
+      : { type, comments, options }
+  ) as RootProps;
+
+  return render(<CommentProvider {...props} />);
+}
+
+describe('CommentProvider', () => {
+  beforeEach(() => {
+    useEdificeClient.mockReturnValue({ user: { userId: 'user-1' } });
+  });
+
+  describe('heading', () => {
+    it('counts the comments in the title', () => {
+      setup({ comments: [comment({ id: 'a' }), comment({ id: 'b' })] });
+
+      expect(screen.getByTestId('comments-info-count-text')).toHaveTextContent(
+        '2 comments',
+      );
+    });
+
+    it('hides the title from print when there is nothing to show', () => {
+      setup();
+
+      expect(screen.getByTestId('comments-info-count-text')).toHaveClass(
+        'd-print-none',
+      );
+    });
+
+    it('keeps the title on print once a comment exists', () => {
+      setup({ comments: [comment({ id: 'a' })] });
+
+      expect(screen.getByTestId('comments-info-count-text')).not.toHaveClass(
+        'd-print-none',
+      );
+    });
+  });
+
+  describe('comment form', () => {
+    it('renders the form for the session user', () => {
+      setup();
+
+      expect(screen.getByTestId('comment-form-user-1')).toBeInTheDocument();
+    });
+
+    it('renders no form while the user is unknown', () => {
+      useEdificeClient.mockReturnValue({ user: undefined });
+
+      setup();
+
+      expect(
+        screen.queryByTestId('comment-form-user-1'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('comment list', () => {
+    it('waits for the author profiles before rendering the list', () => {
+      setup({ isLoading: true });
+
+      expect(screen.queryByTestId('comment-list')).not.toBeInTheDocument();
+    });
+
+    it('renders the list once the profiles are loaded', () => {
+      setup();
+
+      expect(screen.getByTestId('comment-list')).toBeInTheDocument();
+    });
+
+    it('offers a show-more button beyond the page size', async () => {
+      const comments = Array.from({ length: 12 }, (_, index) =>
+        comment({ id: `c${index}`, createdAt: index }),
+      );
+
+      const { user } = setup({ comments, options: { maxComments: 2 } });
+
+      const more = screen.getByText('Read more');
+      await user.click(more);
+
+      expect(screen.getByTestId('comment-list')).toBeInTheDocument();
+    });
+
+    it('offers no show-more button when everything fits', () => {
+      setup({ comments: [comment({ id: 'a' })] });
+
+      expect(screen.queryByText('Read more')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty screen', () => {
+    it('invites the user to comment in edit mode', () => {
+      setup();
+
+      expect(
+        screen.getByText('No comments yet, be the first to comment'),
+      ).toBeInTheDocument();
+      expect(
+        document.querySelector('.comments-emptyscreen'),
+      ).toBeInTheDocument();
+    });
+
+    it('shows nothing in read mode', () => {
+      setup({ type: 'read' });
+
+      expect(
+        screen.queryByText('No comments yet, be the first to comment'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('disappears as soon as a comment exists', () => {
+      setup({ comments: [comment({ id: 'a' })] });
+
+      expect(
+        screen.queryByText('No comments yet, be the first to comment'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('options', () => {
+    it('applies the default page size', () => {
+      const comments = Array.from({ length: 12 }, (_, index) =>
+        comment({ id: `c${index}`, createdAt: index }),
+      );
+
+      setup({ comments });
+
+      // The default maximum is below twelve, so a show-more button is offered.
+      expect(screen.getByText('Read more')).toBeInTheDocument();
+    });
+
+    it('lets the caller override the page size', () => {
+      const comments = Array.from({ length: 12 }, (_, index) =>
+        comment({ id: `c${index}`, createdAt: index }),
+      );
+
+      setup({ comments, options: { maxComments: 20 } });
+
+      expect(screen.queryByText('Read more')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/packages/react/src/modules/homepage/components/Header/Header.spec.tsx
+++ b/packages/react/src/modules/homepage/components/Header/Header.spec.tsx
@@ -1,0 +1,237 @@
+import { render, screen } from '~/setup';
+import Header from './Header';
+
+const { useConversation, useHasWorkflow, useUser, useHeader, useEdificeTheme } =
+  vi.hoisted(() => ({
+    useConversation: vi.fn(),
+    useHasWorkflow: vi.fn(),
+    useUser: vi.fn(),
+    useHeader: vi.fn(),
+    useEdificeTheme: vi.fn(),
+  }));
+
+vi.mock('../../../../hooks', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../hooks')>()),
+  useConversation,
+  useHasWorkflow,
+  useUser,
+}));
+
+vi.mock('../../../../components/Layout/hooks/useHeader', () => ({
+  default: useHeader,
+}));
+
+vi.mock('../../../../providers/', () => ({ useEdificeTheme }));
+
+const CARBONIO =
+  'org.entcore.auth.controllers.CarbonioPreauthController|preauth';
+
+function setup({
+  messages = 0,
+  workflows = {},
+  communitiesWorkflow = false,
+  conversationWorflow = false,
+  theme = { logoutCallback: '/portal' },
+  dataProduct,
+  onNotificationsClick,
+}: {
+  messages?: number;
+  workflows?: Record<string, boolean>;
+  communitiesWorkflow?: boolean;
+  conversationWorflow?: boolean;
+  theme?: { logoutCallback?: string };
+  dataProduct?: string;
+  onNotificationsClick?: () => void;
+} = {}) {
+  useConversation.mockReturnValue({ messages });
+  useUser.mockReturnValue({
+    user: { userId: 'user-1' },
+    avatar: '/avatar.png',
+  });
+  useHasWorkflow.mockImplementation((workflow: string) => workflows[workflow]);
+  useEdificeTheme.mockReturnValue({ theme });
+  useHeader.mockReturnValue({
+    userAvatar: '/avatar.png',
+    userName: 'Pascal',
+    communitiesWorkflow,
+    conversationWorflow,
+  });
+
+  return render(
+    <Header
+      src="/assets"
+      dataProduct={dataProduct}
+      onNotificationsClick={onNotificationsClick}
+    />,
+  );
+}
+
+describe('homepage Header', () => {
+  it('always offers home, applications, notifications and the user menu', () => {
+    setup();
+
+    expect(screen.getByTestId('header-home-button')).toHaveAttribute(
+      'href',
+      '/timeline/timeline',
+    );
+    expect(screen.getByTestId('header-my-apps-button')).toHaveAttribute(
+      'href',
+      '/welcome',
+    );
+    expect(screen.getByTestId('header-user-profile-button')).toHaveAttribute(
+      'href',
+      '/userbook/mon-compte',
+    );
+    expect(screen.getByTestId('header-user-menu-button')).toBeInTheDocument();
+  });
+
+  it('points the logo at the theme assets', () => {
+    setup();
+
+    expect(document.querySelector('img')).toHaveAttribute(
+      'src',
+      '/assets/img/illustrations/logo.png',
+    );
+  });
+
+  it('carries the beta header classes', () => {
+    setup();
+
+    expect(document.querySelector('header')).toHaveClass(
+      'header-beta',
+      'd-print-none',
+      'no-2d',
+      'no-1d',
+    );
+  });
+
+  it('scopes its own theme when a product is given', () => {
+    setup({ dataProduct: 'one' });
+
+    expect(document.querySelector('header')).toHaveAttribute(
+      'data-product',
+      'one',
+    );
+  });
+
+  it('inherits the ambient theme by default', () => {
+    setup();
+
+    expect(document.querySelector('header')).not.toHaveAttribute(
+      'data-product',
+    );
+  });
+
+  describe('communities', () => {
+    it('is offered when the workflow is granted', () => {
+      setup({ communitiesWorkflow: true });
+
+      expect(screen.getByTestId('header-community-button')).toHaveAttribute(
+        'href',
+        '/communities',
+      );
+    });
+
+    it('is hidden otherwise', () => {
+      setup();
+
+      expect(
+        screen.queryByTestId('header-community-button'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('conversation', () => {
+    it('links to the conversation when the workflow is granted', () => {
+      setup({ conversationWorflow: true });
+
+      expect(screen.getByTestId('header-messagerie-button')).toHaveAttribute(
+        'href',
+        '/conversation/conversation',
+      );
+    });
+
+    it('badges the unread messages', () => {
+      setup({ conversationWorflow: true, messages: 4 });
+
+      expect(screen.getByText('4')).toBeInTheDocument();
+    });
+
+    it('shows no badge without any message', () => {
+      setup({ conversationWorflow: true });
+
+      expect(screen.queryByText('0')).not.toBeInTheDocument();
+    });
+
+    it('falls back to the carbonio preauth link in a new tab', () => {
+      setup({ workflows: { [CARBONIO]: true } });
+
+      const link = screen.getByTestId('header-messagerie-button');
+      expect(link).toHaveAttribute('href', '/auth/carbonio/preauth');
+      expect(link).toHaveAttribute('target', '_blank');
+    });
+
+    it('shows no messaging entry without any workflow', () => {
+      setup();
+
+      expect(
+        screen.queryByTestId('header-messagerie-button'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('notifications', () => {
+    it('calls back on click', async () => {
+      const onNotificationsClick = vi.fn();
+      const { user } = setup({ onNotificationsClick });
+
+      await user.click(screen.getAllByRole('button')[0]);
+
+      expect(onNotificationsClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fail without a callback', async () => {
+      const { user } = setup();
+
+      await user.click(screen.getAllByRole('button')[0]);
+
+      expect(screen.getByTestId('header-home-button')).toBeInTheDocument();
+    });
+  });
+
+  describe('user popover', () => {
+    // The logout link lives inside the popover, which only renders on hover.
+    it('appends the theme callback to the logout link', async () => {
+      const { user } = setup();
+
+      await user.hover(screen.getByTestId('header-user-menu-button'));
+
+      expect(screen.getByTestId('header-logout-button')).toHaveAttribute(
+        'href',
+        '/auth/logout?callback=/portal',
+      );
+    });
+
+    it('logs out without a callback when the theme has none', async () => {
+      const { user } = setup({ theme: {} });
+
+      await user.hover(screen.getByTestId('header-user-menu-button'));
+
+      expect(screen.getByTestId('header-logout-button')).toHaveAttribute(
+        'href',
+        '/auth/logout?callback=',
+      );
+    });
+
+    it('opens on hover', async () => {
+      const { user } = setup();
+      const item = screen.getByTestId('header-user-menu-button');
+
+      expect(item).toHaveAttribute('aria-expanded', 'false');
+
+      await user.hover(item);
+
+      expect(item).toHaveAttribute('aria-expanded', 'true');
+    });
+  });
+});

--- a/packages/react/src/modules/homepage/components/LastInfos/LastInfos.spec.tsx
+++ b/packages/react/src/modules/homepage/components/LastInfos/LastInfos.spec.tsx
@@ -1,0 +1,177 @@
+import { render, screen } from '~/setup';
+import LastInfos, { LastInfosProps } from './LastInfos';
+
+function props(overrides: Partial<LastInfosProps> = {}): LastInfosProps {
+  return {
+    id: 42,
+    icon: '/workspace/document/icon-id',
+    threadId: 7,
+    threadName: 'Informations importantes',
+    title: 'Rentrée scolaire',
+    content: '<p>Le contenu de l’actualité</p>',
+    publicationDate: '2026-08-01T10:00:00Z',
+    isHeadline: false,
+    username: 'Pascal',
+    ...overrides,
+  };
+}
+
+const card = () => document.querySelector('.last-infos-card');
+const medias = () => document.querySelectorAll('.last-infos-card-media');
+
+describe('LastInfos', () => {
+  describe('header', () => {
+    it('shows the thread name and its icon', () => {
+      render(<LastInfos {...props()} />);
+
+      expect(screen.getByText('Informations importantes')).toBeInTheDocument();
+      expect(screen.getByAltText('Informations importantes')).toHaveAttribute(
+        'src',
+        '/workspace/document/icon-id',
+      );
+    });
+
+    it('falls back to the news icon without a thread icon', () => {
+      render(<LastInfos {...props({ icon: '' })} />);
+
+      expect(
+        screen.queryByAltText('Informations importantes'),
+      ).not.toBeInTheDocument();
+      expect(
+        document.querySelector('svg.last-infos-card-thread-icon'),
+      ).not.toBeNull();
+    });
+  });
+
+  describe('content', () => {
+    it('shows the title and the text excerpt', () => {
+      render(<LastInfos {...props()} />);
+
+      expect(screen.getByText('Rentrée scolaire')).toBeInTheDocument();
+      expect(screen.getByText('Le contenu de l’actualité')).toBeInTheDocument();
+    });
+
+    it('strips the media elements out of the excerpt', () => {
+      render(
+        <LastInfos
+          {...props({
+            content:
+              '<p>Avant</p><img src="/a.png" /><video src="/v.mp4"></video><iframe src="/i"></iframe><p>Après</p>',
+          })}
+        />,
+      );
+
+      expect(
+        document.querySelector('.last-infos-card-excerpt'),
+      ).toHaveTextContent('AvantAprès');
+    });
+
+    it('renders an empty excerpt without any content', () => {
+      render(<LastInfos {...props({ content: '' })} />);
+
+      expect(
+        document.querySelector('.last-infos-card-excerpt'),
+      ).toBeEmptyDOMElement();
+      expect(medias()).toHaveLength(0);
+    });
+
+    it('ignores an image carrying no source', () => {
+      render(
+        <LastInfos {...props({ content: '<p>Texte</p><img src="  " />' })} />,
+      );
+
+      expect(medias()).toHaveLength(0);
+    });
+  });
+
+  describe('media previews', () => {
+    it('renders no media block without an image', () => {
+      render(<LastInfos {...props()} />);
+
+      expect(document.querySelector('.last-infos-card-medias')).toBeNull();
+    });
+
+    it('previews up to three images', () => {
+      render(
+        <LastInfos
+          {...props({
+            content: '<img src="/a.png" /><img src="/b.png" />',
+          })}
+        />,
+      );
+
+      expect(medias()).toHaveLength(2);
+      expect(
+        document.querySelector('.last-infos-card-media-overlay'),
+      ).toBeNull();
+    });
+
+    it('counts the extra images in an overlay on the third preview', () => {
+      render(
+        <LastInfos
+          {...props({
+            content:
+              '<img src="/a.png" /><img src="/b.png" /><img src="/c.png" /><img src="/d.png" /><img src="/e.png" />',
+          })}
+        />,
+      );
+
+      expect(medias()).toHaveLength(3);
+      expect(
+        document.querySelector('.last-infos-card-media-overlay'),
+      ).toHaveTextContent('+2');
+    });
+
+    it('shows no overlay when exactly three images are available', () => {
+      render(
+        <LastInfos
+          {...props({
+            content:
+              '<img src="/a.png" /><img src="/b.png" /><img src="/c.png" />',
+          })}
+        />,
+      );
+
+      expect(medias()).toHaveLength(3);
+      expect(
+        document.querySelector('.last-infos-card-media-overlay'),
+      ).toBeNull();
+    });
+  });
+
+  describe('interaction', () => {
+    it('renders no action button without a callback', () => {
+      render(<LastInfos {...props()} />);
+
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+      expect(card()).not.toHaveClass('last-infos-card-clickable');
+    });
+
+    it('exposes a labelled action button calling back with the ids', async () => {
+      const onClick = vi.fn();
+      const { user } = render(<LastInfos {...props({ onClick })} />);
+
+      const button = screen.getByRole('button', {
+        name: 'Informations importantes - Rentrée scolaire',
+      });
+      await user.click(button);
+
+      expect(onClick).toHaveBeenCalledWith(7, 42);
+      expect(card()).toHaveClass('last-infos-card-clickable');
+    });
+  });
+
+  describe('headline', () => {
+    it('is not highlighted by default', () => {
+      render(<LastInfos {...props()} />);
+
+      expect(card()).not.toHaveClass('last-infos-card-headline');
+    });
+
+    it('is highlighted when flagged as headline', () => {
+      render(<LastInfos {...props({ isHeadline: true })} />);
+
+      expect(card()).toHaveClass('last-infos-card-headline');
+    });
+  });
+});

--- a/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlash.spec.tsx
+++ b/packages/react/src/modules/homepage/components/MessageFlashList/MessageFlash.spec.tsx
@@ -1,0 +1,281 @@
+import { IFlashMessageModel } from '@edifice.io/client';
+import { render, screen, waitFor } from '~/setup';
+import MessageFlash from './MessageFlash';
+
+const { useEdificeClient, useBreakpoint } = vi.hoisted(() => ({
+  useEdificeClient: vi.fn(),
+  useBreakpoint: vi.fn(),
+}));
+
+vi.mock('../../../..', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../..')>()),
+  useEdificeClient,
+  useBreakpoint,
+}));
+
+function message(
+  partial: Partial<IFlashMessageModel> = {},
+): IFlashMessageModel {
+  return {
+    id: 'flash-1',
+    title: 'Message important',
+    contents: { en: 'English content', fr: 'Contenu français' },
+    color: 'blue',
+    signature: '',
+    ...partial,
+  } as unknown as IFlashMessageModel;
+}
+
+/** jsdom measures nothing, so the overflow detection is driven by scrollHeight. */
+function stubHeights({
+  scrollHeight,
+  lineHeight = '20px',
+}: {
+  scrollHeight: number;
+  lineHeight?: string;
+}) {
+  const descriptor = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    'scrollHeight',
+  );
+  Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+    configurable: true,
+    get: () => scrollHeight,
+  });
+
+  const computedStyle = vi
+    .spyOn(window, 'getComputedStyle')
+    .mockReturnValue({ lineHeight, fontSize: '16px' } as CSSStyleDeclaration);
+
+  return () => {
+    computedStyle.mockRestore();
+    if (descriptor) {
+      Object.defineProperty(HTMLElement.prototype, 'scrollHeight', descriptor);
+    }
+  };
+}
+
+const content = () => document.querySelector('.message-flash-content');
+
+describe('MessageFlash', () => {
+  beforeEach(() => {
+    useEdificeClient.mockReturnValue({ currentLanguage: 'en' });
+    useBreakpoint.mockReturnValue({ lg: true });
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('content language', () => {
+    it('shows the content in the session language', () => {
+      render(<MessageFlash message={message()} />);
+
+      expect(content()).toHaveTextContent('English content');
+    });
+
+    it('falls back to French when the session language is missing', () => {
+      useEdificeClient.mockReturnValue({ currentLanguage: 'de' });
+
+      render(<MessageFlash message={message()} />);
+
+      expect(content()).toHaveTextContent('Contenu français');
+    });
+
+    it('falls back to the first non-null content when French is missing too', () => {
+      useEdificeClient.mockReturnValue({ currentLanguage: 'de' });
+
+      render(
+        <MessageFlash
+          message={message({
+            contents: { es: null, it: 'Contenuto' } as never,
+          })}
+        />,
+      );
+
+      expect(content()).toHaveTextContent('Contenuto');
+    });
+
+    it('renders an empty body without any content', () => {
+      render(<MessageFlash message={message({ contents: undefined })} />);
+
+      expect(content()).toBeEmptyDOMElement();
+    });
+
+    it('renders the content as HTML', () => {
+      render(
+        <MessageFlash
+          message={message({
+            contents: { en: '<strong>bold</strong>' } as never,
+          })}
+        />,
+      );
+
+      expect(content()?.querySelector('strong')).toHaveTextContent('bold');
+    });
+  });
+
+  describe('appearance', () => {
+    it('carries the color modifier class', () => {
+      render(<MessageFlash message={message({ color: 'red' })} />);
+
+      expect(document.querySelector('.message-flash')).toHaveClass(
+        'message-flash-red',
+      );
+    });
+
+    it('carries no modifier class without a color', () => {
+      render(<MessageFlash message={message({ color: undefined })} />);
+
+      expect(document.querySelector('.message-flash')?.className).toBe(
+        'message-flash',
+      );
+    });
+
+    it('shows a warning icon on a red message', () => {
+      render(<MessageFlash message={message({ color: 'red' })} />);
+
+      expect(screen.getByRole('img', { name: 'warning' })).toBeInTheDocument();
+    });
+
+    it('shows an information icon otherwise', () => {
+      render(<MessageFlash message={message()} />);
+
+      expect(
+        screen.getByRole('img', { name: 'information' }),
+      ).toBeInTheDocument();
+    });
+
+    it('displays the title and the signature', () => {
+      render(<MessageFlash message={message({ signature: 'La direction' })} />);
+
+      expect(screen.getByText('Message important')).toBeInTheDocument();
+      expect(screen.getByText('La direction')).toBeInTheDocument();
+    });
+
+    it('truncates the content while collapsed', () => {
+      render(<MessageFlash message={message()} />);
+
+      expect(content()).toHaveClass('text-truncate', 'text-truncate-2');
+    });
+  });
+
+  describe('closing', () => {
+    it('calls back with the message', async () => {
+      const onCloseMessage = vi.fn();
+      const { user } = render(
+        <MessageFlash message={message()} onCloseMessage={onCloseMessage} />,
+      );
+
+      await user.click(screen.getByTestId('message-flash-close-button'));
+
+      expect(onCloseMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'flash-1' }),
+      );
+    });
+
+    it('does not fail without a callback', async () => {
+      const { user } = render(<MessageFlash message={message()} />);
+
+      await user.click(screen.getByTestId('message-flash-close-button'));
+
+      expect(screen.getByText('Message important')).toBeInTheDocument();
+    });
+  });
+
+  describe('collapsing a long message', () => {
+    it('offers no toggle when the content fits in two lines', async () => {
+      const restore = stubHeights({ scrollHeight: 30 });
+
+      render(<MessageFlash message={message()} />);
+
+      await waitFor(() =>
+        expect(
+          screen.queryByTestId('message-flash-view-more-button'),
+        ).not.toBeInTheDocument(),
+      );
+      restore();
+    });
+
+    it('offers a read-more toggle when the content overflows', async () => {
+      const restore = stubHeights({ scrollHeight: 200 });
+
+      render(<MessageFlash message={message()} />);
+
+      expect(
+        await screen.findByTestId('message-flash-view-more-button'),
+      ).toHaveAttribute('aria-expanded', 'false');
+      restore();
+    });
+
+    it('expands and collapses the content through the toggle', async () => {
+      const restore = stubHeights({ scrollHeight: 200 });
+      const { user } = render(<MessageFlash message={message()} />);
+
+      await user.click(
+        await screen.findByTestId('message-flash-view-more-button'),
+      );
+
+      expect(content()).not.toHaveClass('text-truncate');
+      const less = screen.getByTestId('message-flash-view-less-button');
+      expect(less).toHaveAttribute('aria-expanded', 'true');
+
+      await user.click(less);
+
+      expect(content()).toHaveClass('text-truncate');
+      restore();
+    });
+
+    // The close button would overlap the expanded text, so it is only rendered
+    // when the message is collapsible and expanded, or not collapsible at all.
+    it('hides the close button while a long message stays collapsed', async () => {
+      const restore = stubHeights({ scrollHeight: 200 });
+      const { user } = render(<MessageFlash message={message()} />);
+
+      const more = await screen.findByTestId('message-flash-view-more-button');
+      expect(
+        screen.queryByTestId('message-flash-close-button'),
+      ).not.toBeInTheDocument();
+
+      await user.click(more);
+
+      expect(
+        screen.getByTestId('message-flash-close-button'),
+      ).toBeInTheDocument();
+      restore();
+    });
+
+    it('falls back on the font size when no line height is computed', async () => {
+      // 16px * 1.2 * 2 lines + 2 = 40.4, so 60px of content overflows.
+      const restore = stubHeights({ scrollHeight: 60, lineHeight: 'normal' });
+
+      render(<MessageFlash message={message()} />);
+
+      expect(
+        await screen.findByTestId('message-flash-view-more-button'),
+      ).toBeInTheDocument();
+      restore();
+    });
+  });
+
+  describe('responsive footer', () => {
+    it('lays the footer out in a row on a large screen', () => {
+      render(<MessageFlash message={message()} />);
+
+      expect(document.querySelector('.message-flash-footer')).toHaveClass(
+        'flex-row',
+      );
+    });
+
+    it('stacks the footer on a small screen', () => {
+      useBreakpoint.mockReturnValue({ lg: false });
+
+      render(<MessageFlash message={message()} />);
+
+      expect(document.querySelector('.message-flash-footer')).toHaveClass(
+        'flex-column',
+      );
+    });
+  });
+});

--- a/packages/react/src/modules/homepage/components/Notifications/hooks/useNotificationList.spec.tsx
+++ b/packages/react/src/modules/homepage/components/Notifications/hooks/useNotificationList.spec.tsx
@@ -1,0 +1,145 @@
+import { NotificationModel } from '@edifice.io/client';
+import { renderHook } from '~/setup';
+import { useNotificationListContainer } from './useNotificationList';
+
+const { useNotifications, useNotificationTypes } = vi.hoisted(() => ({
+  useNotifications: vi.fn(),
+  useNotificationTypes: vi.fn(),
+}));
+
+vi.mock('../services/queries/notification', () => ({
+  useNotifications,
+  useNotificationTypes,
+}));
+
+const notification = (id: string) =>
+  ({ _id: id }) as unknown as NotificationModel;
+
+function setup({
+  types,
+  typesLoading = false,
+  typesFetched = true,
+  typesError = null,
+  notifications,
+  notificationsLoading = false,
+  notificationsError = null,
+  hasNextPage = false,
+}: {
+  types?: string[];
+  typesLoading?: boolean;
+  typesFetched?: boolean;
+  typesError?: Error | null;
+  notifications?: NotificationModel[];
+  notificationsLoading?: boolean;
+  notificationsError?: Error | null;
+  hasNextPage?: boolean;
+} = {}) {
+  const fetchNextPage = vi.fn();
+
+  useNotificationTypes.mockReturnValue({
+    data: types,
+    isLoading: typesLoading,
+    isFetched: typesFetched,
+    error: typesError,
+  });
+  useNotifications.mockReturnValue({
+    data: notifications,
+    hasNextPage,
+    isLoading: notificationsLoading,
+    error: notificationsError,
+    fetchNextPage,
+  });
+
+  return {
+    ...renderHook(() => useNotificationListContainer()),
+    fetchNextPage,
+  };
+}
+
+describe('useNotificationListContainer', () => {
+  it('exposes the notifications and their types', () => {
+    const { result } = setup({
+      types: ['BLOG'],
+      notifications: [notification('n1')],
+      hasNextPage: true,
+    });
+
+    expect(result.current.notificationTypes).toEqual(['BLOG']);
+    expect(result.current.notifications).toEqual([notification('n1')]);
+    expect(result.current.hasNextPage).toBe(true);
+  });
+
+  it('waits for the types before enabling the notification query', () => {
+    setup({ types: undefined, typesFetched: false });
+
+    expect(useNotifications).toHaveBeenCalledWith([], false);
+  });
+
+  it('enables the notification query once the types are fetched', () => {
+    setup({ types: ['BLOG', 'NEWS'] });
+
+    expect(useNotifications).toHaveBeenCalledWith(['BLOG', 'NEWS'], true);
+  });
+
+  it('keeps the query disabled when the fetch returned no type', () => {
+    setup({ types: undefined, typesFetched: true });
+
+    expect(useNotifications).toHaveBeenCalledWith([], false);
+  });
+
+  it('loads the next page on demand', () => {
+    const { result, fetchNextPage } = setup({ types: ['BLOG'] });
+
+    result.current.loadNextPage();
+
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
+  });
+
+  describe('loading state', () => {
+    it('is true while the types are loading', () => {
+      const { result } = setup({ typesLoading: true });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('is true while the notifications are loading', () => {
+      const { result } = setup({
+        types: ['BLOG'],
+        notificationsLoading: true,
+      });
+
+      expect(result.current.isLoading).toBe(true);
+    });
+
+    it('is false once both queries settled', () => {
+      const { result } = setup({ types: ['BLOG'] });
+
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  describe('error state', () => {
+    it('surfaces the type query error first', () => {
+      const typesError = new Error('types down');
+      const { result } = setup({
+        typesError,
+        notificationsError: new Error('notifications down'),
+      });
+
+      expect(result.current.error).toBe(typesError);
+    });
+
+    it('surfaces the notification query error', () => {
+      const notificationsError = new Error('notifications down');
+      const { result } = setup({ types: ['BLOG'], notificationsError });
+
+      expect(result.current.error).toBe(notificationsError);
+    });
+
+    it('is null without any error', () => {
+      const { result } = setup({ types: ['BLOG'] });
+
+      expect(result.current.error).toBeNull();
+    });
+  });
+});

--- a/packages/react/src/modules/homepage/components/Notifications/services/api/notificationService.spec.ts
+++ b/packages/react/src/modules/homepage/components/Notifications/services/api/notificationService.spec.ts
@@ -1,0 +1,88 @@
+import { NotificationModel } from '@edifice.io/client';
+import { createNotificationService } from './notificationService';
+
+const { get } = vi.hoisted(() => ({ get: vi.fn() }));
+
+vi.mock('@edifice.io/client', () => ({
+  odeServices: { http: () => ({ get }) },
+}));
+
+const service = createNotificationService('/api');
+
+const notification = (id: string) =>
+  ({ _id: id }) as unknown as NotificationModel;
+
+describe('createNotificationService', () => {
+  describe('getNotifications', () => {
+    it('requests the page and every requested type', async () => {
+      get.mockResolvedValue({ status: 'ok', number: 0, results: [] });
+
+      await service.getNotifications(['BLOG', 'NEWS'], 2);
+
+      expect(get).toHaveBeenCalledWith(
+        '/api/timeline/lastNotifications?page=2&type=BLOG&type=NEWS',
+      );
+    });
+
+    it('requests only the page when no type is given', async () => {
+      get.mockResolvedValue({ status: 'ok', number: 0, results: [] });
+
+      await service.getNotifications([], 0);
+
+      expect(get).toHaveBeenCalledWith(
+        '/api/timeline/lastNotifications?page=0',
+      );
+    });
+
+    it('returns the results of a successful response', async () => {
+      const results = [notification('n1'), notification('n2')];
+      get.mockResolvedValue({ status: 'ok', number: 2, results });
+
+      await expect(service.getNotifications(['BLOG'], 0)).resolves.toEqual(
+        results,
+      );
+    });
+
+    it('returns an empty list when the platform reports an error', async () => {
+      get.mockResolvedValue({
+        status: 'error',
+        number: 1,
+        results: [notification('n1')],
+      });
+
+      await expect(service.getNotifications(['BLOG'], 0)).resolves.toEqual([]);
+    });
+
+    it('returns an empty list when the response holds no result', async () => {
+      get.mockResolvedValue({ status: 'ok', number: 0, results: [] });
+
+      await expect(service.getNotifications(['BLOG'], 0)).resolves.toEqual([]);
+    });
+
+    it('returns an empty list when the results are missing altogether', async () => {
+      get.mockResolvedValue({ status: 'ok', number: 3 });
+
+      await expect(service.getNotifications(['BLOG'], 0)).resolves.toEqual([]);
+    });
+  });
+
+  describe('getNotificationTypes', () => {
+    it('requests the type list of the platform', async () => {
+      get.mockResolvedValue(['BLOG', 'NEWS']);
+
+      await expect(service.getNotificationTypes()).resolves.toEqual([
+        'BLOG',
+        'NEWS',
+      ]);
+      expect(get).toHaveBeenCalledWith('/api/timeline/types');
+    });
+  });
+
+  it('prefixes every call with the configured base URL', async () => {
+    get.mockResolvedValue([]);
+
+    await createNotificationService('https://ent.fr').getNotificationTypes();
+
+    expect(get).toHaveBeenCalledWith('https://ent.fr/timeline/types');
+  });
+});

--- a/packages/react/src/modules/homepage/hooks/useWidget.spec.tsx
+++ b/packages/react/src/modules/homepage/hooks/useWidget.spec.tsx
@@ -1,0 +1,194 @@
+import {
+  IWidget,
+  IWidgetPreferences,
+  WIDGET_POSITION,
+} from '@edifice.io/client';
+import { renderHook, waitFor } from '~/setup';
+import useWidget from './useWidget';
+
+const { useWidgetPreferences } = vi.hoisted(() => ({
+  useWidgetPreferences: vi.fn(),
+}));
+
+vi.mock('./useWidgetPreferences', () => ({ useWidgetPreferences }));
+
+function widget(partial: Partial<IWidget> & { name: string }): IWidget {
+  return { mandatory: false, ...partial } as unknown as IWidget;
+}
+
+function setup(
+  options: {
+    widgets?: IWidget[];
+    preferences?: IWidgetPreferences;
+  } = {},
+) {
+  // An explicit `widgets: undefined` must survive, so no default parameter here.
+  const widgets =
+    'widgets' in options ? options.widgets : [widget({ name: 'my-apps' })];
+  const savePreferences = vi.fn();
+
+  useWidgetPreferences.mockReturnValue({
+    widgets,
+    preferences: options.preferences,
+    savePreferences,
+  });
+
+  return { savePreferences };
+}
+
+describe('useWidget', () => {
+  it('exposes the widget matching the requested name', async () => {
+    setup({
+      widgets: [widget({ name: 'my-apps' }), widget({ name: 'notes' })],
+    });
+
+    const { result } = renderHook(() => useWidget('notes'));
+
+    await waitFor(() => expect(result.current.widget?.name).toBe('notes'));
+  });
+
+  it('exposes no widget when the name is unknown to the platform', async () => {
+    setup();
+
+    const { result } = renderHook(() => useWidget('notes'));
+
+    await waitFor(() => expect(result.current.preference).toBeDefined());
+    expect(result.current.widget).toBeUndefined();
+  });
+
+  it('handles an unloaded widget list', async () => {
+    setup({ widgets: undefined });
+
+    const { result } = renderHook(() => useWidget('my-apps'));
+
+    await waitFor(() => expect(result.current.preference).toBeDefined());
+    expect(result.current.widget).toBeUndefined();
+  });
+
+  describe('default preferences', () => {
+    it('falls back to the built-in index and position of the widget', async () => {
+      setup();
+
+      const { result } = renderHook(() => useWidget('my-apps'));
+
+      await waitFor(() =>
+        expect(result.current.preference).toEqual({
+          index: 10,
+          show: true,
+          position: WIDGET_POSITION.RIGHT,
+        }),
+      );
+    });
+
+    it('places a widget it does not know at the very end', async () => {
+      setup({ widgets: [] });
+
+      const { result } = renderHook(() =>
+        useWidget('unknown-widget' as 'notes'),
+      );
+
+      await waitFor(() =>
+        expect(result.current.preference).toEqual({
+          index: 999,
+          show: true,
+          position: undefined,
+        }),
+      );
+    });
+
+    it('honors the stored preference over the default', async () => {
+      setup({
+        preferences: {
+          'my-apps': { index: 3, show: false, position: WIDGET_POSITION.LEFT },
+        } as unknown as IWidgetPreferences,
+      });
+
+      const { result } = renderHook(() => useWidget('my-apps'));
+
+      await waitFor(() =>
+        expect(result.current.preference).toEqual({
+          index: 3,
+          show: false,
+          position: WIDGET_POSITION.LEFT,
+        }),
+      );
+    });
+  });
+
+  describe('mandatory widgets', () => {
+    it('forces a mandatory widget to be shown at its default index', async () => {
+      setup({
+        widgets: [widget({ name: 'my-apps', mandatory: true })],
+        preferences: {
+          'my-apps': { index: 42, show: false, position: WIDGET_POSITION.LEFT },
+        } as unknown as IWidgetPreferences,
+      });
+
+      const { result } = renderHook(() => useWidget('my-apps'));
+
+      await waitFor(() =>
+        expect(result.current.preference).toMatchObject({
+          index: 10,
+          show: true,
+        }),
+      );
+    });
+
+    it('puts a mandatory unknown widget first', async () => {
+      setup({
+        widgets: [widget({ name: 'unknown-widget', mandatory: true })],
+      });
+
+      const { result } = renderHook(() =>
+        useWidget('unknown-widget' as 'notes'),
+      );
+
+      await waitFor(() =>
+        expect(result.current.preference).toMatchObject({
+          index: 0,
+          show: true,
+        }),
+      );
+    });
+  });
+
+  describe('savePreference', () => {
+    it('writes the widget preference into the whole preferences payload', async () => {
+      const preferences = {
+        notes: { index: 1, show: true, position: WIDGET_POSITION.RIGHT },
+      } as unknown as IWidgetPreferences;
+      const { savePreferences } = setup({ preferences });
+
+      const { result } = renderHook(() => useWidget('my-apps'));
+      await waitFor(() => expect(result.current.preference).toBeDefined());
+
+      result.current.savePreference({
+        index: 5,
+        show: false,
+        position: WIDGET_POSITION.LEFT,
+      });
+
+      expect(savePreferences).toHaveBeenCalledWith(
+        expect.objectContaining({
+          'my-apps': {
+            index: 5,
+            show: false,
+            position: WIDGET_POSITION.LEFT,
+          },
+        }),
+      );
+    });
+
+    it('saves nothing while the preferences are not loaded', async () => {
+      const { savePreferences } = setup();
+
+      const { result } = renderHook(() => useWidget('my-apps'));
+      await waitFor(() => expect(result.current.preference).toBeDefined());
+
+      expect(
+        result.current.savePreference({ index: 5, show: true }),
+      ).toBeUndefined();
+      expect(savePreferences).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/react/src/providers/AntThemeProvider/AntProvider.spec.tsx
+++ b/packages/react/src/providers/AntThemeProvider/AntProvider.spec.tsx
@@ -1,0 +1,74 @@
+import { DatePicker } from 'antd';
+import { render, screen } from '~/setup';
+import AntProvider from './AntProvider';
+
+const { useEdificeClient } = vi.hoisted(() => ({
+  useEdificeClient: vi.fn(),
+}));
+
+vi.mock('../EdificeClientProvider/EdificeClientProvider.hook', () => ({
+  useEdificeClient,
+}));
+
+/**
+ * The locale reaches the antd components through the config context, so it is
+ * read back from a rendered picker rather than from the provider itself.
+ */
+function renderWithLocale(currentLanguage: string | undefined) {
+  useEdificeClient.mockReturnValue({ currentLanguage });
+
+  return render(
+    <AntProvider>
+      <DatePicker open />
+    </AntProvider>,
+  );
+}
+
+describe('AntProvider', () => {
+  it('renders its children', () => {
+    useEdificeClient.mockReturnValue({ currentLanguage: 'fr' });
+
+    render(
+      <AntProvider>
+        <span>wrapped</span>
+      </AntProvider>,
+    );
+
+    expect(screen.getByText('wrapped')).toBeInTheDocument();
+  });
+
+  it('uses the French locale for a French session', () => {
+    renderWithLocale('fr');
+
+    expect(
+      screen.getByPlaceholderText('Sélectionner une date'),
+    ).toBeInTheDocument();
+  });
+
+  it.each(['de', 'es', 'it', 'pt'])(
+    'uses a non-French placeholder for the %s locale',
+    (language) => {
+      renderWithLocale(language);
+
+      expect(
+        screen.queryByPlaceholderText('Sélectionner une date'),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it('falls back to French for an unmapped language', () => {
+    renderWithLocale('nl');
+
+    expect(
+      screen.getByPlaceholderText('Sélectionner une date'),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to French when the language is unknown yet', () => {
+    renderWithLocale(undefined);
+
+    expect(
+      screen.getByPlaceholderText('Sélectionner une date'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/react/src/providers/EdificeThemeProvider/EdificeThemeProvider.spec.tsx
+++ b/packages/react/src/providers/EdificeThemeProvider/EdificeThemeProvider.spec.tsx
@@ -1,0 +1,149 @@
+import { render, screen, waitFor } from '~/setup';
+import { useEdificeTheme } from './EdificeThemeProvider.hook';
+import { EdificeThemeProvider } from './EdificeThemeProvider';
+
+const { useConf, useEdificeClient } = vi.hoisted(() => ({
+  useConf: vi.fn(),
+  useEdificeClient: vi.fn(),
+}));
+
+vi.mock('../../hooks/useConf', () => ({ useConf }));
+
+vi.mock('../EdificeClientProvider/EdificeClientProvider.hook', () => ({
+  useEdificeClient,
+}));
+
+vi.mock('../AntThemeProvider/AntProvider', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+function ThemeConsumer() {
+  const { theme } = useEdificeTheme();
+  return <span data-testid="skin">{theme?.skinName ?? 'no-theme'}</span>;
+}
+
+const html = () => document.querySelector('html') as HTMLElement;
+const favicon = () => document.getElementById('favicon') as HTMLAnchorElement;
+
+function mockConf(theme?: Record<string, unknown>) {
+  useConf.mockReturnValue(theme ? { data: { theme } } : { data: undefined });
+}
+
+function renderProvider(defaultTheme?: string) {
+  return render(
+    <EdificeThemeProvider defaultTheme={defaultTheme}>
+      <ThemeConsumer />
+    </EdificeThemeProvider>,
+  );
+}
+
+describe('EdificeThemeProvider', () => {
+  beforeEach(() => {
+    useEdificeClient.mockReturnValue({ appCode: 'blog' });
+
+    // The provider writes into a #favicon link the host page is expected to own.
+    const link = document.createElement('a');
+    link.id = 'favicon';
+    document.body.appendChild(link);
+  });
+
+  afterEach(() => {
+    favicon()?.remove();
+    ['data-skin', 'data-theme', 'data-product'].forEach((attribute) =>
+      html().removeAttribute(attribute),
+    );
+  });
+
+  it('queries the configuration of the current application', () => {
+    mockConf({ skinName: 'default' });
+
+    renderProvider();
+
+    expect(useConf).toHaveBeenCalledWith({ appCode: 'blog' });
+  });
+
+  it('exposes the theme to its consumers', async () => {
+    mockConf({ skinName: 'cursus' });
+
+    renderProvider();
+
+    expect(await screen.findByTestId('skin')).toHaveTextContent('cursus');
+  });
+
+  it('exposes no theme while the configuration is loading', () => {
+    mockConf(undefined);
+
+    renderProvider();
+
+    expect(screen.getByTestId('skin')).toHaveTextContent('no-theme');
+  });
+
+  it('points the favicon at the theme base path', async () => {
+    mockConf({ basePath: '/assets/themes/cursus' });
+
+    renderProvider();
+
+    await waitFor(() =>
+      expect(favicon().href).toContain(
+        '/assets/themes/cursus/img/illustrations/favicon.ico',
+      ),
+    );
+  });
+
+  it('writes the skin and theme names on the html element', async () => {
+    mockConf({ skinName: 'cursus', themeName: 'cursus-theme' });
+
+    renderProvider();
+
+    await waitFor(() => {
+      expect(html()).toHaveAttribute('data-skin', 'cursus');
+      expect(html()).toHaveAttribute('data-theme', 'cursus-theme');
+    });
+  });
+
+  it('prefers the npm theme over the theme name', async () => {
+    mockConf({ themeName: 'cursus-theme', npmTheme: 'npm-theme' });
+
+    renderProvider();
+
+    await waitFor(() =>
+      expect(html()).toHaveAttribute('data-theme', 'npm-theme'),
+    );
+  });
+
+  it('derives the product from the last segment of the bootstrap version', async () => {
+    mockConf({ bootstrapVersion: 'ode-bootstrap-neo' });
+
+    renderProvider();
+
+    await waitFor(() => expect(html()).toHaveAttribute('data-product', 'neo'));
+  });
+
+  it('lets an explicit default theme win over the bootstrap version', async () => {
+    mockConf({ bootstrapVersion: 'ode-bootstrap-neo' });
+
+    renderProvider('one');
+
+    await waitFor(() => expect(html()).toHaveAttribute('data-product', 'one'));
+  });
+
+  it('empties the product for the "none" default theme', async () => {
+    mockConf({ bootstrapVersion: 'ode-bootstrap-neo' });
+
+    renderProvider('none');
+
+    await waitFor(() => expect(html()).toHaveAttribute('data-product', ''));
+  });
+
+  // Nothing guards the undefined case, so the attribute is set to the string
+  // "undefined" rather than left out.
+  it('writes a literal "undefined" product without a bootstrap version', async () => {
+    mockConf({ skinName: 'default' });
+
+    renderProvider();
+
+    await waitFor(() =>
+      expect(html()).toHaveAttribute('data-product', 'undefined'),
+    );
+  });
+});


### PR DESCRIPTION
# Description

Lot 13 de l'effort de couverture de `@edifice.io/react` : **35 fichiers de specs, 468 tests**, en quatre commits. La suite du package passe de **115 fichiers / 663 tests** à **150 / 1131**. Aucun fichier de production n'est touché.

**Couverture de branches du package : 86,02 % → 88,50 %** (1902/2211 → 2002/2262, +100 branches couvertes). Mesure faite avec le moteur local (Vitest 3, sourcemap) : les valeurs absolues ne sont pas comparables à celles du ticket, mesurées sous le moteur AST-aware de Vitest 4 — mais le delta et les fichiers pointés sont exacts.

Le lot vise « modules transverses et composants divers » (~762 branches). Le ticket prévoit explicitement de piocher selon le temps disponible : les cinq blocs sont attaqués par leur plus gros gain plutôt que traités exhaustivement.

| Bloc | Fichiers testés | Tests |
| --- | --- | --- |
| **Layout** | `useHelp` (41 br.), `WidgetApps` (18), `NavLink` | 37 |
| **modules/comments** | `useComments` (36), `useCommentReplies` (12), `useAutosizeTextarea` (4), `CommentDate` (6) | 48 |
| **modules/audience** — *aucun test auparavant* | `useReactionIcons`, `ReactionSummary`, `ViewsCounter`, `ViewsByProfileCard` | 35 |
| **modules/homepage** | `MessageFlash` (42), `useWidget` (10) | 30 |
| **Composants divers** | `Grid` / `Grid.Col` (8) | 11 |

Second commit, sur les gros fichiers d'abord laissés de côté :

| Bloc | Fichiers testés | Tests |
| --- | --- | --- |
| **Layout** | `Header` (52 br. — le plus gros du lot) | 25 |
| **Composants divers** | `PageLayout` (32) | 29 |
| **providers** | `EdificeThemeProvider`, `AntProvider` (31) | 18 |
| **modules/comments** | `Comment` (24), `CommentProvider` (15), `CommentReplies` (8) | 42 |

Troisième commit, le reliquat de la liste du ticket :

| Bloc | Fichiers testés | Tests |
| --- | --- | --- |
| **Composants divers** | `Dropdown` items + recherche (34), `MediaViewer/ToolbarZoom` | 23 |
| **Tabs / Menu** | `useTabs` (13), `useMenu` (4) | 27 |
| **modules/homepage** | `Header` (13), `LastInfos` (15), `useNotificationList` (8), `notificationService` | 51 |
| **UserRightsList** | `rightsHelpers` | 17 |

Quatrième commit, les branches résiduelles, cette fois **guidé par le coverage** plutôt qu'à l'estime. Seize des dix-sept fichiers ciblés passent à **100 % de branches** :

| Fichier | Avant | Après |
| --- | --- | --- |
| `Toolbar.tsx` | 79,2 % | **100 %** |
| `Select.tsx` | 76,2 % | **100 %** |
| `useDropzone.ts` | 84,2 % | **100 %** |
| `ComboboxTrigger.tsx` | 60,0 % | **100 %** |
| `Combobox.tsx` | 87,5 % | **100 %** |
| `MediaWrapper.tsx` | 62,5 % | **100 %** |
| `ToolbarViewer.tsx` | 80,0 % | **100 %** |
| `useBookmarkEntries.tsx` | 86,2 % | **100 %** |
| `useSharingItems.tsx` | 89,7 % | **100 %** |
| `Dropzone.tsx` / `DropzoneContext.tsx` | 84,6 % / 50 % | **100 %** |
| `Card.tsx` / `CardContext` / `CardImage` / `CardUser` | 50–75 % | **100 %** |
| `SaveBookmark.tsx` | 50 % | **100 %** |

Quelques comportements non triviaux couverts au passage :

- `useHelp` : résolution de l'URL d'aide selon la route (`/adapter` + paramètre `eliot`, `class-admin`, `userbook`, `timeline`) et le thème 1D/2D, gestion du 404 et de l'échec réseau, puis contenu parsé — sommaire cliquable, bascule des sections, réécriture des `src` d'images.
- `MessageFlash` : choix de la langue du contenu (session → `fr` → premier contenu non nul), détection du débordement au-delà de deux lignes, bascule *lire plus / lire moins*, et bouton de fermeture volontairement masqué tant qu'un message long reste replié.
- `useComments` : filtrage des réponses et des commentaires supprimés — un commentaire supprimé reste affiché s'il porte encore une réponse —, pagination, titre singulier/pluriel, et callbacks jamais appelés en mode `read`.
- `useWidget` : préférences par défaut par widget, widget obligatoire forcé à visible, sauvegarde ignorée tant que les préférences ne sont pas chargées.

## Non traité dans ce lot

- **`AddAttachments` (48 branches)** — bloqué par l'import circulaire d'ENABLING-1119, signalé comme tel dans le ticket. À reprendre après ce correctif.
- **`PdfViewer`** — aucune branche à couvrir (le composant est neutralisé par le mock `react-pdf` du setup).
- **`UserRightsList.tsx:214`** (`if (!item) return null`) — seule branche restante des fichiers ciblés : **inatteignable par l'API publique**, le ref n'exposant que `addItem` et les utilisateurs d'un bookmark n'ayant pas de bouton de suppression. C'est du code défensif.
- **`utilities` (6)** — déjà couvertes par les specs existantes (`check-user-rights`, `create-selectors`, `emptyscreen-mapping`, `mime-types`, `react-query-utils`, `refs`, `rotate-transition-style`) : rien à ajouter.
- **`SearchEngine` (2)** — écrit dans `window.location.href`, ce que jsdom refuse sans stub global de la navigation. Il est mocké dans la spec de `Layout/Header` pour cette raison.

## Deux constats relevés en chemin

Encodés en commentaire dans les specs concernées plutôt que corrigés ici, un lot de tests n'ayant pas à changer le comportement de prod :

1. **`PageLayout`** — le commentaire de `analyzeChildren` affirme que `Children.toArray` aplatit les fragments. C'est faux : il n'aplatit que les tableaux. Une partie composée enveloppée dans `<>...</>` n'est donc jamais reconnue et perd sa classe de colonne. Le test encode le comportement réel et vérifie qu'un tableau, lui, fonctionne.
2. **`EdificeThemeProvider`** — sans version bootstrap ni thème par défaut, `data-product` reçoit la chaîne `"undefined"` au lieu de ne pas être posé.
3. **`useTabs`** — sélectionner un identifiant inconnu ne laisse pas l'onglet vide : l'effet de positionnement ramène sur `defaultId`, et c'est cet onglet-là qui est annoncé via `onChange`.
4. **`useDropzone.addFiles` perd son travail quand `forceFilters` est absent** — le cas par défaut. La branche par défaut stocke l'argument `files` brut au lieu de `filesToAdd`, donc ni la conversion HEIC → JPEG (#PEDAGO-3263) ni la suppression des caractères spéciaux du nom (#WB-3377) n'atteignent la liste : les deux ne fonctionnent qu'avec `forceFilters: true`. Les specs documentent les deux comportements. **C'est le constat le plus sérieux du lot**, il mérite son propre ticket.
5. **`CardImage`** — `{...style}` est répandu en *props* sur l'AppIcon de repli, pas en style : la variante `landscape` n'a donc pas d'effet observable dans le DOM, et seulement sur la branche sans image.

**Compatibilité Vitest 4** : les specs n'utilisent que `vi.hoisted` + `vi.mock` avec factory, et aucune option de config retirée par la v4. Vérifié en exécutant les fichiers dans un worktree de `feat/ENABLING-841-vite-8` (Vitest 4.1.7 / Vite 8), à chaque passe : **158, 114, 112 puis 158 tests verts à l'identique**.

**Aucun seuil de couverture n'est modifié** : ce lot est fait en avance de phase de la migration Vite/Vitest (ENABLING-841), les planchers seront recalibrés là-bas sur le moteur AST-aware — c'est à ce moment-là qu'il faudra remonter les planchers pour verrouiller le gain.

Deux contraintes de jsdom sont documentées dans les specs concernées, parce qu'elles reviendront sur tout test du même genre : jsdom ne mesure rien, donc `scrollHeight` et `getComputedStyle` sont stubés pour piloter la détection de débordement (`MessageFlash`, `useAutosizeTextarea`) ; et une section en `hidden` sort de l'arbre d'accessibilité, donc `useHelp` l'assert via le DOM plutôt que par un `getByRole`.

Ticket : [ENABLING-1133](https://edifice-community.atlassian.net/browse/ENABLING-1133)

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [x] Hooks

## Has the documentation changed?

- [ ] Storybook

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Comment tester

1. `pnpm test` — 150 fichiers / 1131 tests attendus sur `@edifice.io/react`.
2. `pnpm lint && pnpm format` — aucun warning nouveau imputable aux specs (les 17 warnings de `@edifice.io/react` préexistent, tous dans des fichiers source).
3. Cibler le lot seul : `pnpm --filter @edifice.io/react exec vitest run src/modules/audience src/modules/comments src/modules/homepage src/components/Layout src/components/Grid src/components/PageLayout src/components/Dropdown src/components/Tabs src/components/Menu src/components/MediaViewer src/components/UserRightsList src/providers`.
4. Mesurer : `pnpm --filter @edifice.io/react test:coverage` — 88,50 % de branches attendus (contre 86,02 % sur `develop-enabling`).
5. Après le merge d'ENABLING-841, relancer la suite : les specs sont écrites pour passer sans retouche sous Vitest 4.


[ENABLING-1133]: https://edifice-community.atlassian.net/browse/ENABLING-1133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ