### PR TITLE
fix(react):#IMPULS-6133 button in Alert should be align right

### DIFF
--- a/packages/react/src/components/Alert/Alert.stories.tsx
+++ b/packages/react/src/components/Alert/Alert.stories.tsx
@@ -108,7 +108,7 @@ export const WithAction: Story = {
       </Button>
     ),
     children:
-      'Ornare senectus inceptos, laboriosam montes suscipit, tristique rhoncus, tristique irure itaque cum, tellus imperdiet ornare nostra nec curae cumque vitae, minus ridiculus? Auctor eget.',
+      'Ornare senectus inceptos, laboriosam montes suscipit, tristique rhoncus !',
     isDismissible: true,
   },
 };

--- a/packages/react/src/components/Alert/Alert.tsx
+++ b/packages/react/src/components/Alert/Alert.tsx
@@ -189,7 +189,7 @@ const Alert = forwardRef(
         {isVisible ? (
           <div ref={refAlert} className={divContainerClasses} role="alert">
             {!isConfirm && mapping[type].icon}
-            <div className="alert-content small">{children}</div>
+            <div className="alert-content small flex-grow-1">{children}</div>
             {button && (
               <div className="ms-12">
                 {button}{' '}


### PR DESCRIPTION
# Description

Fix `Alert` component so the action `button` is aligned to the right of the alert, regardless of the length of the content text.

The alert content div now grows to fill the available space (`flex-grow-1`), pushing the button container to the right edge of the alert instead of leaving it stuck right after a short message. The Storybook `WithAction` story text was also shortened to make the misalignment (and the fix) visible at a glance.

Ticket: [IMPULS-6133](https://edifice-community.atlassian.net/browse/IMPULS-6133)

> **Note base de PR** : cette branche est basée sur `develop-b2school` (pas `develop`) — elle est stackée sur les commits IMPULS-6008 / IMPULS-5874 déjà présents sur `develop-b2school`. Ouvrir la PR avec `develop-b2school` comme base pour ne comparer que ce commit.

## Which Package changed?

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [x] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

[IMPULS-6133]: https://edifice-community.atlassian.net/browse/IMPULS-6133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ