### PR TITLE
feat(homepage): #IMPULS-5978, add Annuaire button to SchoolSpace widget

### DIFF
--- a/apps/docs/i18n.ts
+++ b/apps/docs/i18n.ts
@@ -281,6 +281,8 @@ i18n.use(initReactI18next).init({
           'Classes et groupes',
         'homepage.userspace.relative.link.classes':
           'La classe de [[childName]]',
+        //------------------ SchoolSpace -------------------------
+        'homepage.school-space.directory': 'Annuaire',
 
         //------------------------------------------------------
         //------------------ Header navigation -----------------

--- a/packages/bootstrap/src/components/homepage/_school-space.scss
+++ b/packages/bootstrap/src/components/homepage/_school-space.scss
@@ -1,13 +1,9 @@
-@use '../../themes/configs/primitives' as *;
-
 .school-space {
-  --border-color: #{$yellow-300};
-  --background-color: #{$yellow-100};
-  --border-radius: #{$border-radius-2xl};
-  --px: #{$spacer-8};
-  --py: #{$spacer-8};
+  --border-color: var(--primitive-yellow-300);
+  --background-color: var(--primitive-yellow-100);
+  --border-radius: var(--primitive-border-radius-2xl);
 
-  padding: var(--py) var(--px);
+  padding: var(--primitive-spacer-12);
   border: 1px solid var(--border-color);
   border-radius: var(--border-radius);
   background-color: var(--background-color);
@@ -16,8 +12,12 @@
   background-position: top right;
 
   &-container {
-    padding: var(--primitive-spacer-12);
+    padding: var(--primitive-spacer-8);
     line-height: var(--primitive-font-lineheight-xs);
     color: var(--primitive-text-color-default);
+  }
+
+  .school-space-directory-button {
+    align-self: center;
   }
 }

--- a/packages/config/src/msw/data/schoolSpace.ts
+++ b/packages/config/src/msw/data/schoolSpace.ts
@@ -1,0 +1,19 @@
+import { School } from '../../../../client/dist';
+
+export const mockSchool1: School = {
+  id: 'school-1',
+  name: 'Collège Jean Moulin',
+  UAI: '0012345A',
+  classes: [],
+  exports: [],
+};
+
+export const mockSchool2: School = {
+  id: 'school-2',
+  name: 'Lycée Jeanne Ferry',
+  UAI: '0098765Z',
+  classes: [],
+  exports: [],
+};
+
+export const mockSchools: School[] = [mockSchool1, mockSchool2];

--- a/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.spec.tsx
+++ b/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.spec.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '~/setup';
+import SchoolSpace from './SchoolSpace';
+
+import {
+  mockSchool1,
+  mockSchool2,
+} from '../../../../../../config/src/msw/data/schoolSpace';
+
+describe('SchoolSpace', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { href: '' },
+    });
+  });
+
+  it('renders nothing when no school is selected', () => {
+    const { container } = render(<SchoolSpace selectedSchool={undefined} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a directory button pointing to the selected school', () => {
+    render(<SchoolSpace selectedSchool={mockSchool1} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Annuaire' }),
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to the directory of the selected school when clicked', async () => {
+    const { user } = render(<SchoolSpace selectedSchool={mockSchool1} />);
+
+    await user.click(screen.getByRole('button', { name: 'Annuaire' }));
+
+    expect(window.location.href).toBe(
+      '/userbook/annuaire#/search?structure=school-1',
+    );
+  });
+
+  it('updates the directory link when the selected school changes', async () => {
+    const { user, rerender } = render(
+      <SchoolSpace
+        selectedSchool={mockSchool1}
+        schools={[mockSchool1, mockSchool2]}
+      />,
+    );
+
+    rerender(
+      <SchoolSpace
+        selectedSchool={mockSchool2}
+        schools={[mockSchool1, mockSchool2]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Annuaire' }));
+
+    expect(window.location.href).toBe(
+      '/userbook/annuaire#/search?structure=school-2',
+    );
+  });
+});

--- a/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.stories.tsx
+++ b/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.stories.tsx
@@ -1,5 +1,6 @@
 import { School } from '@edifice.io/client';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { mockSchools as schools } from '../../../../../../config/src/msw/data/schoolSpace';
 import SchoolSpace, { SchoolSpaceProps } from './SchoolSpace';
 
 const meta: Meta<typeof SchoolSpace> = {
@@ -31,23 +32,6 @@ const renderWithProps = (props: SchoolSpaceProps) => () => (
     <SchoolSpace {...props} />
   </div>
 );
-
-const schools = [
-  {
-    id: 'school-1',
-    name: 'Collège Jean Moulin',
-    UAI: '0012345A',
-    classes: [],
-    exports: [],
-  },
-  {
-    id: 'school-2',
-    name: 'Lycée Jeanne Ferry de Loisette en Royan',
-    UAI: '0098765Z',
-    classes: [],
-    exports: [],
-  },
-] satisfies Array<School>;
 
 export const MultipleSchools: Story = {
   render: renderWithProps({

--- a/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.tsx
+++ b/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.tsx
@@ -1,8 +1,8 @@
 import { School } from '@edifice.io/client';
 import { useTranslation } from 'react-i18next';
-import { Dropdown, Flex, IconButton, useToggle } from '../../../..';
+import { ButtonBeta, Dropdown, Flex, IconButton, useToggle } from '../../../..';
 import { getRotateTransitionStyle } from '../../../../utilities';
-import { IconRafterUp } from '../../../icons/components';
+import { IconRafterUp, IconUserSearch } from '../../../icons/components';
 
 /**
  * SchoolSpace component displays the currently selected school and provides
@@ -28,8 +28,12 @@ const SchoolSpace = ({
   // Do not render anything if no school is selected
   if (!selectedSchool) return null;
 
+  const directoryUrl = `/userbook/annuaire#/search?${new URLSearchParams({
+    structure: selectedSchool.id,
+  }).toString()}`;
+
   return (
-    <div className="school-space">
+    <Flex gap="4" direction="column" className="school-space">
       <Flex
         className="school-space-container"
         justify="center"
@@ -72,7 +76,15 @@ const SchoolSpace = ({
           </Dropdown>
         )}
       </Flex>
-    </div>
+      <ButtonBeta
+        variant="outline"
+        className="school-space-directory-button"
+        leftIcon={<IconUserSearch />}
+        onClick={() => (window.location.href = directoryUrl)}
+      >
+        {t('homepage.school-space.directory')}
+      </ButtonBeta>
+    </Flex>
   );
 };
 

--- a/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.tsx
+++ b/packages/react/src/modules/homepage/components/SchoolSpace/SchoolSpace.tsx
@@ -22,11 +22,11 @@ const SchoolSpace = ({
   const [isExpanded, toggleExpanded] = useToggle(false);
   const { t } = useTranslation();
 
-  // Only show dropdown if there are multiple schools to choose from
-  const hasManySchools = schools && schools.length > 1;
-
   // Do not render anything if no school is selected
   if (!selectedSchool) return null;
+
+  // Only show dropdown if there are multiple schools to choose from
+  const hasManySchools = schools && schools.length > 1;
 
   const directoryUrl = `/userbook/annuaire#/search?${new URLSearchParams({
     structure: selectedSchool.id,


### PR DESCRIPTION
# Description

Ajoute un bouton "Annuaire" dans le widget `SchoolSpace` (zone Établissement de la page d'accueil), permettant un accès rapide à l'annuaire de l'établissement actuellement sélectionné. Le lien est recalculé automatiquement lorsque l'utilisateur change d'établissement via le dropdown existant.

Réutilise le pattern de construction d'URL déjà introduit par IMPULS-5874 (`/userbook/annuaire#/search?structure=<id>`).

Ticket : [IMPULS-5978](https://edifice-community.atlassian.net/browse/IMPULS-5978)

## Which Package changed?

Please check the name of the package you changed

- [x] Components
- [ ] Core
- [ ] Icons
- [ ] Hooks

## Has the documentation changed?

- [x] Storybook

## Type of change

Please check options that are relevant.

- [ ] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [x] New feature (MINOR)
- [ ] Breaking change (MAJOR)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

[IMPULS-5978]: https://edifice-community.atlassian.net/browse/IMPULS-5978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ